### PR TITLE
avx,sgecpsc: Fix inner kernel name for OS:windows

### DIFF
--- a/auxiliary/x_aux_ext_dep_lib.c
+++ b/auxiliary/x_aux_ext_dep_lib.c
@@ -48,7 +48,7 @@ void ZEROS(REAL **pA, int row, int col)
 void ZEROS_ALIGN(REAL **pA, int row, int col)
 	{
 #if defined(OS_WINDOWS)
-	*pA = (REAL *) _aligneMALLOC( (row*col)*sizeof(REAL), 64 );
+	*pA = (REAL *) _aligned_malloc( (row*col)*sizeof(REAL), 64 );
 #else
 	void *temp;
 	int err = posix_memalign(&temp, 64, (row*col)*sizeof(REAL));
@@ -78,7 +78,7 @@ void FREE(REAL *pA)
 void FREE_ALIGN(REAL *pA)
 	{
 #if defined(OS_WINDOWS)
-	_aligneFREE( pA );
+	_aligned_free( pA );
 #else
 	free( pA );
 #endif

--- a/kernel/avx/kernel_sgecpsc_lib8.S
+++ b/kernel/avx/kernel_sgecpsc_lib8.S
@@ -847,7 +847,7 @@ inner_kernel_sgecp_8_2_lib8:
 	ret
 
 #if defined(OS_LINUX)
-	.size	inner_kernel_sgecpsc_8_2_lib8, .-inner_kernel_sgecpsc_8_2_lib8
+	.size	inner_kernel_sgecp_8_2_lib8, .-inner_kernel_sgecp_8_2_lib8
 #endif
 #endif
 
@@ -877,7 +877,7 @@ inner_kernel_sgecpsc_8_3_lib8:
 _inner_kernel_sgecpsc_8_3_lib8:
 #elif defined(OS_WINDOWS)
 	.def inner_kernel_sgecpsc_8_3_lib8; .scl 3; .type 32; .endef
-inner_kernel_sgecpsc_8_2_lib8:
+inner_kernel_sgecpsc_8_3_lib8:
 #endif
 #endif
 
@@ -980,7 +980,7 @@ inner_kernel_sgecpsc_8_2_lib8:
 	ret
 
 #if defined(OS_LINUX)
-	.size	inner_kernel_sgecpsc_8_2_lib8, .-inner_kernel_sgecpsc_8_2_lib8
+	.size	inner_kernel_sgecpsc_8_3_lib8, .-inner_kernel_sgecpsc_8_3_lib8
 #endif
 #endif
 
@@ -1121,7 +1121,7 @@ inner_kernel_sgecpsc_8_4_lib8:
 _inner_kernel_sgecpsc_8_4_lib8:
 #elif defined(OS_WINDOWS)
 	.def inner_kernel_sgecpsc_8_4_lib8; .scl 3; .type 32; .endef
-inner_kernel_sgecpsc_8_2_lib8:
+inner_kernel_sgecpsc_8_4_lib8:
 #endif
 #endif
 
@@ -1574,7 +1574,7 @@ inner_kernel_sgecpsc_8_6_lib8:
 _inner_kernel_sgecpsc_8_6_lib8:
 #elif defined(OS_WINDOWS)
 	.def inner_kernel_sgecpsc_8_6_lib8; .scl 3; .type 32; .endef
-inner_kernel_sgecpsc_8_2_lib8:
+inner_kernel_sgecpsc_8_6_lib8:
 #endif
 #endif
 
@@ -1819,7 +1819,7 @@ inner_kernel_sgecpsc_8_7_lib8:
 _inner_kernel_sgecpsc_8_7_lib8:
 #elif defined(OS_WINDOWS)
 	.def inner_kernel_sgecpsc_8_7_lib8; .scl 3; .type 32; .endef
-inner_kernel_sgecpsc_8_2_lib8:
+inner_kernel_sgecpsc_8_7_lib8:
 #endif
 #endif
 


### PR DESCRIPTION
Tested of Windows 10 64bit