### PR TITLE
cmake: Fix benchmarks,test,example compilation options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ set(MIN_KERNEL_SIZE 2x2 CACHE STRING "Minimum kernel size")
 
 # Skip BLASFEO utils for unsupported systems and for Realease build
 if(CMAKE_SYSTEM MATCHES "dSpace" OR CMAKE_BUILD_TYPE MATCHES "Release")
-	set(BLASFEO_EXAMPLES OFF CACHE BOOL "Examples disabled" FORCE)
+	set(BLASFEO_TESTING OFF CACHE BOOL "Examples disabled" FORCE)
 	set(BLASFEO_BENCHMARKS OFF CACHE BOOL "Benchmarks disabled" FORCE)
 	set(BLASFEO_EXAMPLES OFF CACHE BOOL "Examples disabled" FORCE)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,8 +59,12 @@ set(REF_BLAS 0 CACHE STRING "Reference blas to use")
 # Options
 # set(BLASFEO_TESTING ON CACHE BOOL "Tests enabled")
 set(BLASFEO_TESTING OFF CACHE BOOL "Tests disabled")
+
 # set(BLASFEO_BENCHMARKS ON CACHE BOOL "Benchmarks enabled")
 set(BLASFEO_BENCHMARKS OFF CACHE BOOL "Benchmarks disabled")
+
+set(BLASFEO_EXAMPLES ON CACHE BOOL "Examples enabled")
+# set(BLASFEO_EXAMPLES OFF CACHE BOOL "Examples disabled")
 
 # Use C99 extension to math library
 set(USE_C99_MATH ON CACHE BOOL "Use C99 extension to math library")
@@ -71,6 +75,13 @@ set(EXT_DEP ON CACHE BOOL "Compile external dependencies in BLASFEO")
 
 set(MIN_KERNEL_SIZE 2x2 CACHE STRING "Minimum kernel size")
 # set(MIN_KERNEL_SIZE 4x4 CACHE STRING "Minimum kernel size")
+
+# Skip BLASFEO utils for unsupported systems and for Realease build
+if(CMAKE_SYSTEM MATCHES "dSpace" OR CMAKE_BUILD_TYPE MATCHES "Release")
+	set(BLASFEO_EXAMPLES OFF CACHE BOOL "Examples disabled" FORCE)
+	set(BLASFEO_BENCHMARKS OFF CACHE BOOL "Benchmarks disabled" FORCE)
+	set(BLASFEO_EXAMPLES OFF CACHE BOOL "Examples disabled" FORCE)
+endif()
 
 configure_file(${PROJECT_SOURCE_DIR}/blasfeo_target.h.in
 	${CMAKE_CURRENT_SOURCE_DIR}/include/blasfeo_target.h @ONLY)
@@ -118,11 +129,6 @@ endif()
 
 if(BLASFEO_BENCHMARKS MATCHES ON)
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DBENCHMARKS_MODE=1")
-	if(NOT REF_BLAS)
-		message(FATAL_ERROR
-				"\nBENCHMARKS_MODE: No reference blas selected"
-				"\nUse i.e. -DREF_BLAS=OPENBLAS")
-	endif()
 endif()
 
 if(MIN_KERNEL_SIZE MATCHES 2x2)
@@ -184,7 +190,7 @@ endif()
 
 #
 if(${REF_BLAS} MATCHES 0)
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DREF_BLAS_NONE")
 endif(${REF_BLAS} MATCHES 0)
 
 if(${REF_BLAS} MATCHES OPENBLAS)
@@ -698,14 +704,17 @@ install(EXPORT blasfeoConfig DESTINATION cmake)
 file(GLOB_RECURSE BLASFEO_HEADERS "include/*.h")
 install(FILES ${BLASFEO_HEADERS} DESTINATION ${BLASFEO_HEADERS_INSTALLATION_DIRECTORY})
 
-#if(NOT CMAKE_SYSTEM MATCHES "dSpace" AND NOT CMAKE_BUILD_TYPE MATCHES "Release")
-if(NOT CMAKE_SYSTEM MATCHES "dSpace")
-	# tests
+# tests
+if(BLASFEO_TESTING MATCHES ON)
 	add_subdirectory(tests)
+endif()
 
-	# benchmarks
+# benchmarks
+if(BLASFEO_BENCHMARKS MATCHES ON)
 	add_subdirectory(benchmarks)
