### PR TITLE
Adds full compatibility for compiling on Windows for x86 targets with Clang-CL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ tests/libblasfeo_ref.a
 
 # CMake
 build*
+Build*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,7 +288,10 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${C_FLAGS_BLAS_${EXTERNAL_BLAS}}")
 
 # common C flags
 if(CMAKE_C_COMPILER_ID MATCHES "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang")
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2 -fPIC")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2")
+	if(NOT CMAKE_C_SIMULATE_ID MATCHES "MSVC") # See https://stackoverflow.com/questions/49480535
+		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC") # Windows is always position independent code
+	endif()
 endif()
 
 

--- a/blas_api/dgemm.c
+++ b/blas_api/dgemm.c
@@ -73,13 +73,13 @@ void blasfeo_dgemm(char *ta, char *tb, int *pm, int *pn, int *pk, double *alpha,
 // TODO visual studio alignment
 #if defined(TARGET_X64_INTEL_HASWELL) | defined(TARGET_ARMV8A_ARM_CORTEX_A53)
 #if defined (_MSC_VER)
-	double pU[3*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU[3*4*K_MAX_STACK];
 #else
 	double pU[3*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
 #elif defined(TARGET_X64_INTEL_SANDY_BRIDGE) | defined(TARGET_ARMV8A_ARM_CORTEX_A57)
 #if defined (_MSC_VER)
-	double pU[2*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU[2*4*K_MAX_STACK];
 #else
 	double pU[2*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -87,7 +87,7 @@ void blasfeo_dgemm(char *ta, char *tb, int *pm, int *pn, int *pk, double *alpha,
 	double pU[1*4*K_MAX_STACK];
 #else
 #if defined (_MSC_VER)
-	double pU[1*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU[1*4*K_MAX_STACK];
 #else
 	double pU[1*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif

--- a/blas_api/dgetrf.c
+++ b/blas_api/dgetrf.c
@@ -78,7 +78,7 @@ void blasfeo_dgetrf(int *pm, int *pn, double *C, int *pldc, int *ipiv, int *info
 	double pd0[K_MAX_STACK];
 #else
 #if defined (_MSC_VER)
-	double pd0[K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pd0[K_MAX_STACK];
 #else
 	double pd0[K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -86,13 +86,13 @@ void blasfeo_dgetrf(int *pm, int *pn, double *C, int *pldc, int *ipiv, int *info
 
 #if defined(TARGET_X64_INTEL_HASWELL) | defined(TARGET_ARMV8A_ARM_CORTEX_A53)
 #if defined (_MSC_VER)
-	double pU0[3*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[3*4*K_MAX_STACK];
 #else
 	double pU0[3*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
 #elif defined(TARGET_X64_INTEL_SANDY_BRIDGE) | defined(TARGET_ARMV8A_ARM_CORTEX_A57)
 #if defined (_MSC_VER)
-	double pU0[2*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[2*4*K_MAX_STACK];
 #else
 	double pU0[2*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -100,7 +100,7 @@ void blasfeo_dgetrf(int *pm, int *pn, double *C, int *pldc, int *ipiv, int *info
 	double pU0[1*4*K_MAX_STACK];
 #else
 #if defined (_MSC_VER)
-	double pU0[1*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[1*4*K_MAX_STACK];
 #else
 	double pU0[1*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif

--- a/blas_api/dgetrf_np.c
+++ b/blas_api/dgetrf_np.c
@@ -84,7 +84,7 @@ void blas_dgetrf_np(int *pm, int *pn, double *C, int *pldc, int *info)
 	double pd0[K_MAX_STACK];
 #else
 #if defined (_MSC_VER)
-	double pd0[K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pd0[K_MAX_STACK];
 #else
 	double pd0[K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -92,13 +92,13 @@ void blas_dgetrf_np(int *pm, int *pn, double *C, int *pldc, int *info)
 
 #if defined(TARGET_X64_INTEL_HASWELL) | defined(TARGET_ARMV8A_ARM_CORTEX_A53)
 #if defined (_MSC_VER)
-	double pU0[3*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[3*4*K_MAX_STACK];
 #else
 	double pU0[3*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
 #elif defined(TARGET_X64_INTEL_SANDY_BRIDGE) | defined(TARGET_ARMV8A_ARM_CORTEX_A57)
 #if defined (_MSC_VER)
-	double pU0[2*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[2*4*K_MAX_STACK];
 #else
 	double pU0[2*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -106,7 +106,7 @@ void blas_dgetrf_np(int *pm, int *pn, double *C, int *pldc, int *info)
 	double pU0[1*4*K_MAX_STACK];
 #else
 #if defined (_MSC_VER)
-	double pU0[1*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[1*4*K_MAX_STACK];
 #else
 	double pU0[1*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif

--- a/blas_api/dpotrf.c
+++ b/blas_api/dpotrf.c
@@ -77,7 +77,7 @@ void blasfeo_dpotrf(char *uplo, int *pm, double *C, int *pldc, int *info)
 	double pd[K_MAX_STACK];
 #else
 #if defined (_MSC_VER)
-	double pd[K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pd[K_MAX_STACK];
 #else
 	double pd[K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -85,16 +85,16 @@ void blasfeo_dpotrf(char *uplo, int *pm, double *C, int *pldc, int *info)
 
 #if defined(TARGET_X64_INTEL_HASWELL) | defined(TARGET_ARMV8A_ARM_CORTEX_A53)
 #if defined (_MSC_VER)
-	double pU[3*4*K_MAX_STACK] __declspec(align(64));
-	double pD[4*16] __declspec(align(64));
+	__declspec(align(64)) double pU[3*4*K_MAX_STACK];
+	__declspec(align(64)) double pD[4*16];
 #else
 	double pU[3*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 	double pD[4*16] __attribute__ ((aligned (64)));
 #endif
 #elif defined(TARGET_X64_INTEL_SANDY_BRIDGE) | defined(TARGET_ARMV8A_ARM_CORTEX_A57)
 #if defined (_MSC_VER)
-	double pU[2*4*K_MAX_STACK] __declspec(align(64));
-	double pD[2*16] __declspec(align(64));
+	__declspec(align(64)) double pU[2*4*K_MAX_STACK];
+	__declspec(align(64)) double pD[2*16];
 #else
 	double pU[2*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 	double pD[2*16] __attribute__ ((aligned (64)));
@@ -104,8 +104,8 @@ void blasfeo_dpotrf(char *uplo, int *pm, double *C, int *pldc, int *info)
 	double pD[1*16];
 #else
 #if defined (_MSC_VER)
-	double pU[1*4*K_MAX_STACK] __declspec(align(64));
-	double pD[1*16] __declspec(align(64));
+	__declspec(align(64)) double pU[1*4*K_MAX_STACK];
+	__declspec(align(64)) double pD[1*16];
 #else
 	double pU[1*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 	double pD[1*16] __attribute__ ((aligned (64)));

--- a/blas_api/dsyrk.c
+++ b/blas_api/dsyrk.c
@@ -84,14 +84,14 @@ void blasfeo_dsyrk(char *uplo, char *ta, int *pm, int *pk, double *alpha, double
 // TODO visual studio alignment
 #if defined(TARGET_X64_INTEL_HASWELL) | defined(TARGET_ARMV8A_ARM_CORTEX_A53)
 #if defined (_MSC_VER)
-	double pU0[3*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[3*4*K_MAX_STACK];
 #else
 	double pU0[3*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
 //	double pD0[4*16] __attribute__ ((aligned (64)));
 #elif defined(TARGET_X64_INTEL_SANDY_BRIDGE) | defined(TARGET_ARMV8A_ARM_CORTEX_A57)
 #if defined (_MSC_VER)
-	double pU0[2*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[2*4*K_MAX_STACK];
 #else
 	double pU0[2*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -101,7 +101,7 @@ void blasfeo_dsyrk(char *uplo, char *ta, int *pm, int *pk, double *alpha, double
 //	double pD0[1*16];
 #else
 #if defined (_MSC_VER)
-	double pU0[1*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[1*4*K_MAX_STACK];
 #else
 	double pU0[1*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif

--- a/blas_api/dtrmm.c
+++ b/blas_api/dtrmm.c
@@ -136,13 +136,13 @@ void blasfeo_dtrmm(char *side, char *uplo, char *transa, char *diag, int *pm, in
 // TODO visual studio alignment
 #if defined(TARGET_X64_INTEL_HASWELL) | defined(TARGET_ARMV8A_ARM_CORTEX_A53)
 #if defined (_MSC_VER)
-	double pU0[3*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[3*4*K_MAX_STACK];
 #else
 	double pU0[3*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
 #elif defined(TARGET_X64_INTEL_SANDY_BRIDGE) | defined(TARGET_ARMV8A_ARM_CORTEX_A57)
 #if defined (_MSC_VER)
-	double pU0[2*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[2*4*K_MAX_STACK];
 #else
 	double pU0[2*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -150,7 +150,7 @@ void blasfeo_dtrmm(char *side, char *uplo, char *transa, char *diag, int *pm, in
 	double pU0[1*4*K_MAX_STACK];
 #else
 #if defined (_MSC_VER)
-	double pU0[1*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[1*4*K_MAX_STACK];
 #else
 	double pU0[1*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif

--- a/blas_api/dtrsm.c
+++ b/blas_api/dtrsm.c
@@ -138,7 +138,7 @@ void blasfeo_dtrsm(char *side, char *uplo, char *transa, char *diag, int *pm, in
 	double pd0[K_MAX_STACK];
 #else
 #if defined (_MSC_VER)
-	double pd0[K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pd0[K_MAX_STACK];
 #else
 	double pd0[K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -146,13 +146,13 @@ void blasfeo_dtrsm(char *side, char *uplo, char *transa, char *diag, int *pm, in
 
 #if defined(TARGET_X64_INTEL_HASWELL) | defined(TARGET_ARMV8A_ARM_CORTEX_A53)
 #if defined (_MSC_VER)
-	double pU0[3*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[3*4*K_MAX_STACK];
 #else
 	double pU0[3*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
 #elif defined(TARGET_X64_INTEL_SANDY_BRIDGE) | defined(TARGET_ARMV8A_ARM_CORTEX_A57)
 #if defined (_MSC_VER)
-	double pU0[2*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[2*4*K_MAX_STACK];
 #else
 	double pU0[2*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -160,7 +160,7 @@ void blasfeo_dtrsm(char *side, char *uplo, char *transa, char *diag, int *pm, in
 	double pU0[1*4*K_MAX_STACK];
 #else
 #if defined (_MSC_VER)
-	double pU0[1*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[1*4*K_MAX_STACK];
 #else
 	double pU0[1*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif

--- a/blas_api/sgemm.c
+++ b/blas_api/sgemm.c
@@ -80,21 +80,21 @@ void blasfeo_sgemm(char *ta, char *tb, int *pm, int *pn, int *pk, float *alpha, 
 // TODO visual studio alignment
 #if defined(TARGET_X64_INTEL_HASWELL)
 #if defined (_MSC_VER)
-	float pU[3*8*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) float pU[3*8*K_MAX_STACK];
 #else
 	float pU[3*8*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
 	int sdu = (k+ps_8-1)/ps_8*ps_8;
 #elif defined(TARGET_X64_INTEL_SANDY_BRIDGE)
 #if defined (_MSC_VER)
-	float pU[2*8*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) float pU[2*8*K_MAX_STACK];
 #else
 	float pU[2*8*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
 	int sdu = (k+ps_8-1)/ps_8*ps_8;
 #elif defined(TARGET_ARMV7A_ARM_CORTEX_A15) | defined(TARGET_ARMV7A_ARM_CORTEX_A9) | defined(TARGET_ARMV7A_ARM_CORTEX_A7)
 #if defined (_MSC_VER)
-	float pU[2*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) float pU[2*4*K_MAX_STACK];
 #else
 	float pU[2*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -104,7 +104,7 @@ void blasfeo_sgemm(char *ta, char *tb, int *pm, int *pn, int *pk, float *alpha, 
 	int sdu = (k+ps_4-1)/ps_4*ps_4;
 #else
 #if defined (_MSC_VER)
-	float pU[1*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) float pU[1*4*K_MAX_STACK];
 #else
 	float pU[1*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif

--- a/blasfeo_api/d_blas3_lib4.c
+++ b/blasfeo_api/d_blas3_lib4.c
@@ -1412,13 +1412,13 @@ void blasfeo_dgemm_tn(int m, int n, int k, double alpha, struct blasfeo_dmat *sA
 // TODO visual studio alignment
 #if defined(TARGET_X64_INTEL_HASWELL) | defined(TARGET_ARMV8A_ARM_CORTEX_A53)
 #if defined (_MSC_VER)
-	double pU0[3*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[3*4*K_MAX_STACK];
 #else
 	double pU0[3*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
 #elif defined(TARGET_X64_INTEL_SANDY_BRIDGE) | defined(TARGET_ARMV8A_ARM_CORTEX_A57)
 #if defined (_MSC_VER)
-	double pU0[2*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[2*4*K_MAX_STACK];
 #else
 	double pU0[2*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -1426,7 +1426,7 @@ void blasfeo_dgemm_tn(int m, int n, int k, double alpha, struct blasfeo_dmat *sA
 	double pU0[1*4*K_MAX_STACK];
 #else
 #if defined (_MSC_VER)
-	double pU0[1*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[1*4*K_MAX_STACK];
 #else
 	double pU0[1*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -2312,13 +2312,13 @@ void blasfeo_dgemm_tt(int m, int n, int k, double alpha, struct blasfeo_dmat *sA
 // TODO visual studio alignment
 #if defined(TARGET_X64_INTEL_HASWELL) | defined(TARGET_ARMV8A_ARM_CORTEX_A53)
 #if defined (_MSC_VER)
-	double pU[3*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU[3*4*K_MAX_STACK];
 #else
 	double pU[3*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
 #elif defined(TARGET_X64_INTEL_SANDY_BRIDGE) | defined(TARGET_ARMV8A_ARM_CORTEX_A57)
 #if defined (_MSC_VER)
-	double pU[2*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU[2*4*K_MAX_STACK];
 #else
 	double pU[2*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -2326,7 +2326,7 @@ void blasfeo_dgemm_tt(int m, int n, int k, double alpha, struct blasfeo_dmat *sA
 	double pU[1*4*K_MAX_STACK];
 #else
 #if defined (_MSC_VER)
-	double pU[1*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU[1*4*K_MAX_STACK];
 #else
 	double pU[1*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -4962,13 +4962,13 @@ void blasfeo_dsyrk_ln(int m, int k, double alpha, struct blasfeo_dmat *sA, int a
 // TODO visual studio alignment
 #if defined(TARGET_X64_INTEL_HASWELL) | defined(TARGET_ARMV8A_ARM_CORTEX_A53)
 #if defined (_MSC_VER)
-	double pU0[3*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[3*4*K_MAX_STACK];
 #else
 	double pU0[3*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
 #elif defined(TARGET_X64_INTEL_SANDY_BRIDGE) | defined(TARGET_ARMV8A_ARM_CORTEX_A57)
 #if defined (_MSC_VER)
-	double pU0[2*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[2*4*K_MAX_STACK];
 #else
 	double pU0[2*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -4976,7 +4976,7 @@ void blasfeo_dsyrk_ln(int m, int k, double alpha, struct blasfeo_dmat *sA, int a
 	double pU0[1*4*K_MAX_STACK];
 #else
 #if defined (_MSC_VER)
-	double pU0[1*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[1*4*K_MAX_STACK];
 #else
 	double pU0[1*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -6414,13 +6414,13 @@ void blasfeo_dsyrk_ut(int m, int k, double alpha, struct blasfeo_dmat *sA, int a
 // TODO visual studio alignment
 #if defined(TARGET_X64_INTEL_HASWELL) | defined(TARGET_ARMV8A_ARM_CORTEX_A53)
 #if defined (_MSC_VER)
-	double pU0[3*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[3*4*K_MAX_STACK];
 #else
 	double pU0[3*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
 #elif defined(TARGET_X64_INTEL_SANDY_BRIDGE) | defined(TARGET_ARMV8A_ARM_CORTEX_A57)
 #if defined (_MSC_VER)
-	double pU0[2*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[2*4*K_MAX_STACK];
 #else
 	double pU0[2*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -6428,7 +6428,7 @@ void blasfeo_dsyrk_ut(int m, int k, double alpha, struct blasfeo_dmat *sA, int a
 	double pU0[1*4*K_MAX_STACK];
 #else
 #if defined (_MSC_VER)
-	double pU0[1*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[1*4*K_MAX_STACK];
 #else
 	double pU0[1*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif

--- a/blasfeo_api/d_lapack_lib4.c
+++ b/blasfeo_api/d_lapack_lib4.c
@@ -84,13 +84,13 @@ void blasfeo_dgetrf_rp_test(int m, int n, struct blasfeo_dmat *sC, int ci, int c
 // TODO visual studio alignment
 #if defined(TARGET_X64_INTEL_HASWELL) | defined(TARGET_ARMV8A_ARM_CORTEX_A53)
 #if defined (_MSC_VER)
-	double pU0[3*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[3*4*K_MAX_STACK];
 #else
 	double pU0[3*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
 #elif defined(TARGET_X64_INTEL_SANDY_BRIDGE) | defined(TARGET_ARMV8A_ARM_CORTEX_A57)
 #if defined (_MSC_VER)
-	double pU0[2*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[2*4*K_MAX_STACK];
 #else
 	double pU0[2*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -98,7 +98,7 @@ void blasfeo_dgetrf_rp_test(int m, int n, struct blasfeo_dmat *sC, int ci, int c
 	double pU0[1*4*K_MAX_STACK];
 #else
 #if defined (_MSC_VER)
-	double pU0[1*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[1*4*K_MAX_STACK];
 #else
 	double pU0[1*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -558,13 +558,13 @@ void blasfeo_dgetrf_np_test(int m, int n, struct blasfeo_dmat *sC, int ci, int c
 // TODO visual studio alignment
 #if defined(TARGET_X64_INTEL_HASWELL) | defined(TARGET_ARMV8A_ARM_CORTEX_A53)
 #if defined (_MSC_VER)
-	double pU0[3*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[3*4*K_MAX_STACK];
 #else
 	double pU0[3*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
 #elif defined(TARGET_X64_INTEL_SANDY_BRIDGE) | defined(TARGET_ARMV8A_ARM_CORTEX_A57)
 #if defined (_MSC_VER)
-	double pU0[2*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[2*4*K_MAX_STACK];
 #else
 	double pU0[2*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -572,7 +572,7 @@ void blasfeo_dgetrf_np_test(int m, int n, struct blasfeo_dmat *sC, int ci, int c
 	double pU0[1*4*K_MAX_STACK];
 #else
 #if defined (_MSC_VER)
-	double pU0[1*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[1*4*K_MAX_STACK];
 #else
 	double pU0[1*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -3504,16 +3504,16 @@ void blasfeo_dgelqf(int m, int n, struct blasfeo_dmat *sC, int ci, int cj, struc
 	double *dD = sD->dA + di;
 #if defined(TARGET_X64_INTEL_HASWELL)
 #if defined (_MSC_VER)
-	double pT[144] __declspec(align(64)) = {0};
-	double pK[144] __declspec(align(64)) = {0};
+	__declspec(align(64)) double pT[144] = {0};
+	__declspec(align(64)) double pK[144] = {0};
 #else
 #if defined (_MSC_VER)
-	double pT[144] __declspec(align(64)) = {0};
+	__declspec(align(64)) double pT[144] = {0};
 #else
 	double pT[144] __attribute__ ((aligned (64))) = {0};
 #endif
 #if defined (_MSC_VER)
-	double pK[144] __declspec(align(64)) = {0};
+	__declspec(align(64)) double pK[144] = {0};
 #else
 	double pK[144] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -3729,16 +3729,16 @@ void blasfeo_dorglq(int m, int n, int k, struct blasfeo_dmat *sC, int ci, int cj
 
 #if defined(TARGET_X64_INTEL_HASWELL)
 #if defined (_MSC_VER)
-	double pT[144] __declspec(align(64)) = {0};
-	double pK[144] __declspec(align(64)) = {0};
+	__declspec(align(64)) double pT[144] = {0};
+	__declspec(align(64)) double pK[144] = {0};
 #else
 #if defined (_MSC_VER)
-	double pT[144] __declspec(align(64)) = {0};
+	__declspec(align(64)) double pT[144] = {0};
 #else
 	double pT[144] __attribute__ ((aligned (64))) = {0};
 #endif
 #if defined (_MSC_VER)
-	double pK[144] __declspec(align(64)) = {0};
+	__declspec(align(64)) double pK[144] = {0};
 #else
 	double pK[144] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -3839,16 +3839,16 @@ void blasfeo_dgelqf_pd(int m, int n, struct blasfeo_dmat *sC, int ci, int cj, st
 	double *dD = sD->dA + di;
 #if defined(TARGET_X64_INTEL_HASWELL)
 #if defined (_MSC_VER)
-	double pT[144] __declspec(align(64)) = {0};
-	double pK[144] __declspec(align(64)) = {0};
+	__declspec(align(64)) double pT[144] = {0};
+	__declspec(align(64)) double pK[144] = {0};
 #else
 #if defined (_MSC_VER)
-	double pT[144] __declspec(align(64)) = {0};
+	__declspec(align(64)) double pT[144] = {0};
 #else
 	double pT[144] __attribute__ ((aligned (64))) = {0};
 #endif
 #if defined (_MSC_VER)
-	double pK[144] __declspec(align(64)) = {0};
+	__declspec(align(64)) double pK[144] = {0};
 #else
 	double pK[144] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -4026,16 +4026,16 @@ void blasfeo_dgelqf_pd_la(int m, int n1, struct blasfeo_dmat *sD, int di, int dj
 	double *dD = sD->dA + di;
 #if defined(TARGET_X64_INTEL_HASWELL)
 #if defined (_MSC_VER)
-	double pT[144] __declspec(align(64)) = {0};
-	double pK[96] __declspec(align(64)) = {0};
+	__declspec(align(64)) double pT[144] = {0};
+	__declspec(align(64)) double pK[96] = {0};
 #else
 #if defined (_MSC_VER)
-	double pT[144] __declspec(align(64)) = {0};
+	__declspec(align(64)) double pT[144] = {0};
 #else
 	double pT[144] __attribute__ ((aligned (64))) = {0};
 #endif
 #if defined (_MSC_VER)
-	double pK[96] __declspec(align(64)) = {0};
+	__declspec(align(64)) double pK[96] = {0};
 #else
 	double pK[96] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -4155,16 +4155,16 @@ void blasfeo_dgelqf_pd_lla(int m, int n1, struct blasfeo_dmat *sD, int di, int d
 	double *dD = sD->dA + di;
 #if defined(TARGET_X64_INTEL_HASWELL)
 #if defined (_MSC_VER)
-	double pT[144] __declspec(align(64)) = {0};
-	double pK[96] __declspec(align(64)) = {0};
+	__declspec(align(64)) double pT[144] = {0};
+	__declspec(align(64)) double pK[96] = {0};
 #else
 #if defined (_MSC_VER)
-	double pT[144] __declspec(align(64)) = {0};
+	__declspec(align(64)) double pT[144] = {0};
 #else
 	double pT[144] __attribute__ ((aligned (64))) = {0};
 #endif
 #if defined (_MSC_VER)
-	double pK[96] __declspec(align(64)) = {0};
+	__declspec(align(64)) double pK[96] = {0};
 #else
 	double pK[96] __attribute__ ((aligned (64))) = {0};
 #endif

--- a/blasfeo_api/s_blas3_lib4.c
+++ b/blasfeo_api/s_blas3_lib4.c
@@ -1454,7 +1454,7 @@ void blasfeo_ssyrk_ln(int m, int k, float alpha, struct blasfeo_smat *sA, int ai
 // TODO visual studio alignment
 #if defined(TARGET_ARMV8A_ARM_CORTEX_A57) | defined(TARGET_ARMV8A_ARM_CORTEX_A53)
 #if defined (_MSC_VER)
-	float pU0[2*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) float pU0[2*4*K_MAX_STACK];
 #else
 	float pU0[2*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -1462,7 +1462,7 @@ void blasfeo_ssyrk_ln(int m, int k, float alpha, struct blasfeo_smat *sA, int ai
 	float pU0[1*4*K_MAX_STACK];
 #else
 #if defined (_MSC_VER)
-	float pU0[1*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) float pU0[1*4*K_MAX_STACK];
 #else
 	float pU0[1*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif

--- a/blasfeo_api/s_blas3_lib8.c
+++ b/blasfeo_api/s_blas3_lib8.c
@@ -96,7 +96,7 @@ void blasfeo_sgemm_nt(int m, int n, int k, float alpha, struct blasfeo_smat *sA,
 
 	// register spil space
 #if defined (_MSC_VER)
-//	float spil[32] __declspec(align(64));
+//	__declspec(align(64)) float spil[32];
 #else
 //	float spil[32] __attribute__ ((aligned (64)));
 #endif

--- a/experimental/giaf/blas/blas/dgemm.c
+++ b/experimental/giaf/blas/blas/dgemm.c
@@ -61,7 +61,7 @@ void blasfeo_dgemm(char *ta, char *tb, int *pm, int *pn, int *pk, double *alpha,
 	int bs = 4;
 
 #if defined (_MSC_VER)
-	double pU[12*256] __declspec(align(64));
+	__declspec(align(64)) double pU[12*256];
 #else
 	double pU[12*256] __attribute__ ((aligned (64)));
 #endif

--- a/experimental/giaf/blas/blas/dpotrf.c
+++ b/experimental/giaf/blas/blas/dpotrf.c
@@ -57,13 +57,13 @@ void blasfeo_dpotrf(char *uplo, int *pm, double *C, int *pldc) // TODO int *info
 	int bs = 4;
 
 #if defined (_MSC_VER)
-	double pd[256] __declspec(align(64));
+	__declspec(align(64)) double pd[256];
 #else
 	double pd[256] __attribute__ ((aligned (64)));
 #endif
 
 #if defined (_MSC_VER)
-	double pU[12*256] __declspec(align(64));
+	__declspec(align(64)) double pU[12*256];
 #else
 	double pU[12*256] __attribute__ ((aligned (64)));
 #endif

--- a/kernel/armv8a/kernel_dgetrf_pivot_lib.c
+++ b/kernel/armv8a/kernel_dgetrf_pivot_lib.c
@@ -48,13 +48,13 @@ void kernel_dgetrf_pivot_12_vs_lib(int m, double *C, int ldc, double *pd, int* i
 
 #if defined(TARGET_X64_INTEL_HASWELL) | defined(TARGET_ARMV8A_ARM_CORTEX_A53)
 #if defined (_MSC_VER)
-	double pU0[3*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[3*4*K_MAX_STACK];
 #else
 	double pU0[3*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
 #elif defined(TARGET_X64_INTEL_SANDY_BRIDGE) | defined(TARGET_ARMV8A_ARM_CORTEX_A57)
 #if defined (_MSC_VER)
-	double pU0[2*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[2*4*K_MAX_STACK];
 #else
 	double pU0[2*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -62,7 +62,7 @@ void kernel_dgetrf_pivot_12_vs_lib(int m, double *C, int ldc, double *pd, int* i
 	double pU0[1*4*K_MAX_STACK];
 #else
 #if defined (_MSC_VER)
-	double pU0[1*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[1*4*K_MAX_STACK];
 #else
 	double pU0[1*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -176,13 +176,13 @@ void kernel_dgetrf_pivot_8_vs_lib(int m, double *C, int ldc, double *pd, int* ip
 
 #if defined(TARGET_X64_INTEL_HASWELL) | defined(TARGET_ARMV8A_ARM_CORTEX_A53)
 #if defined (_MSC_VER)
-	double pU0[3*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[3*4*K_MAX_STACK];
 #else
 	double pU0[3*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
 #elif defined(TARGET_X64_INTEL_SANDY_BRIDGE) | defined(TARGET_ARMV8A_ARM_CORTEX_A57)
 #if defined (_MSC_VER)
-	double pU0[2*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[2*4*K_MAX_STACK];
 #else
 	double pU0[2*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -190,7 +190,7 @@ void kernel_dgetrf_pivot_8_vs_lib(int m, double *C, int ldc, double *pd, int* ip
 	double pU0[1*4*K_MAX_STACK];
 #else
 #if defined (_MSC_VER)
-	double pU0[1*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[1*4*K_MAX_STACK];
 #else
 	double pU0[1*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif

--- a/kernel/avx/kernel_dgetrf_pivot_lib.c
+++ b/kernel/avx/kernel_dgetrf_pivot_lib.c
@@ -1330,13 +1330,13 @@ void kernel_dgetrf_pivot_8_vs_lib(int m, double *C, int ldc, double *pd, int* ip
 
 #if defined(TARGET_X64_INTEL_HASWELL) | defined(TARGET_ARMV8A_ARM_CORTEX_A53)
 #if defined (_MSC_VER)
-	double pU0[3*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[3*4*K_MAX_STACK];
 #else
 	double pU0[3*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
 #elif defined(TARGET_X64_INTEL_SANDY_BRIDGE) | defined(TARGET_ARMV8A_ARM_CORTEX_A57)
 #if defined (_MSC_VER)
-	double pU0[2*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[2*4*K_MAX_STACK];
 #else
 	double pU0[2*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -1344,7 +1344,7 @@ void kernel_dgetrf_pivot_8_vs_lib(int m, double *C, int ldc, double *pd, int* ip
 	double pU0[1*4*K_MAX_STACK];
 #else
 #if defined (_MSC_VER)
-	double pU0[1*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[1*4*K_MAX_STACK];
 #else
 	double pU0[1*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif

--- a/kernel/avx2/kernel_dgetrf_pivot_lib.c
+++ b/kernel/avx2/kernel_dgetrf_pivot_lib.c
@@ -2116,13 +2116,13 @@ void kernel_dgetrf_pivot_12_vs_lib(int m, double *C, int ldc, double *pd, int* i
 
 #if defined(TARGET_X64_INTEL_HASWELL) | defined(TARGET_ARMV8A_ARM_CORTEX_A53)
 #if defined (_MSC_VER)
-	double pU0[3*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[3*4*K_MAX_STACK];
 #else
 	double pU0[3*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
 #elif defined(TARGET_X64_INTEL_SANDY_BRIDGE) | defined(TARGET_ARMV8A_ARM_CORTEX_A57)
 #if defined (_MSC_VER)
-	double pU0[2*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[2*4*K_MAX_STACK];
 #else
 	double pU0[2*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -2130,7 +2130,7 @@ void kernel_dgetrf_pivot_12_vs_lib(int m, double *C, int ldc, double *pd, int* i
 	double pU0[1*4*K_MAX_STACK];
 #else
 #if defined (_MSC_VER)
-	double pU0[1*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[1*4*K_MAX_STACK];
 #else
 	double pU0[1*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -3400,13 +3400,13 @@ void kernel_dgetrf_pivot_8_vs_lib(int m, double *C, int ldc, double *pd, int* ip
 
 #if defined(TARGET_X64_INTEL_HASWELL) | defined(TARGET_ARMV8A_ARM_CORTEX_A53)
 #if defined (_MSC_VER)
-	double pU0[3*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[3*4*K_MAX_STACK];
 #else
 	double pU0[3*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
 #elif defined(TARGET_X64_INTEL_SANDY_BRIDGE) | defined(TARGET_ARMV8A_ARM_CORTEX_A57)
 #if defined (_MSC_VER)
-	double pU0[2*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[2*4*K_MAX_STACK];
 #else
 	double pU0[2*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif
@@ -3414,7 +3414,7 @@ void kernel_dgetrf_pivot_8_vs_lib(int m, double *C, int ldc, double *pd, int* ip
 	double pU0[1*4*K_MAX_STACK];
 #else
 #if defined (_MSC_VER)
-	double pU0[1*4*K_MAX_STACK] __declspec(align(64));
+	__declspec(align(64)) double pU0[1*4*K_MAX_STACK];
 #else
 	double pU0[1*4*K_MAX_STACK] __attribute__ ((aligned (64)));
 #endif

--- a/kernel/generic/kernel_dgemm_4x4_lib.c
+++ b/kernel/generic/kernel_dgemm_4x4_lib.c
@@ -48,7 +48,7 @@ void kernel_dgemm_nt_4x4_libcccc(int kmax, double *alpha, double *A, int lda, do
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -275,7 +275,7 @@ static void kernel_dgemm_nt_4x3_libcccc(int kmax, double *alpha, double *A, int 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -466,7 +466,7 @@ static void kernel_dgemm_nt_4x2_libcccc(int kmax, double *alpha, double *A, int 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -622,7 +622,7 @@ static void kernel_dgemm_nt_4x1_libcccc(int kmax, double *alpha, double *A, int 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -740,7 +740,7 @@ void kernel_dgemm_nt_4x4_vs_libcccc(int kmax, double *alpha, double *A, int lda,
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -942,7 +942,7 @@ void kernel_dgemm_nt_4x4_lib44cc(int kmax, double *alpha, double *A, double *B, 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -990,7 +990,7 @@ void kernel_dgemm_nt_4x4_vs_lib44cc(int kmax, double *alpha, double *A, double *
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -1123,7 +1123,7 @@ void kernel_dgemm_nn_4x4_libcccc(int kmax, double *alpha, double *A, int lda, do
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -1350,7 +1350,7 @@ static void kernel_dgemm_nn_4x3_libcccc(int kmax, double *alpha, double *A, int 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -1541,7 +1541,7 @@ static void kernel_dgemm_nn_4x2_libcccc(int kmax, double *alpha, double *A, int 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -1697,7 +1697,7 @@ static void kernel_dgemm_nn_4x1_libcccc(int kmax, double *alpha, double *A, int 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -1815,7 +1815,7 @@ void kernel_dgemm_nn_4x4_vs_libcccc(int kmax, double *alpha, double *A, int lda,
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -1983,7 +1983,7 @@ void kernel_dgemm_tt_4x4_libcccc(int kmax, double *alpha, double *A, int lda, do
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -2039,7 +2039,7 @@ void kernel_dgemm_tt_4x4_vs_libcccc(int kmax, double *alpha, double *A, int lda,
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -2176,7 +2176,7 @@ void kernel_dgemm_tt_4x4_libc4cc(int kmax, double *alpha, double *A, int lda, do
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -2232,7 +2232,7 @@ void kernel_dgemm_tt_4x4_vs_libc4cc(int kmax, double *alpha, double *A, int lda,
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -2369,7 +2369,7 @@ void kernel_dsyrk_nt_l_4x4_lib44cc(int kmax, double *alpha, double *A, double *B
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -2411,7 +2411,7 @@ void kernel_dsyrk_nt_l_4x4_vs_lib44cc(int kmax, double *alpha, double *A, double
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -2496,7 +2496,7 @@ void kernel_dsyrk_nt_u_4x4_lib44cc(int kmax, double *alpha, double *A, double *B
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -2544,7 +2544,7 @@ void kernel_dsyrk_nt_u_4x4_vs_lib44cc(int kmax, double *alpha, double *A, double
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -2677,7 +2677,7 @@ void kernel_dtrmm_nn_rl_4x4_lib4ccc(int kmax, double *alpha, double *A, double *
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -2847,7 +2847,7 @@ void kernel_dtrmm_nn_rl_4x4_vs_lib4ccc(int kmax, double *alpha, double *A, doubl
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -3118,7 +3118,7 @@ void kernel_dtrmm_nn_rl_4x4_tran_lib4c4c(int kmax, double *alpha, double *A, dou
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -3291,7 +3291,7 @@ void kernel_dtrmm_nn_rl_4x4_tran_vs_lib4c4c(int kmax, double *alpha, double *A, 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -3575,7 +3575,7 @@ void kernel_dtrmm_nn_rl_one_4x4_lib4ccc(int kmax, double *alpha, double *A, doub
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -3741,7 +3741,7 @@ void kernel_dtrmm_nn_rl_one_4x4_vs_lib4ccc(int kmax, double *alpha, double *A, d
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -4008,7 +4008,7 @@ void kernel_dtrmm_nn_rl_one_4x4_tran_lib4c4c(int kmax, double *alpha, double *A,
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -4177,7 +4177,7 @@ void kernel_dtrmm_nn_rl_one_4x4_tran_vs_lib4c4c(int kmax, double *alpha, double 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -4457,7 +4457,7 @@ void kernel_dtrmm_nn_ru_4x4_lib4ccc(int kmax, double *alpha, double *A, double *
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -4619,7 +4619,7 @@ void kernel_dtrmm_nn_ru_4x4_vs_lib4ccc(int kmax, double *alpha, double *A, doubl
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -5059,7 +5059,7 @@ void kernel_dtrmm_nn_ru_4x4_tran_lib4c4c(int kmax, double *alpha, double *A, dou
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -5223,7 +5223,7 @@ void kernel_dtrmm_nn_ru_4x4_tran_vs_lib4c4c(int kmax, double *alpha, double *A, 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -5676,7 +5676,7 @@ void kernel_dtrmm_nn_ru_one_4x4_lib4ccc(int kmax, double *alpha, double *A, doub
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -5834,7 +5834,7 @@ void kernel_dtrmm_nn_ru_one_4x4_vs_lib4ccc(int kmax, double *alpha, double *A, d
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -6264,7 +6264,7 @@ void kernel_dtrmm_nn_ru_one_4x4_tran_lib4c4c(int kmax, double *alpha, double *A,
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -6424,7 +6424,7 @@ void kernel_dtrmm_nn_ru_one_4x4_tran_vs_lib4c4c(int kmax, double *alpha, double 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -6867,7 +6867,7 @@ void kernel_dtrmm_nt_rl_4x4_lib44cc(int kmax, double *alpha, double *A, double *
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -7030,7 +7030,7 @@ void kernel_dtrmm_nt_rl_4x4_vs_lib44cc(int kmax, double *alpha, double *A, doubl
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -7472,7 +7472,7 @@ void kernel_dtrmm_nt_rl_4x4_tran_lib444c(int kmax, double *alpha, double *A, dou
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -7637,7 +7637,7 @@ void kernel_dtrmm_nt_rl_4x4_tran_vs_lib444c(int kmax, double *alpha, double *A, 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -8091,7 +8091,7 @@ void kernel_dtrmm_nt_rl_one_4x4_lib44cc(int kmax, double *alpha, double *A, doub
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -8250,7 +8250,7 @@ void kernel_dtrmm_nt_rl_one_4x4_vs_lib44cc(int kmax, double *alpha, double *A, d
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -8682,7 +8682,7 @@ void kernel_dtrmm_nt_rl_one_4x4_tran_lib444c(int kmax, double *alpha, double *A,
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -8843,7 +8843,7 @@ void kernel_dtrmm_nt_rl_one_4x4_tran_vs_lib444c(int kmax, double *alpha, double 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -9287,7 +9287,7 @@ void kernel_dtrmm_nt_rl_4x4_lib4ccc(int kmax, double *alpha, double *A, double *
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -9449,7 +9449,7 @@ void kernel_dtrmm_nt_rl_4x4_vs_lib4ccc(int kmax, double *alpha, double *A, doubl
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -9889,7 +9889,7 @@ void kernel_dtrmm_nt_rl_4x4_tran_lib4c4c(int kmax, double *alpha, double *A, dou
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -10053,7 +10053,7 @@ void kernel_dtrmm_nt_rl_4x4_tran_vs_lib4c4c(int kmax, double *alpha, double *A, 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -10506,7 +10506,7 @@ void kernel_dtrmm_nt_rl_one_4x4_lib4ccc(int kmax, double *alpha, double *A, doub
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -10664,7 +10664,7 @@ void kernel_dtrmm_nt_rl_one_4x4_vs_lib4ccc(int kmax, double *alpha, double *A, d
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -11095,7 +11095,7 @@ void kernel_dtrmm_nt_rl_one_4x4_tran_lib4c4c(int kmax, double *alpha, double *A,
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -11255,7 +11255,7 @@ void kernel_dtrmm_nt_rl_one_4x4_tran_vs_lib4c4c(int kmax, double *alpha, double 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -11698,7 +11698,7 @@ void kernel_dtrmm_nt_ru_4x4_lib44cc(int kmax, double *alpha, double *A, double *
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -11888,7 +11888,7 @@ void kernel_dtrmm_nt_ru_4x4_vs_lib44cc(int kmax, double *alpha, double *A, doubl
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -12159,7 +12159,7 @@ void kernel_dtrmm_nt_ru_4x4_tran_lib444c(int kmax, double *alpha, double *A, dou
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -12332,7 +12332,7 @@ void kernel_dtrmm_nt_ru_4x4_tran_vs_lib444c(int kmax, double *alpha, double *A, 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -12616,7 +12616,7 @@ void kernel_dtrmm_nt_ru_4x4_lib4ccc(int kmax, double *alpha, double *A, double *
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -12786,7 +12786,7 @@ void kernel_dtrmm_nt_ru_4x4_vs_lib4ccc(int kmax, double *alpha, double *A, doubl
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -13057,7 +13057,7 @@ void kernel_dtrmm_nt_ru_4x4_tran_lib4c4c(int kmax, double *alpha, double *A, dou
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -13230,7 +13230,7 @@ void kernel_dtrmm_nt_ru_4x4_tran_vs_lib4c4c(int kmax, double *alpha, double *A, 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -13514,7 +13514,7 @@ void kernel_dtrmm_nt_ru_one_4x4_lib44cc(int kmax, double *alpha, double *A, doub
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -13700,7 +13700,7 @@ void kernel_dtrmm_nt_ru_one_4x4_vs_lib44cc(int kmax, double *alpha, double *A, d
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -13967,7 +13967,7 @@ void kernel_dtrmm_nt_ru_one_4x4_tran_lib444c(int kmax, double *alpha, double *A,
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -14136,7 +14136,7 @@ void kernel_dtrmm_nt_ru_one_4x4_tran_vs_lib444c(int kmax, double *alpha, double 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -14416,7 +14416,7 @@ void kernel_dtrmm_nt_ru_one_4x4_lib4ccc(int kmax, double *alpha, double *A, doub
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -14582,7 +14582,7 @@ void kernel_dtrmm_nt_ru_one_4x4_vs_lib4ccc(int kmax, double *alpha, double *A, d
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -14849,7 +14849,7 @@ void kernel_dtrmm_nt_ru_one_4x4_tran_lib4c4c(int kmax, double *alpha, double *A,
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -15018,7 +15018,7 @@ void kernel_dtrmm_nt_ru_one_4x4_tran_vs_lib4c4c(int kmax, double *alpha, double 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -15294,7 +15294,7 @@ void kernel_dpotrf_nt_l_4x4_lib44cc(int kmax, double *A, double *B, double *C, i
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -15347,7 +15347,7 @@ void kernel_dpotrf_nt_l_4x4_vs_lib44cc(int kmax, double *A, double *B, double *C
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -15490,7 +15490,7 @@ void kernel_dtrsm_nn_rl_inv_4x4_lib4c44c(int kmax, double *A, double *B, int ldb
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -15594,7 +15594,7 @@ void kernel_dtrsm_nn_rl_inv_4x4_vs_lib4c44c(int kmax, double *A, double *B, int 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -15793,7 +15793,7 @@ void kernel_dtrsm_nn_rl_inv_4x4_lib4cccc(int kmax, double *A, double *B, int ldb
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -15897,7 +15897,7 @@ void kernel_dtrsm_nn_rl_inv_4x4_vs_lib4cccc(int kmax, double *A, double *B, int 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -16096,7 +16096,7 @@ void kernel_dtrsm_nn_rl_one_4x4_lib4c44c(int kmax, double *A, double *B, int ldb
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -16179,7 +16179,7 @@ void kernel_dtrsm_nn_rl_one_4x4_vs_lib4c44c(int kmax, double *A, double *B, int 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -16357,7 +16357,7 @@ void kernel_dtrsm_nn_rl_one_4x4_lib4cccc(int kmax, double *A, double *B, int ldb
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -16440,7 +16440,7 @@ void kernel_dtrsm_nn_rl_one_4x4_vs_lib4cccc(int kmax, double *A, double *B, int 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -16618,7 +16618,7 @@ void kernel_dtrsm_nt_rl_inv_4x4_lib44cc4(int kmax, double *A, double *B, double 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -16741,7 +16741,7 @@ void kernel_dtrsm_nt_rl_inv_4x4_vs_lib44cc4(int kmax, double *A, double *B, doub
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -17038,7 +17038,7 @@ void kernel_dtrsm_nt_rl_inv_4x4_lib44ccc(int kmax, double *A, double *B, double 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -17162,7 +17162,7 @@ void kernel_dtrsm_nt_rl_inv_4x4_vs_lib44ccc(int kmax, double *A, double *B, doub
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -17460,7 +17460,7 @@ void kernel_dtrsm_nt_rl_inv_4x4_lib4c44c(int kmax, double *A, double *B, int ldb
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -17563,7 +17563,7 @@ void kernel_dtrsm_nt_rl_inv_4x4_vs_lib4c44c(int kmax, double *A, double *B, int 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -17758,7 +17758,7 @@ void kernel_dtrsm_nt_rl_inv_4x4_lib4cccc(int kmax, double *A, double *B, int ldb
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -17861,7 +17861,7 @@ void kernel_dtrsm_nt_rl_inv_4x4_vs_lib4cccc(int kmax, double *A, double *B, int 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -18056,7 +18056,7 @@ void kernel_dtrsm_nt_rl_one_4x4_lib44cc4(int kmax, double *A, double *B, double 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -18158,7 +18158,7 @@ void kernel_dtrsm_nt_rl_one_4x4_vs_lib44cc4(int kmax, double *A, double *B, doub
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -18434,7 +18434,7 @@ void kernel_dtrsm_nt_rl_one_4x4_lib4c44c(int kmax, double *A, double *B, int ldb
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -18517,7 +18517,7 @@ void kernel_dtrsm_nt_rl_one_4x4_vs_lib4c44c(int kmax, double *A, double *B, int 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -18691,7 +18691,7 @@ void kernel_dtrsm_nt_rl_one_4x4_lib4cccc(int kmax, double *A, double *B, int ldb
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -18773,7 +18773,7 @@ void kernel_dtrsm_nt_rl_one_4x4_vs_lib4cccc(int kmax, double *A, double *B, int 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -18947,7 +18947,7 @@ void kernel_dtrsm_nn_ru_inv_4x4_lib4c44c(int kmax, double *A, double *B, int ldb
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -19050,7 +19050,7 @@ void kernel_dtrsm_nn_ru_inv_4x4_vs_lib4c44c(int kmax, double *A, double *B, int 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -19245,7 +19245,7 @@ void kernel_dtrsm_nn_ru_inv_4x4_lib4cccc(int kmax, double *A, double *B, int ldb
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -19349,7 +19349,7 @@ void kernel_dtrsm_nn_ru_inv_4x4_vs_lib4cccc(int kmax, double *A, double *B, int 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -19544,7 +19544,7 @@ void kernel_dtrsm_nn_ru_one_4x4_lib4c44c(int kmax, double *A, double *B, int ldb
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -19626,7 +19626,7 @@ void kernel_dtrsm_nn_ru_one_4x4_vs_lib4c44c(int kmax, double *A, double *B, int 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -19800,7 +19800,7 @@ void kernel_dtrsm_nn_ru_one_4x4_lib4cccc(int kmax, double *A, double *B, int ldb
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -19883,7 +19883,7 @@ void kernel_dtrsm_nn_ru_one_4x4_vs_lib4cccc(int kmax, double *A, double *B, int 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -20057,7 +20057,7 @@ void kernel_dtrsm_nt_ru_inv_4x4_lib44cc4(int kmax, double *A, double *B, double 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -20181,7 +20181,7 @@ void kernel_dtrsm_nt_ru_inv_4x4_vs_lib44cc4(int kmax, double *A, double *B, doub
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -20400,7 +20400,7 @@ void kernel_dtrsm_nt_ru_inv_4x4_lib4c44c(int kmax, double *A, double *B, int ldb
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -20504,7 +20504,7 @@ void kernel_dtrsm_nt_ru_inv_4x4_vs_lib4c44c(int kmax, double *A, double *B, int 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -20703,7 +20703,7 @@ void kernel_dtrsm_nt_ru_inv_4x4_lib4cccc(int kmax, double *A, double *B, int ldb
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -20807,7 +20807,7 @@ void kernel_dtrsm_nt_ru_inv_4x4_vs_lib4cccc(int kmax, double *A, double *B, int 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -21006,7 +21006,7 @@ void kernel_dtrsm_nt_ru_one_4x4_lib44cc4(int kmax, double *A, double *B, double 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -21109,7 +21109,7 @@ void kernel_dtrsm_nt_ru_one_4x4_vs_lib44cc4(int kmax, double *A, double *B, doub
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -21307,7 +21307,7 @@ void kernel_dtrsm_nt_ru_one_4x4_lib4c44c(int kmax, double *A, double *B, int ldb
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -21390,7 +21390,7 @@ void kernel_dtrsm_nt_ru_one_4x4_vs_lib4c44c(int kmax, double *A, double *B, int 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -21568,7 +21568,7 @@ void kernel_dtrsm_nt_ru_one_4x4_lib4cccc(int kmax, double *A, double *B, int ldb
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -21651,7 +21651,7 @@ void kernel_dtrsm_nt_ru_one_4x4_vs_lib4cccc(int kmax, double *A, double *B, int 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -21830,7 +21830,7 @@ void kernel_dtrsm_nn_ll_one_4x4_lib4cccc(int kmax, double *A, double *B, int ldb
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -21914,7 +21914,7 @@ void kernel_dtrsm_nn_ll_one_4x4_vs_lib4cccc(int kmax, double *A, double *B, int 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -22081,7 +22081,7 @@ void kernel_dgetrf_nn_4x4_lib4ccc(int kmax, double *A, double *B, int ldb, doubl
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -22181,7 +22181,7 @@ void kernel_dgetrf_nn_4x4_vs_lib4ccc(int kmax, double *A, double *B, int ldb, do
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif

--- a/kernel/generic/kernel_dgemm_4x4_lib4.c
+++ b/kernel/generic/kernel_dgemm_4x4_lib4.c
@@ -64,7 +64,7 @@ void kernel_dgemm_nt_4x4_lib4(int kmax, double *alpha, double *A, double *B, dou
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -288,7 +288,7 @@ void kernel_dgemm_nt_4x4_vs_lib4(int kmax, double *alpha, double *A, double *B, 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -414,7 +414,7 @@ void kernel_dgemm_nt_4x4_gen_lib4(int kmax, double *alpha, double *A, double *B,
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -745,7 +745,7 @@ void kernel_dgemm_nn_4x4_lib4(int kmax, double *alpha, double *A, int offsetB, d
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -1211,7 +1211,7 @@ void kernel_dgemm_nn_4x4_vs_lib4(int kmax, double *alpha, double *A, int offsetB
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -1337,7 +1337,7 @@ void kernel_dgemm_nn_4x4_gen_lib4(int kmax, double *alpha, double *A, int offset
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -1655,7 +1655,7 @@ void kernel_dgemm_tt_4x4_lib4(int kmax, double *alpha, int offsetA, double *A, i
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -1713,7 +1713,7 @@ void kernel_dgemm_tt_4x4_vs_lib4(int kmax, double *alpha, int offsetA, double *A
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -1852,7 +1852,7 @@ void kernel_dgemm_tt_4x4_gen_lib4(int kmax, double *alpha, int offsetA, double *
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -2183,7 +2183,7 @@ void kernel_dsyrk_nn_u_4x4_lib4(int kmax, double *alpha, double *A, int offsetB,
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -2222,7 +2222,7 @@ void kernel_dsyrk_nn_u_4x4_vs_lib4(int kmax, double *alpha, double *A, int offse
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -2338,7 +2338,7 @@ void kernel_dsyrk_nt_l_4x4_lib4(int kmax, double *alpha, double *A, double *B, d
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -2377,7 +2377,7 @@ void kernel_dsyrk_nt_l_4x4_vs_lib4(int kmax, double *alpha, double *A, double *B
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -2459,7 +2459,7 @@ void kernel_dsyrk_nt_l_4x4_gen_lib4(int kmax, double *alpha, double *A, double *
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -2898,7 +2898,7 @@ void kernel_dsyrk_nt_u_4x4_lib4(int kmax, double *alpha, double *A, double *B, d
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -2937,7 +2937,7 @@ void kernel_dsyrk_nt_u_4x4_vs_lib4(int kmax, double *alpha, double *A, double *B
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -3053,7 +3053,7 @@ void kernel_dsyrk_nt_u_4x4_gen_lib4(int kmax, double *alpha, double *A, double *
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -3339,7 +3339,7 @@ void kernel_dtrmm_nt_ru_4x4_lib4(int kmax, double *alpha, double *A, double *B, 
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -3450,7 +3450,7 @@ void kernel_dtrmm_nt_ru_4x4_vs_lib4(int kmax, double *alpha, double *A, double *
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -3663,7 +3663,7 @@ void kernel_dtrmm_nn_rl_4x4_lib4(int kmax, double *alpha, double *A, int offsetB
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -4269,7 +4269,7 @@ void kernel_dtrmm_nn_rl_4x4_vs_lib4(int kmax, double *alpha, double *A, int offs
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -4976,7 +4976,7 @@ void kernel_dtrmm_nn_rl_4x4_gen_lib4(int kmax, double *alpha, double *A, int off
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -5776,7 +5776,7 @@ void kernel_dpotrf_nt_l_4x4_lib4(int kmax, double *A, double *B, double *C, doub
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -5886,7 +5886,7 @@ void kernel_dpotrf_nt_l_4x4_vs_lib4(int kmax, double *A, double *B, double *C, d
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -6073,7 +6073,7 @@ void kernel_dtrsm_nt_rl_inv_4x4_lib4(int kmax, double *A, double *B, double *bet
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -6176,7 +6176,7 @@ void kernel_dtrsm_nt_rl_inv_4x4_vs_lib4(int kmax, double *A, double *B, double *
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -6395,7 +6395,7 @@ void kernel_dtrsm_nt_rl_one_4x4_lib4(int kmax, double *A, double *B, double *bet
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -6477,7 +6477,7 @@ void kernel_dtrsm_nt_rl_one_4x4_vs_lib4(int kmax, double *A, double *B, double *
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -6651,7 +6651,7 @@ void kernel_dtrsm_nt_ru_inv_4x4_lib4(int kmax, double *A, double *B, double *bet
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -6754,7 +6754,7 @@ void kernel_dtrsm_nt_ru_inv_4x4_vs_lib4(int kmax, double *A, double *B, double *
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -6950,7 +6950,7 @@ void kernel_dtrsm_nt_ru_one_4x4_lib4(int kmax, double *A, double *B, double *bet
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -7033,7 +7033,7 @@ void kernel_dtrsm_nt_ru_one_4x4_vs_lib4(int kmax, double *A, double *B, double *
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -7210,7 +7210,7 @@ void kernel_dgetrf_nn_4x4_lib4(int kmax, double *A, double *B, int sdb, double *
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -7310,7 +7310,7 @@ void kernel_dgetrf_nn_4x4_vs_lib4(int kmax, double *A, double *B, int sdb, doubl
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -7502,7 +7502,7 @@ void kernel_dgetrf_nt_4x4_lib4(int kmax, double *A, double *B, double *C, double
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -7602,7 +7602,7 @@ void kernel_dgetrf_nt_4x4_vs_lib4(int kmax, double *A, double *B, double *C, dou
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -7796,7 +7796,7 @@ void kernel_dtrsm_nn_ll_inv_4x4_lib4(int kmax, double *A, double *B, int sdb, do
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -7905,7 +7905,7 @@ void kernel_dtrsm_nn_ll_inv_4x4_vs_lib4(int kmax, double *A, double *B, int sdb,
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -8106,7 +8106,7 @@ void kernel_dtrsm_nn_ll_one_4x4_lib4(int kmax, double *A, double *B, int sdb, do
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -8194,7 +8194,7 @@ void kernel_dtrsm_nn_ll_one_4x4_vs_lib4(int kmax, double *A, double *B, int sdb,
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -8377,7 +8377,7 @@ void kernel_dtrsm_nn_ru_inv_4x4_lib4(int kmax, double *A, double *B, int sdb, do
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -8489,7 +8489,7 @@ void kernel_dtrsm_nn_ru_inv_4x4_vs_lib4(int kmax, double *A, double *B, int sdb,
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -8695,7 +8695,7 @@ void kernel_dtrsm_nn_lu_inv_4x4_lib4(int kmax, double *A, double *B, int sdb, do
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -8810,7 +8810,7 @@ void kernel_dtrsm_nn_lu_inv_4x4_vs_lib4(int kmax, double *A, double *B, int sdb,
 	double CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	double CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) double CC[16] = {0};
 #else
 	double CC[16] __attribute__ ((aligned (64))) = {0};
 #endif

--- a/kernel/generic/kernel_sgemm_4x4_lib.c
+++ b/kernel/generic/kernel_sgemm_4x4_lib.c
@@ -48,7 +48,7 @@ void kernel_sgemm_nt_4x4_libcccc(int kmax, float *alpha, float *A, int lda, floa
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -275,7 +275,7 @@ static void kernel_sgemm_nt_4x3_libcccc(int kmax, float *alpha, float *A, int ld
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -466,7 +466,7 @@ static void kernel_sgemm_nt_4x2_libcccc(int kmax, float *alpha, float *A, int ld
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -622,7 +622,7 @@ static void kernel_sgemm_nt_4x1_libcccc(int kmax, float *alpha, float *A, int ld
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -740,7 +740,7 @@ void kernel_sgemm_nt_4x4_vs_libcccc(int kmax, float *alpha, float *A, int lda, f
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -937,7 +937,7 @@ void kernel_sgemm_nt_4x4_lib44cc(int kmax, float *alpha, float *A, float *B, flo
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -985,7 +985,7 @@ void kernel_sgemm_nt_4x4_vs_lib44cc(int kmax, float *alpha, float *A, float *B, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -1118,7 +1118,7 @@ void kernel_sgemm_nn_4x4_libcccc(int kmax, float *alpha, float *A, int lda, floa
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -1345,7 +1345,7 @@ static void kernel_sgemm_nn_4x3_libcccc(int kmax, float *alpha, float *A, int ld
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -1536,7 +1536,7 @@ static void kernel_sgemm_nn_4x2_libcccc(int kmax, float *alpha, float *A, int ld
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -1692,7 +1692,7 @@ static void kernel_sgemm_nn_4x1_libcccc(int kmax, float *alpha, float *A, int ld
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -1810,7 +1810,7 @@ void kernel_sgemm_nn_4x4_vs_libcccc(int kmax, float *alpha, float *A, int lda, f
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -1978,7 +1978,7 @@ void kernel_sgemm_tt_4x4_libcccc(int kmax, float *alpha, float *A, int lda, floa
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -2034,7 +2034,7 @@ void kernel_sgemm_tt_4x4_vs_libcccc(int kmax, float *alpha, float *A, int lda, f
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -2171,7 +2171,7 @@ void kernel_sgemm_tt_4x4_libc4cc(int kmax, float *alpha, float *A, int lda, floa
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -2227,7 +2227,7 @@ void kernel_sgemm_tt_4x4_vs_libc4cc(int kmax, float *alpha, float *A, int lda, f
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -2364,7 +2364,7 @@ void kernel_ssyrk_nt_l_4x4_lib44cc(int kmax, float *alpha, float *A, float *B, f
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -2406,7 +2406,7 @@ void kernel_ssyrk_nt_l_4x4_vs_lib44cc(int kmax, float *alpha, float *A, float *B
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -2491,7 +2491,7 @@ void kernel_ssyrk_nt_u_4x4_lib44cc(int kmax, float *alpha, float *A, float *B, f
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -2539,7 +2539,7 @@ void kernel_ssyrk_nt_u_4x4_vs_lib44cc(int kmax, float *alpha, float *A, float *B
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -2672,7 +2672,7 @@ void kernel_strmm_nn_rl_4x4_lib4ccc(int kmax, float *alpha, float *A, float *B, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -2842,7 +2842,7 @@ void kernel_strmm_nn_rl_4x4_vs_lib4ccc(int kmax, float *alpha, float *A, float *
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -3113,7 +3113,7 @@ void kernel_strmm_nn_rl_4x4_tran_lib4c4c(int kmax, float *alpha, float *A, float
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -3286,7 +3286,7 @@ void kernel_strmm_nn_rl_4x4_tran_vs_lib4c4c(int kmax, float *alpha, float *A, fl
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -3570,7 +3570,7 @@ void kernel_strmm_nn_rl_one_4x4_lib4ccc(int kmax, float *alpha, float *A, float 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -3736,7 +3736,7 @@ void kernel_strmm_nn_rl_one_4x4_vs_lib4ccc(int kmax, float *alpha, float *A, flo
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -4003,7 +4003,7 @@ void kernel_strmm_nn_rl_one_4x4_tran_lib4c4c(int kmax, float *alpha, float *A, f
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -4172,7 +4172,7 @@ void kernel_strmm_nn_rl_one_4x4_tran_vs_lib4c4c(int kmax, float *alpha, float *A
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -4452,7 +4452,7 @@ void kernel_strmm_nn_ru_4x4_lib4ccc(int kmax, float *alpha, float *A, float *B, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -4614,7 +4614,7 @@ void kernel_strmm_nn_ru_4x4_vs_lib4ccc(int kmax, float *alpha, float *A, float *
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -5054,7 +5054,7 @@ void kernel_strmm_nn_ru_4x4_tran_lib4c4c(int kmax, float *alpha, float *A, float
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -5218,7 +5218,7 @@ void kernel_strmm_nn_ru_4x4_tran_vs_lib4c4c(int kmax, float *alpha, float *A, fl
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -5671,7 +5671,7 @@ void kernel_strmm_nn_ru_one_4x4_lib4ccc(int kmax, float *alpha, float *A, float 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -5829,7 +5829,7 @@ void kernel_strmm_nn_ru_one_4x4_vs_lib4ccc(int kmax, float *alpha, float *A, flo
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -6259,7 +6259,7 @@ void kernel_strmm_nn_ru_one_4x4_tran_lib4c4c(int kmax, float *alpha, float *A, f
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -6419,7 +6419,7 @@ void kernel_strmm_nn_ru_one_4x4_tran_vs_lib4c4c(int kmax, float *alpha, float *A
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -6862,7 +6862,7 @@ void kernel_strmm_nt_rl_4x4_lib44cc(int kmax, float *alpha, float *A, float *B, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -7025,7 +7025,7 @@ void kernel_strmm_nt_rl_4x4_vs_lib44cc(int kmax, float *alpha, float *A, float *
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -7467,7 +7467,7 @@ void kernel_strmm_nt_rl_4x4_tran_lib444c(int kmax, float *alpha, float *A, float
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -7632,7 +7632,7 @@ void kernel_strmm_nt_rl_4x4_tran_vs_lib444c(int kmax, float *alpha, float *A, fl
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -8086,7 +8086,7 @@ void kernel_strmm_nt_rl_one_4x4_lib44cc(int kmax, float *alpha, float *A, float 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -8245,7 +8245,7 @@ void kernel_strmm_nt_rl_one_4x4_vs_lib44cc(int kmax, float *alpha, float *A, flo
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -8677,7 +8677,7 @@ void kernel_strmm_nt_rl_one_4x4_tran_lib444c(int kmax, float *alpha, float *A, f
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -8838,7 +8838,7 @@ void kernel_strmm_nt_rl_one_4x4_tran_vs_lib444c(int kmax, float *alpha, float *A
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -9282,7 +9282,7 @@ void kernel_strmm_nt_rl_4x4_lib4ccc(int kmax, float *alpha, float *A, float *B, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -9444,7 +9444,7 @@ void kernel_strmm_nt_rl_4x4_vs_lib4ccc(int kmax, float *alpha, float *A, float *
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -9884,7 +9884,7 @@ void kernel_strmm_nt_rl_4x4_tran_lib4c4c(int kmax, float *alpha, float *A, float
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -10048,7 +10048,7 @@ void kernel_strmm_nt_rl_4x4_tran_vs_lib4c4c(int kmax, float *alpha, float *A, fl
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -10501,7 +10501,7 @@ void kernel_strmm_nt_rl_one_4x4_lib4ccc(int kmax, float *alpha, float *A, float 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -10659,7 +10659,7 @@ void kernel_strmm_nt_rl_one_4x4_vs_lib4ccc(int kmax, float *alpha, float *A, flo
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -11090,7 +11090,7 @@ void kernel_strmm_nt_rl_one_4x4_tran_lib4c4c(int kmax, float *alpha, float *A, f
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -11250,7 +11250,7 @@ void kernel_strmm_nt_rl_one_4x4_tran_vs_lib4c4c(int kmax, float *alpha, float *A
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -11693,7 +11693,7 @@ void kernel_strmm_nt_ru_4x4_lib44cc(int kmax, float *alpha, float *A, float *B, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -11883,7 +11883,7 @@ void kernel_strmm_nt_ru_4x4_vs_lib44cc(int kmax, float *alpha, float *A, float *
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -12154,7 +12154,7 @@ void kernel_strmm_nt_ru_4x4_tran_lib444c(int kmax, float *alpha, float *A, float
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -12327,7 +12327,7 @@ void kernel_strmm_nt_ru_4x4_tran_vs_lib444c(int kmax, float *alpha, float *A, fl
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -12611,7 +12611,7 @@ void kernel_strmm_nt_ru_4x4_lib4ccc(int kmax, float *alpha, float *A, float *B, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -12781,7 +12781,7 @@ void kernel_strmm_nt_ru_4x4_vs_lib4ccc(int kmax, float *alpha, float *A, float *
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -13052,7 +13052,7 @@ void kernel_strmm_nt_ru_4x4_tran_lib4c4c(int kmax, float *alpha, float *A, float
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -13225,7 +13225,7 @@ void kernel_strmm_nt_ru_4x4_tran_vs_lib4c4c(int kmax, float *alpha, float *A, fl
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -13509,7 +13509,7 @@ void kernel_strmm_nt_ru_one_4x4_lib44cc(int kmax, float *alpha, float *A, float 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -13695,7 +13695,7 @@ void kernel_strmm_nt_ru_one_4x4_vs_lib44cc(int kmax, float *alpha, float *A, flo
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -13962,7 +13962,7 @@ void kernel_strmm_nt_ru_one_4x4_tran_lib444c(int kmax, float *alpha, float *A, f
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -14131,7 +14131,7 @@ void kernel_strmm_nt_ru_one_4x4_tran_vs_lib444c(int kmax, float *alpha, float *A
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -14411,7 +14411,7 @@ void kernel_strmm_nt_ru_one_4x4_lib4ccc(int kmax, float *alpha, float *A, float 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -14577,7 +14577,7 @@ void kernel_strmm_nt_ru_one_4x4_vs_lib4ccc(int kmax, float *alpha, float *A, flo
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -14844,7 +14844,7 @@ void kernel_strmm_nt_ru_one_4x4_tran_lib4c4c(int kmax, float *alpha, float *A, f
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -15013,7 +15013,7 @@ void kernel_strmm_nt_ru_one_4x4_tran_vs_lib4c4c(int kmax, float *alpha, float *A
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -15289,7 +15289,7 @@ void kernel_spotrf_nt_l_4x4_lib44cc(int kmax, float *A, float *B, float *C, int 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -15342,7 +15342,7 @@ void kernel_spotrf_nt_l_4x4_vs_lib44cc(int kmax, float *A, float *B, float *C, i
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -15485,7 +15485,7 @@ void kernel_strsm_nn_rl_inv_4x4_lib4c44c(int kmax, float *A, float *B, int ldb, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -15589,7 +15589,7 @@ void kernel_strsm_nn_rl_inv_4x4_vs_lib4c44c(int kmax, float *A, float *B, int ld
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -15788,7 +15788,7 @@ void kernel_strsm_nn_rl_inv_4x4_lib4cccc(int kmax, float *A, float *B, int ldb, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -15892,7 +15892,7 @@ void kernel_strsm_nn_rl_inv_4x4_vs_lib4cccc(int kmax, float *A, float *B, int ld
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -16091,7 +16091,7 @@ void kernel_strsm_nn_rl_one_4x4_lib4c44c(int kmax, float *A, float *B, int ldb, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -16174,7 +16174,7 @@ void kernel_strsm_nn_rl_one_4x4_vs_lib4c44c(int kmax, float *A, float *B, int ld
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -16352,7 +16352,7 @@ void kernel_strsm_nn_rl_one_4x4_lib4cccc(int kmax, float *A, float *B, int ldb, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -16435,7 +16435,7 @@ void kernel_strsm_nn_rl_one_4x4_vs_lib4cccc(int kmax, float *A, float *B, int ld
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -16613,7 +16613,7 @@ void kernel_strsm_nt_rl_inv_4x4_lib44cc4(int kmax, float *A, float *B, float *be
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -16736,7 +16736,7 @@ void kernel_strsm_nt_rl_inv_4x4_vs_lib44cc4(int kmax, float *A, float *B, float 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -17033,7 +17033,7 @@ void kernel_strsm_nt_rl_inv_4x4_lib44ccc(int kmax, float *A, float *B, float *C,
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -17157,7 +17157,7 @@ void kernel_strsm_nt_rl_inv_4x4_vs_lib44ccc(int kmax, float *A, float *B, float 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -17455,7 +17455,7 @@ void kernel_strsm_nt_rl_inv_4x4_lib4c44c(int kmax, float *A, float *B, int ldb, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -17558,7 +17558,7 @@ void kernel_strsm_nt_rl_inv_4x4_vs_lib4c44c(int kmax, float *A, float *B, int ld
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -17753,7 +17753,7 @@ void kernel_strsm_nt_rl_inv_4x4_lib4cccc(int kmax, float *A, float *B, int ldb, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -17856,7 +17856,7 @@ void kernel_strsm_nt_rl_inv_4x4_vs_lib4cccc(int kmax, float *A, float *B, int ld
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -18051,7 +18051,7 @@ void kernel_strsm_nt_rl_one_4x4_lib44cc4(int kmax, float *A, float *B, float *be
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -18153,7 +18153,7 @@ void kernel_strsm_nt_rl_one_4x4_vs_lib44cc4(int kmax, float *A, float *B, float 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -18429,7 +18429,7 @@ void kernel_strsm_nt_rl_one_4x4_lib4c44c(int kmax, float *A, float *B, int ldb, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -18512,7 +18512,7 @@ void kernel_strsm_nt_rl_one_4x4_vs_lib4c44c(int kmax, float *A, float *B, int ld
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -18686,7 +18686,7 @@ void kernel_strsm_nt_rl_one_4x4_lib4cccc(int kmax, float *A, float *B, int ldb, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -18768,7 +18768,7 @@ void kernel_strsm_nt_rl_one_4x4_vs_lib4cccc(int kmax, float *A, float *B, int ld
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -18942,7 +18942,7 @@ void kernel_strsm_nn_ru_inv_4x4_lib4c44c(int kmax, float *A, float *B, int ldb, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -19045,7 +19045,7 @@ void kernel_strsm_nn_ru_inv_4x4_vs_lib4c44c(int kmax, float *A, float *B, int ld
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -19240,7 +19240,7 @@ void kernel_strsm_nn_ru_inv_4x4_lib4cccc(int kmax, float *A, float *B, int ldb, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -19344,7 +19344,7 @@ void kernel_strsm_nn_ru_inv_4x4_vs_lib4cccc(int kmax, float *A, float *B, int ld
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -19539,7 +19539,7 @@ void kernel_strsm_nn_ru_one_4x4_lib4c44c(int kmax, float *A, float *B, int ldb, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -19621,7 +19621,7 @@ void kernel_strsm_nn_ru_one_4x4_vs_lib4c44c(int kmax, float *A, float *B, int ld
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -19795,7 +19795,7 @@ void kernel_strsm_nn_ru_one_4x4_lib4cccc(int kmax, float *A, float *B, int ldb, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -19878,7 +19878,7 @@ void kernel_strsm_nn_ru_one_4x4_vs_lib4cccc(int kmax, float *A, float *B, int ld
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -20052,7 +20052,7 @@ void kernel_strsm_nt_ru_inv_4x4_lib44cc4(int kmax, float *A, float *B, float *be
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -20176,7 +20176,7 @@ void kernel_strsm_nt_ru_inv_4x4_vs_lib44cc4(int kmax, float *A, float *B, float 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -20395,7 +20395,7 @@ void kernel_strsm_nt_ru_inv_4x4_lib4c44c(int kmax, float *A, float *B, int ldb, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -20499,7 +20499,7 @@ void kernel_strsm_nt_ru_inv_4x4_vs_lib4c44c(int kmax, float *A, float *B, int ld
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -20698,7 +20698,7 @@ void kernel_strsm_nt_ru_inv_4x4_lib4cccc(int kmax, float *A, float *B, int ldb, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -20802,7 +20802,7 @@ void kernel_strsm_nt_ru_inv_4x4_vs_lib4cccc(int kmax, float *A, float *B, int ld
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -21001,7 +21001,7 @@ void kernel_strsm_nt_ru_one_4x4_lib44cc4(int kmax, float *A, float *B, float *be
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -21104,7 +21104,7 @@ void kernel_strsm_nt_ru_one_4x4_vs_lib44cc4(int kmax, float *A, float *B, float 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -21302,7 +21302,7 @@ void kernel_strsm_nt_ru_one_4x4_lib4c44c(int kmax, float *A, float *B, int ldb, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -21385,7 +21385,7 @@ void kernel_strsm_nt_ru_one_4x4_vs_lib4c44c(int kmax, float *A, float *B, int ld
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -21563,7 +21563,7 @@ void kernel_strsm_nt_ru_one_4x4_lib4cccc(int kmax, float *A, float *B, int ldb, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -21646,7 +21646,7 @@ void kernel_strsm_nt_ru_one_4x4_vs_lib4cccc(int kmax, float *A, float *B, int ld
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -21825,7 +21825,7 @@ void kernel_strsm_nn_ll_one_4x4_lib4cccc(int kmax, float *A, float *B, int ldb, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -21909,7 +21909,7 @@ void kernel_strsm_nn_ll_one_4x4_vs_lib4cccc(int kmax, float *A, float *B, int ld
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif

--- a/kernel/generic/kernel_sgemm_4x4_lib4.c
+++ b/kernel/generic/kernel_sgemm_4x4_lib4.c
@@ -53,7 +53,7 @@ void kernel_sgemm_nt_4x4_lib4(int kmax, float *alpha, float *A, float *B, float 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -277,7 +277,7 @@ void kernel_sgemm_nt_4x4_vs_lib4(int kmax, float *alpha, float *A, float *B, flo
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -403,7 +403,7 @@ void kernel_sgemm_nt_4x4_gen_lib4(int kmax, float *alpha, float *A, float *B, fl
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -727,7 +727,7 @@ void kernel_sgemm_nn_4x4_lib4(int kmax, float *alpha, float *A, int offsetB, flo
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -1193,7 +1193,7 @@ void kernel_sgemm_nn_4x4_vs_lib4(int kmax, float *alpha, float *A, int offsetB, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -1319,7 +1319,7 @@ void kernel_sgemm_nn_4x4_gen_lib4(int kmax, float *alpha, float *A, int offsetB,
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -1637,7 +1637,7 @@ void kernel_ssyrk_nt_l_4x4_lib4(int kmax, float *alpha, float *A, float *B, floa
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -1676,7 +1676,7 @@ void kernel_ssyrk_nt_l_4x4_vs_lib4(int kmax, float *alpha, float *A, float *B, f
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -1758,7 +1758,7 @@ void kernel_ssyrk_nt_l_4x4_gen_lib4(int kmax, float *alpha, float *A, float *B, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -2201,7 +2201,7 @@ void kernel_strmm_nt_ru_4x4_lib4(int kmax, float *alpha, float *A, float *B, flo
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -2312,7 +2312,7 @@ void kernel_strmm_nt_ru_4x4_vs_lib4(int kmax, float *alpha, float *A, float *B, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -2525,7 +2525,7 @@ void kernel_strmm_nn_rl_4x4_lib4(int kmax, float *alpha, float *A, int offsetB, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -3131,7 +3131,7 @@ void kernel_strmm_nn_rl_4x4_vs_lib4(int kmax, float *alpha, float *A, int offset
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -3838,7 +3838,7 @@ void kernel_strmm_nn_rl_4x4_gen_lib4(int kmax, float *alpha, float *A, int offse
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -4638,7 +4638,7 @@ void kernel_spotrf_nt_l_4x4_lib4(int kmax, float *A, float *B, float *C, float *
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -4748,7 +4748,7 @@ void kernel_spotrf_nt_l_4x4_vs_lib4(int kmax, float *A, float *B, float *C, floa
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -4935,7 +4935,7 @@ void kernel_strsm_nt_rl_inv_4x4_lib4(int kmax, float *A, float *B, float *beta, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -5038,7 +5038,7 @@ void kernel_strsm_nt_rl_inv_4x4_vs_lib4(int kmax, float *A, float *B, float *bet
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -5257,7 +5257,7 @@ void kernel_strsm_nt_rl_one_4x4_lib4(int kmax, float *A, float *B, float *beta, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -5339,7 +5339,7 @@ void kernel_strsm_nt_rl_one_4x4_vs_lib4(int kmax, float *A, float *B, float *bet
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -5513,7 +5513,7 @@ void kernel_strsm_nt_ru_inv_4x4_lib4(int kmax, float *A, float *B, float *beta, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -5616,7 +5616,7 @@ void kernel_strsm_nt_ru_inv_4x4_vs_lib4(int kmax, float *A, float *B, float *bet
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -5814,7 +5814,7 @@ void kernel_sgetrf_nn_4x4_lib4(int kmax, float *A, float *B, int sdb, float *C, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -5914,7 +5914,7 @@ void kernel_sgetrf_nn_4x4_vs_lib4(int kmax, float *A, float *B, int sdb, float *
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -6104,7 +6104,7 @@ void kernel_strsm_nt_ru_one_4x4_lib4(int kmax, float *A, float *B, float *beta, 
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -6187,7 +6187,7 @@ void kernel_strsm_nt_ru_one_4x4_vs_lib4(int kmax, float *A, float *B, float *bet
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -6366,7 +6366,7 @@ void kernel_strsm_nn_ll_one_4x4_lib4(int kmax, float *A, float *B, int sdb, floa
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -6455,7 +6455,7 @@ void kernel_strsm_nn_ll_one_4x4_vs_lib4(int kmax, float *A, float *B, int sdb, f
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -6639,7 +6639,7 @@ void kernel_strsm_nn_ru_inv_4x4_lib4(int kmax, float *A, float *B, int sdb, floa
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -6751,7 +6751,7 @@ void kernel_strsm_nn_ru_inv_4x4_vs_lib4(int kmax, float *A, float *B, int sdb, f
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -6957,7 +6957,7 @@ void kernel_strsm_nn_lu_inv_4x4_lib4(int kmax, float *A, float *B, int sdb, floa
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -7072,7 +7072,7 @@ void kernel_strsm_nn_lu_inv_4x4_vs_lib4(int kmax, float *A, float *B, int sdb, f
 	float CC[16] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[16] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[16] = {0};
 #else
 	float CC[16] __attribute__ ((aligned (64))) = {0};
 #endif

--- a/kernel/generic/kernel_sgemm_8x4_lib8.c
+++ b/kernel/generic/kernel_sgemm_8x4_lib8.c
@@ -54,7 +54,7 @@ void kernel_strmm_nt_ru_8x4_lib8(int kmax, float *alpha, float *A, float *B, flo
 	float CC[32] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[32] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[32] = {0};
 #else
 	float CC[32] __attribute__ ((aligned (64))) = {0};
 #endif
@@ -202,7 +202,7 @@ void kernel_strmm_nt_ru_8x4_vs_lib8(int kmax, float *alpha, float *A, float *B, 
 	float CC[32] = {0};
 #else
 #if defined (_MSC_VER)
-	float CC[32] __declspec(align(64)) = {0};
+	__declspec(align(64)) float CC[32] = {0};
 #else
 	float CC[32] __attribute__ ((aligned (64))) = {0};
 #endif


### PR DESCRIPTION
* Using Clang-CL can compile any supported target.
* Using MinGW can compile any supported target.

Fixes issues: https://github.com/giaf/blasfeo/issues/120, https://github.com/giaf/blasfeo/issues/101.