### PR TITLE
Fix dgemm avx2 2x2 kernels

### DIFF
--- a/kernel/avx2/kernel_dgemm_10xX_lib4.S
+++ b/kernel/avx2/kernel_dgemm_10xX_lib4.S
@@ -838,8 +838,8 @@ inner_scale_ab_10x2_lib4:
 
 	vmulpd		%ymm0, %ymm15, %ymm0
 	vmulpd		%ymm1, %ymm15, %ymm1
-	vmulpd		%ymm2, %ymm15, %ymm2
-	vmulpd		%ymm3, %ymm15, %ymm3
+	vmulpd		%ymm4, %ymm15, %ymm4
+	vmulpd		%ymm5, %ymm15, %ymm5
 
 	vmulpd		%ymm8, %ymm15, %ymm8
 

--- a/kernel/avx2/kernel_dgemm_8x2_lib4.S
+++ b/kernel/avx2/kernel_dgemm_8x2_lib4.S
@@ -694,10 +694,10 @@ inner_edge_dgemm_add_nn_8x2_lib4:
 	vmovapd			0(%r11, %r12, 1), %ymm9
 	vbroadcastsd	0(%r13), %ymm12
 	vfmadd231pd		%ymm8, %ymm12, %ymm0
-	vfmadd231pd		%ymm9, %ymm12, %ymm4
+	vfmadd231pd		%ymm9, %ymm12, %ymm2
 	vbroadcastsd	32(%r13), %ymm12
 	vfmadd231pd		%ymm8, %ymm12, %ymm1
-	vfmadd231pd		%ymm9, %ymm12, %ymm5
+	vfmadd231pd		%ymm9, %ymm12, %ymm3
 
 	subl			$1, %r10d // k-1
 	subl			$1, %ebx // kend-1


### PR DESCRIPTION
NB: Different routines use different floating point register set:
i.e. `dgemm_8x2` uses `ymm0, ymm1, ymm2, ymm3`
while `dgemm_10x2` uses `ymm0, ymm1, ymm4, ymm5, ymm8`,
in this way it can the code can be closer to `dgemm_10x4` case. 