+endif()
 
-	# examples
+# examples
+if(BLASFEO_EXAMPLES MATCHES ON)
 	add_subdirectory(examples)
 endif()

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -29,34 +29,70 @@
 add_executable(benchmark_d_blas benchmark_d_blas.c)
 add_executable(benchmark_s_blas benchmark_s_blas.c)
 
-target_link_libraries(benchmark_d_blas blasfeo)
-target_link_libraries(benchmark_s_blas blasfeo)
-
 # link blas external blas implementations
-if(BLASFEO_BENCHMARKS MATCHES ON)
-	if(${REF_BLAS} MATCHES OPENBLAS)
-		target_link_libraries(benchmark_d_blas /opt/openblas/lib/libopenblas.a -pthread -lgfortran -lm)
-		target_link_libraries(benchmark_s_blas /opt/openblas/lib/libopenblas.a -pthread -lgfortran -lm)
-	endif(${REF_BLAS} MATCHES OPENBLAS)
+if(${REF_BLAS} MATCHES OPENBLAS)
+	target_link_libraries(benchmark_d_blas
+		/opt/openblas/lib/libopenblas.a
+		-pthread -lgfortran -lm)
+	target_link_libraries(benchmark_s_blas
+		/opt/openblas/lib/libopenblas.a
+		-pthread -lgfortran -lm)
 
-	if(${REF_BLAS} MATCHES BLIS)
-		target_link_libraries(benchmark_d_blas /opt/netlib/liblapack.a /opt/blis/lib/libblis.a -fopenmp -lgfortran -lm)
-		target_link_libraries(benchmark_s_blas /opt/netlib/liblapack.a /opt/blis/lib/libblis.a -fopenmp -lgfortran -lm)
-	endif(${REF_BLAS} MATCHES BLIS)
+elseif(${REF_BLAS} MATCHES BLIS)
+	target_link_libraries(benchmark_d_blas
+		/opt/netlib/liblapack.a
+		/opt/blis/lib/libblis.a
+		-fopenmp -lgfortran -lm)
+	target_link_libraries(benchmark_s_blas
+		/opt/netlib/liblapack.a
+		/opt/blis/lib/libblis.a
+		-fopenmp -lgfortran -lm)
 
-	if(${REF_BLAS} MATCHES NETLIB)
-		target_link_libraries(benchmark_d_blas /opt/netlib/liblapack.a /opt/netlib/libblas.a -lgfortran -lm)
-		target_link_libraries(benchmark_s_blas /opt/netlib/liblapack.a /opt/netlib/libblas.a -lgfortran -lm)
-	endif(${REF_BLAS} MATCHES NETLIB)
+elseif(${REF_BLAS} MATCHES NETLIB)
+	target_link_libraries(benchmark_d_blas
+		/opt/netlib/liblapack.a
+		/opt/netlib/libblas.a
+		-lgfortran -lm)
+	target_link_libraries(benchmark_s_blas
+		/opt/netlib/liblapack.a
+		/opt/netlib/libblas.a
+		-lgfortran -lm)
 
-	if(${REF_BLAS} MATCHES MKL)
-		target_link_libraries(benchmark_d_blas -Wl,--start-group /opt/intel/mkl/lib/intel64/libmkl_gf_lp64.a /opt/intel/mkl/lib/intel64/libmkl_core.a /opt/intel/mkl/lib/intel64/libmkl_sequential.a -Wl,--end-group -ldl -lpthread -lm)
-		target_link_libraries(benchmark_s_blas -Wl,--start-group /opt/intel/mkl/lib/intel64/libmkl_gf_lp64.a /opt/intel/mkl/lib/intel64/libmkl_core.a /opt/intel/mkl/lib/intel64/libmkl_sequential.a -Wl,--end-group -ldl -lpthread -lm)
-	endif(${REF_BLAS} MATCHES MKL)
+elseif(${REF_BLAS} MATCHES MKL)
+	target_link_libraries(benchmark_d_blas
+		-Wl,--start-group
+		/opt/intel/mkl/lib/intel64/libmkl_gf_lp64.a
+		/opt/intel/mkl/lib/intel64/libmkl_core.a
+		/opt/intel/mkl/lib/intel64/libmkl_sequential.a
+		-Wl,--end-group -ldl -lpthread -lm)
+	target_link_libraries(benchmark_s_blas
+		-Wl,--start-group
+		/opt/intel/mkl/lib/intel64/libmkl_gf_lp64.a
+		/opt/intel/mkl/lib/intel64/libmkl_core.a
+		/opt/intel/mkl/lib/intel64/libmkl_sequential.a
+		-Wl,--end-group -ldl -lpthread -lm)
 
-	if(${REF_BLAS} MATCHES ATLAS)
-		target_link_libraries(benchmark_d_blas /opt/atlas/lib/liblapack.a /opt/atlas/lib/libcblas.a /opt/atlas/lib/libf77blas.a /opt/atlas/lib/libatlas.a -lgfortran -lm)
-		target_link_libraries(benchmark_s_blas /opt/atlas/lib/liblapack.a /opt/atlas/lib/libcblas.a /opt/atlas/lib/libf77blas.a /opt/atlas/lib/libatlas.a -lgfortran -lm)
-	endif(${REF_BLAS} MATCHES ATLAS)
+elseif(${REF_BLAS} MATCHES ATLAS)
+	target_link_libraries(benchmark_d_blas
+		/opt/atlas/lib/liblapack.a
+		/opt/atlas/lib/libcblas.a
+		/opt/atlas/lib/libf77blas.a
+		/opt/atlas/lib/libatlas.a
+		-lgfortran -lm)
+	target_link_libraries(benchmark_s_blas
+		/opt/atlas/lib/liblapack.a
+		/opt/atlas/lib/libcblas.a
+		/opt/atlas/lib/libf77blas.a
+		/opt/atlas/lib/libatlas.a
+		-lgfortran -lm)
+
+elseif(${REF_BLAS} MATCHES 0)
+	target_link_libraries(benchmark_d_blas blasfeo -lm)
+	target_link_libraries(benchmark_s_blas blasfeo -lm)
+
+else()
+	message(FATAL_ERROR
+		"\nBENCHMARKS_MODE: No reference blas selected"
+		"\nUse i.e. -DREF_BLAS=OPENBLAS or -DREF_BLAS=0 to disable the comparison")
 
 endif()

--- a/benchmarks/benchmark_d_blas.c
+++ b/benchmarks/benchmark_d_blas.c
@@ -53,7 +53,7 @@
 #define D_NC 1
 #endif
 
-
+// comparison with standard blas libraries
 
 #if defined(REF_BLAS_NETLIB)
 #include "cblas.h"
@@ -74,7 +74,6 @@ void omp_set_num_threads(int num_threads);
 #if defined(REF_BLAS_MKL)
 #include "mkl.h"
 #endif
-
 
 #include "cpu_freq.h"
 
@@ -872,7 +871,12 @@ int main()
 //		float flop_operation = 4.0/3.0*n*n*n; // syrk+potrf
 
 		float Gflops_blasfeo  = 1e-9*flop_operation/time_blasfeo;
+
+		#ifndef REF_BLAS_NONE
 		float Gflops_blas     = 1e-9*flop_operation/time_blas;
+		#else
+		float Gflops_blas     = 0;
+		#endif
 
 		printf("%d\t%7.2f\t%7.2f\t%7.2f\t%7.2f\n",
 			n,

--- a/benchmarks/benchmark_s_blas.c
+++ b/benchmarks/benchmark_s_blas.c
@@ -435,7 +435,12 @@ int main()
 		float Gflops_max = flops_max * GHz_max;
 
 		float Gflops_blasfeo  = 1e-9*flop_operation/time_blasfeo;
+
+		#ifndef REF_BLAS_NONE
 		float Gflops_blas     = 1e-9*flop_operation/time_blas;
+		#else
+		float Gflops_blas     = 0;
+		#endif
 
 
 		printf("%d\t%7.2f\t%7.2f\t%7.2f\t%7.2f\n",

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -42,7 +42,3 @@ target_link_libraries(example_s_lu_factorization blasfeo m)
 
 add_executable(example_kernel_dgemm example_kernel_dgemm.c kernel_dgemm.S)
 target_link_libraries(example_kernel_dgemm blasfeo m)
-
-
-
-


### PR DESCRIPTION
Fix enabling and disabling of BLASFEO utils (benchmarks, test, examples) from CMake build system.