### PR TITLE
Add CMake compile and run tests for intrinsics

### DIFF
--- a/cmake/ArchitectureTests.cmake
+++ b/cmake/ArchitectureTests.cmake
@@ -1,0 +1,54 @@
+# This file contains the various architecture tests that each target
+# must pass when testing the ISA and intrinsics.
+
+# For Intel Haswell, test for if the AVX2 and FMA ISAs work
+set(CMP_CHECK_X64_INTEL_HASWELL
+  TEST_AVX2
+  TEST_FMA
+  )
+
+# For Intel Sandy Bridge, test for if the AVX ISA works
+set(CMP_CHECK_X64_INTEL_SANDY_BRIDGE
+  TEST_AVX
+  )
+
+# For Intel Core, test for if the SSE3 ISA works
+set(CMP_CHECK_X64_INTEL_CORE
+  TEST_SSE3
+  )
+
+# For AMD Bulldozer, test for if the AVX and FMA ISAs work
+set(CMP_CHECK_X64_AMD_BULLDOZER
+  TEST_AVX
+  TEST_FMA
+  )
+
+# For the Cortex A57, test for if the VFPv4 and NEONv2 ISAs work
+set(CMP_CHECK_ARMV8A_ARM_CORTEX_A57
+  TEST_VFPv4
+  TEST_NEONv2
+  )
+
+# For the Cortex A53, test for if the VFPv4 and NEONv2 ISAs work
+set(CMP_CHECK_ARMV8A_ARM_CORTEX_A53
+  TEST_VFPv4
+  TEST_NEONv2
+  )
+
+# For the Cortex A15, test for if the VFPv3 and NEON ISAs work
+set(CMP_CHECK_ARMV7A_ARM_CORTEX_A15
+  TEST_VFPv3
+  TEST_NEON
+  )
+
+# For the Cortex A7, test for if the VFPv3 and NEON ISAs work
+set(CMP_CHECK_ARMV7A_ARM_CORTEX_A7
+  TEST_VFPv3
+  TEST_NEON
+  )
+
+# For the Cortex A9, test for if the VFPv3 and NEON ISAs work
+set(CMP_CHECK_ARMV7A_ARM_CORTEX_A9
+  TEST_VFPv3
+  TEST_NEON
+  )

--- a/cmake/TestSingleTarget.cmake
+++ b/cmake/TestSingleTarget.cmake
@@ -5,13 +5,13 @@ function(TestSingleTarget)
 
   # This function will test the compilation and running of the
   # target specified in TEST_TARGET
-  TestForISA()
+  TestISA( ${TEST_TARGET} )
 
-  if(${CHK_TARGET_BUILD})
+  if(${CHKISA_TARGET_BUILD})
     message(STATUS "Testing target ${TEST_TARGET}: compilation [success]")
 
     if(NOT ${BLASFEO_CROSSCOMPILING} )
-      if(${CHK_TARGET_RUN})
+      if(${CHKISA_TARGET_RUN})
         message(STATUS "Testing target ${TEST_TARGET}: run [success]")
       else()
         message(STATUS "Testing target ${TEST_TARGET}: run [failed]")
@@ -21,7 +21,7 @@ function(TestSingleTarget)
   else()
     message(STATUS "Testing target ${TEST_TARGET}: compilation [failed]")
     message("Compile output:")
-    message(${CHK_TARGET_OUTPUT})
+    message(${CHKISA_TARGET_OUTPUT})
     message(FATAL_ERROR "Unable to compile for target ${TEST_TARGET}")
   endif()
 

--- a/cmake/TestSingleTarget.cmake
+++ b/cmake/TestSingleTarget.cmake
@@ -1,28 +1,50 @@
-include(${PROJECT_SOURCE_DIR}/cmake/isa_tests/isa_test.cmake)
+include( ${PROJECT_SOURCE_DIR}/cmake/isa_tests/isa_test.cmake )
+include( ${PROJECT_SOURCE_DIR}/cmake/intrinsic_tests/intrinsic_test.cmake )
 
-function(TestSingleTarget)
-  set(TEST_TARGET ${TARGET})
+function( TestSingleTarget )
+  set( TEST_TARGET ${TARGET} )
 
   # This function will test the compilation and running of the
   # target specified in TEST_TARGET
   TestISA( ${TEST_TARGET} )
 
-  if(${CHKISA_TARGET_BUILD})
-    message(STATUS "Testing target ${TEST_TARGET}: compilation [success]")
+  if( ${CHKISA_TARGET_BUILD} )
+    message( STATUS "Testing target ${TEST_TARGET}: assembly compilation [success]" )
 
-    if(NOT ${BLASFEO_CROSSCOMPILING} )
-      if(${CHKISA_TARGET_RUN})
-        message(STATUS "Testing target ${TEST_TARGET}: run [success]")
+    if( NOT ${BLASFEO_CROSSCOMPILING} )
+      if( ${CHKISA_TARGET_RUN})
+        message( STATUS "Testing target ${TEST_TARGET}: assembly run [success]" )
       else()
-        message(STATUS "Testing target ${TEST_TARGET}: run [failed]")
+        message( STATUS "Testing target ${TEST_TARGET}: assembly run [failed]" )
       endif()
     endif()
 
   else()
-    message(STATUS "Testing target ${TEST_TARGET}: compilation [failed]")
-    message("Compile output:")
-    message(${CHKISA_TARGET_OUTPUT})
-    message(FATAL_ERROR "Unable to compile for target ${TEST_TARGET}")
+    message( STATUS "Testing target ${TEST_TARGET}: assembly compilation [failed]" )
+    message( "Compile output:" )
+    message( ${CHKISA_TARGET_OUTPUT} )
+    message( FATAL_ERROR "Unable to compile with assembly for target ${TEST_TARGET}" )
+  endif()
+
+  # This function will test the compiler support for intrinsics
+  TestIntrinsics( ${TEST_TARGET} )
+
+  if( ${CHKINTRINSIC_TARGET_BUILD} )
+    message( STATUS "Testing target ${TEST_TARGET}: intrinsic compilation [success]" )
+
+    if( NOT ${BLASFEO_CROSSCOMPILING} )
+      if( ${CHKINTRINSIC_TARGET_RUN} )
+        message( STATUS "Testing target ${TEST_TARGET}: intrinsic run [success]" )
+      else()
+        message( STATUS "Testing target ${TEST_TARGET}: intrinsic run [failed]" )
+      endif()
+    endif()
+
+  else()
+    message( STATUS "Testing target ${TEST_TARGET}: intrinsic compilation [failed]" )
+    message( "Compile output:" )
+    message( ${CHKINTRINSIC_TARGET_OUTPUT} )
+    message( FATAL_ERROR "Unable to compile with intrinsics for target ${TEST_TARGET}" )
   endif()
 
 endfunction()

--- a/cmake/X64AutomaticTargetSelection.cmake
+++ b/cmake/X64AutomaticTargetSelection.cmake
@@ -6,12 +6,12 @@ function(X64AutomaticTargetSelection)
   foreach(TEST_TARGET ${X64_AUTOMATIC_TARGETS})
     # This function will test the compilation and running of the
     # target specified in TEST_TARGET
-    TestForISA()
+    TestISA( ${TEST_TARGET} )
 
-    if(${CHK_TARGET_BUILD})
+    if(${CHKISA_TARGET_BUILD})
       message(STATUS "Testing target ${TEST_TARGET}: compilation [success]")
 
-      if(${CHK_TARGET_RUN})
+      if(${CHKISA_TARGET_RUN})
         message(STATUS "Testing target ${TEST_TARGET}: run [success]")
 
         # It both compiles and runs, so pass it up to the parent to use

--- a/cmake/X64AutomaticTargetSelection.cmake
+++ b/cmake/X64AutomaticTargetSelection.cmake
@@ -1,33 +1,61 @@
-include(${PROJECT_SOURCE_DIR}/cmake/isa_tests/isa_test.cmake)
+include( ${PROJECT_SOURCE_DIR}/cmake/isa_tests/isa_test.cmake )
+include( ${PROJECT_SOURCE_DIR}/cmake/intrinsic_tests/intrinsic_test.cmake )
 
-function(X64AutomaticTargetSelection)
+function( X64AutomaticTargetSelection )
 
   # Iterate over each target to test the compilation and running
-  foreach(TEST_TARGET ${X64_AUTOMATIC_TARGETS})
+  foreach( TEST_TARGET ${X64_AUTOMATIC_TARGETS} )
     # This function will test the compilation and running of the
     # target specified in TEST_TARGET
     TestISA( ${TEST_TARGET} )
 
-    if(${CHKISA_TARGET_BUILD})
-      message(STATUS "Testing target ${TEST_TARGET}: compilation [success]")
+    set( ISA_TEST_PASS FALSE )
 
-      if(${CHKISA_TARGET_RUN})
-        message(STATUS "Testing target ${TEST_TARGET}: run [success]")
+    if( ${CHKISA_TARGET_BUILD} )
+      message( STATUS "Testing target ${TEST_TARGET}: assembly compilation [success]" )
 
-        # It both compiles and runs, so pass it up to the parent to use
-        set(TARGET ${TEST_TARGET} PARENT_SCOPE)
-        return()
+      if( ${CHKISA_TARGET_RUN} )
+        message(STATUS "Testing target ${TEST_TARGET}: assembly run [success]" )
+
+        set( ISA_TEST_PASS TRUE )
 
       else()
-        message(STATUS "Testing target ${TEST_TARGET}: run [failed]")
+        message( STATUS "Testing target ${TEST_TARGET}: assembly run [failed]" )
       endif()
 
     else()
-      message(STATUS "Testing target ${TEST_TARGET}: compilation [failed]")
+      message( STATUS "Testing target ${TEST_TARGET}: assembly compilation [failed]" )
+    endif()
+
+    TestIntrinsics( ${TEST_TARGET} )
+
+    set( INTRINSIC_TEST_PASS FALSE )
+
+    if( ${CHKINTRINSIC_TARGET_BUILD} )
+      message( STATUS "Testing target ${TEST_TARGET}: intrinsic compilation [success]" )
+
+      if( ${CHKINTRINSIC_TARGET_RUN} )
+        message( STATUS "Testing target ${TEST_TARGET}: intrinsic run [success]" )
+
+        set( INTRINSIC_TEST_PASS TRUE )
+
+      else()
+        message( STATUS "Testing target ${TEST_TARGET}: intrinsic run [failed]" )
+      endif()
+
+    else()
+      message( STATUS "Testing target ${TEST_TARGET}: intrinsic compilation [failed]" )
+    endif()
+
+
+    if( ${ISA_TEST_PASS} AND ${INTRINSIC_TEST_PASS} )
+      # It both compiles and runs, so pass it up to the parent to use
+      set( TARGET ${TEST_TARGET} PARENT_SCOPE )
+      return()
     endif()
 
   endforeach()
 
-  message(FATAL_ERROR "Unable to identify a target to use. Please select one manually.")
+  message( FATAL_ERROR "Unable to identify a target to use. Please select one manually." )
 
 endfunction()

--- a/cmake/intrinsic_tests/intrinsic_test.c
+++ b/cmake/intrinsic_tests/intrinsic_test.c
@@ -1,0 +1,83 @@
+
+#if defined( TEST_AVX ) || defined( TEST_AVX2 ) || defined( TEST_FMA )
+    // Header that contains the AVX, AVX2 and FMA intrinsics
+    #include <immintrin.h>
+#endif
+
+#ifdef TEST_SSE3
+    // Header that contains the SSE3 intrinsics
+    #include <pmmintrin.h>
+#endif
+
+
+int main()
+{
+
+#ifdef TEST_AVX
+    // Test for working AVX intrinsics
+
+    // This setter is AVX minimum
+    __m256d retVal_AVX = _mm256_set_pd( 1.0f, 2.0f, 3.0f, 4.0f );
+#endif
+
+#ifdef TEST_AVX2
+    // Test for working AVX2 intrinsics
+
+    // This setter is AVX minimum
+    __m256i testVal_AVX2_1 = _mm256_set_epi32( 1, 2, 3, 4, 5, 6, 7, 8 );
+    __m256i testVal_AVX2_2 = _mm256_set_epi32( 2, 3, 4, 5, 6, 7, 8, 9 );
+
+    __m256i retVal_AVX2 = _mm256_sub_epi32( testVal_AVX2_1, testVal_AVX2_2 );
+#endif
+
+#ifdef TEST_FMA
+    // Test for working FMA intrinsics
+
+    // These brodcast setters are SSE minimum
+    __m128 testVal_FMA_1 = _mm_set1_ps( 5.0 );
+    __m128 testVal_FMA_2 = _mm_set1_ps( 3.0 );
+    __m128 testVal_FMA_3 = _mm_set1_ps( 7.0 );
+
+    // This is FMA minimum
+    __m128 retVal_FMA = _mm_fmadd_ps( testVal_FMA_1, testVal_FMA_2, testVal_FMA_3 );
+#endif
+
+#ifdef TEST_SSE3
+    // Test for working SSE3 intrinsics
+
+    // These brodcast setters are SSE minimum
+    __m128 testVal_SSE3_1 = _mm_set1_ps( 5.0 );
+    __m128 testVal_SSE3_2 = _mm_set1_ps( 3.0 );
+
+    // This adder is SSE3 minimum
+    __m128 retVal_SSE3 = _mm_hadd_ps( testVal_SSE3_1, testVal_SSE3_2 );
+#endif
+
+#ifdef TEST_VFPv4
+    // Test for working VFPv4 intrinsics
+
+    //TODO
+#endif
+
+#ifdef TEST_NEONv2
+    // Test for working NEONv2 intrinsics
+    test_neonv2();
+
+    //TODO
+#endif
+
+#ifdef TEST_VFPv3
+    // Test for working VFPv3 intrinsics
+
+    // TODO
+#endif
+
+#ifdef TEST_NEON
+    // Test for working NEON intrinsics
+
+
+    //TODO
+#endif
+
+    return 0;
+}

--- a/cmake/intrinsic_tests/intrinsic_test.c
+++ b/cmake/intrinsic_tests/intrinsic_test.c
@@ -27,6 +27,7 @@ int main()
     __m256i testVal_AVX2_1 = _mm256_set_epi32( 1, 2, 3, 4, 5, 6, 7, 8 );
     __m256i testVal_AVX2_2 = _mm256_set_epi32( 2, 3, 4, 5, 6, 7, 8, 9 );
 
+    // This subtraction is AVX2 minimum
     __m256i retVal_AVX2 = _mm256_sub_epi32( testVal_AVX2_1, testVal_AVX2_2 );
 #endif
 
@@ -61,7 +62,6 @@ int main()
 
 #ifdef TEST_NEONv2
     // Test for working NEONv2 intrinsics
-    test_neonv2();
 
     //TODO
 #endif

--- a/cmake/intrinsic_tests/intrinsic_test.cmake
+++ b/cmake/intrinsic_tests/intrinsic_test.cmake
@@ -1,31 +1,31 @@
 # This function will prepare a test for a target (specified by the
 # variable TEST_TARGET) and execute it. This consists of compiling
-# a C file with associated assembly files using the compile flags,
-# and then executing the result to see if it runs correctly.
+# a C files using the intrinsics supported by the target using the
+# compile flags, and then executing the result to see if it runs
+# correctly.
 #
-# The assembly files contain an exemplar instruction for the ISA,
-# so if they fail to run it means the specific ISA is not supported.
+# The test file contains an exemplar intrinsic for the target,
+# so if they fail to run it means the specific target is not supported.
 #
 # The requested target to test is passed as the argument to the function.
 #
 # The results of the test are stored as the variables
-#  CHKISA_TARGET_BUILD - True if the target built without error
-#  CHKISA_TARGET_RUN   - True if the test ran without error
-function(TestISA TEST_TARGET)
+#  CHKINTRINSIC_TARGET_BUILD - True if the target built without error
+#  CHKINTRINSIC_TARGET_RUN   - True if the test ran without error
+function( TestIntrinsics TEST_TARGET )
 
   # Pull in the tests each architecture needs to run
   include( ${PROJECT_SOURCE_DIR}/cmake/ArchitectureTests.cmake )
 
   # The main source file to test with
   set(CMP_CHECK_SRCS
-      ${PROJECT_SOURCE_DIR}/cmake/isa_tests/isa_test.c
+      ${PROJECT_SOURCE_DIR}/cmake/intrinsic_tests/intrinsic_test.c
       )
 
   set(C_DEFS_CHK "")
 
-  # Add the assembly test files and the compile definitions
+  # Add the compile definitions
   foreach(CHECK ${CMP_CHECK_${TEST_TARGET}})
-      list( APPEND CMP_CHECK_SRCS ${PROJECT_SOURCE_DIR}/cmake/isa_tests/${CHECK}.S )
       list( APPEND C_DEFS_CHK "-D${CHECK} " )
   endforeach()
 
@@ -36,7 +36,7 @@ function(TestISA TEST_TARGET)
   set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} ${ASM_FLAGS_TARGET_${TEST_TARGET}}")
 
   if(${BLASFEO_CROSSCOMPILING})
-    set(CHKISA_TARGET_RUN_${TEST_TARGET} "1")
+    set(CHKINTRINSIC_TARGET_RUN_${TEST_TARGET} "1")
 
     # Only tell CMake to compile the files, not link them since we are doing cross-compilation
     if (${CMAKE_VERSION} VERSION_EQUAL "3.6.0" OR ${CMAKE_VERSION} VERSION_GREATER "3.6")
@@ -45,36 +45,36 @@ function(TestISA TEST_TARGET)
       set(CMAKE_EXE_LINKER_FLAGS_INIT "--specs=nosys.specs")
     endif()
 
-    try_compile( CHKISA_TARGET_BUILD_${TEST_TARGET}                   # Variable to save the build result to
+    try_compile( CHKINTRINSIC_TARGET_BUILD_${TEST_TARGET}                   # Variable to save the build result to
                  "${CMAKE_BINARY_DIR}/compilerTest/${TEST_TARGET}" # Directory to compile in
                  SOURCES ${CMP_CHECK_SRCS}                         # Source to compile
                  CMAKE_FLAGS
                    "-DCOMPILE_DEFINITIONS=${C_DEFS_CHK}"
-                 OUTPUT_VARIABLE CHK_OUTPUT_${TEST_TARGET}
+                 OUTPUT_VARIABLE CHK_OUTPUT${TEST_TARGET}
                 )
   else()
-    try_run( CHKISA_TARGET_RUN_${TEST_TARGET}                     # Variable to save the run result to
-             CHKISA_TARGET_BUILD_${TEST_TARGET}                   # Variable to save the build result to
+    try_run( CHKINTRINSIC_TARGET_RUN_${TEST_TARGET}                     # Variable to save the run result to
+             CHKINTRINSIC_TARGET_BUILD_${TEST_TARGET}                   # Variable to save the build result to
              "${CMAKE_BINARY_DIR}/compilerTest/${TEST_TARGET}" # Directory to compile in
              SOURCES ${CMP_CHECK_SRCS}                         # Source to compile
              CMAKE_FLAGS
               "-DCOMPILE_DEFINITIONS=${C_DEFS_CHK}"
-             OUTPUT_VARIABLE CHK_OUTPUT_${TEST_TARGET}
+             OUTPUT_VARIABLE CHK_OUTPUT${TEST_TARGET}
             )
   endif()
 
-  if(${CHKISA_TARGET_BUILD_${TEST_TARGET}})
-    set(CHKISA_TARGET_BUILD TRUE PARENT_SCOPE)
+  if(${CHKINTRINSIC_TARGET_BUILD_${TEST_TARGET}})
+    set(CHKINTRINSIC_TARGET_BUILD TRUE PARENT_SCOPE)
 
-    if(${CHKISA_TARGET_RUN_${TEST_TARGET}} STREQUAL "0")
-      set(CHKISA_TARGET_RUN TRUE PARENT_SCOPE)
+    if(${CHKINTRINSIC_TARGET_RUN_${TEST_TARGET}} STREQUAL "0")
+      set(CHKINTRINSIC_TARGET_RUN TRUE PARENT_SCOPE)
     else()
-      set(CHKISA_TARGET_RUN FALSE PARENT_SCOPE)
+      set(CHKINTRINSIC_TARGET_RUN FALSE PARENT_SCOPE)
     endif()
 
   else()
-    set(CHKISA_TARGET_BUILD FALSE PARENT_SCOPE)
-    set(CHKISA_TARGET_OUTPUT ${CHK_OUTPUT_${TEST_TARGET}} PARENT_SCOPE)
+    set(CHKINTRINSIC_TARGET_BUILD FALSE PARENT_SCOPE)
+    set(CHKINTRINSIC_TARGET_OUTPUT ${CHK_OUTPUT${TEST_TARGET}} PARENT_SCOPE)
   endif()
 
 endfunction()

--- a/cmake/isa_tests/isa_test.cmake
+++ b/cmake/isa_tests/isa_test.cmake
@@ -6,10 +6,12 @@
 # The assembly files contain an exemplar instruction for the ISA,
 # so if they fail to run it means the specific ISA is not supported.
 #
+# The requested target to test is passed as the argument to the function.
+#
 # The results of the test are stored as the variables
-#  CHK_TARGET_BUILD - True if the target built without error
-#  CHK_TARGET_RUN   - True if the test ran without error
-function(TestForISA)
+#  CHKISA_TARGET_BUILD - True if the target built without error
+#  CHKISA_TARGET_RUN   - True if the test ran without error
+function(TestISA TEST_TARGET)
   # For Intel Haswell, test for if the AVX2 and FMA ISAs work
   set(CMP_CHECK_X64_INTEL_HASWELL
       TEST_AVX2
@@ -82,7 +84,7 @@ function(TestForISA)
   set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} ${ASM_FLAGS_TARGET_${TEST_TARGET}}")
 
   if(${BLASFEO_CROSSCOMPILING})
-    set(CHK_TARGET_RUN_${TEST_TARGET} "1")
+    set(CHKISA_TARGET_RUN_${TEST_TARGET} "1")
 
     # Only tell CMake to compile the files, not link them since we are doing cross-compilation
     if (${CMAKE_VERSION} VERSION_EQUAL "3.6.0" OR ${CMAKE_VERSION} VERSION_GREATER "3.6")
@@ -91,36 +93,36 @@ function(TestForISA)
       set(CMAKE_EXE_LINKER_FLAGS_INIT "--specs=nosys.specs")
     endif()
 
-    try_compile( CHK_TARGET_BUILD_${TEST_TARGET}                   # Variable to save the build result to
+    try_compile( CHKISA_TARGET_BUILD_${TEST_TARGET}                   # Variable to save the build result to
                  "${CMAKE_BINARY_DIR}/compilerTest/${TEST_TARGET}" # Directory to compile in
                  SOURCES ${CMP_CHECK_SRCS}                         # Source to compile
                  CMAKE_FLAGS
                    "-DCOMPILE_DEFINITIONS=${C_DEFS_CHK}"
-                 OUTPUT_VARIABLE CHK_OUTPUT${TEST_TARGET}
+                 OUTPUT_VARIABLE CHK_OUTPUT_${TEST_TARGET}
                 )
   else()
-    try_run( CHK_TARGET_RUN_${TEST_TARGET}                     # Variable to save the run result to
-             CHK_TARGET_BUILD_${TEST_TARGET}                   # Variable to save the build result to
+    try_run( CHKISA_TARGET_RUN_${TEST_TARGET}                     # Variable to save the run result to
+             CHKISA_TARGET_BUILD_${TEST_TARGET}                   # Variable to save the build result to
              "${CMAKE_BINARY_DIR}/compilerTest/${TEST_TARGET}" # Directory to compile in
              SOURCES ${CMP_CHECK_SRCS}                         # Source to compile
              CMAKE_FLAGS
               "-DCOMPILE_DEFINITIONS=${C_DEFS_CHK}"
-             OUTPUT_VARIABLE CHK_OUTPUT${TEST_TARGET}
+             OUTPUT_VARIABLE CHK_OUTPUT_${TEST_TARGET}
             )
   endif()
 
-  if(${CHK_TARGET_BUILD_${TEST_TARGET}})
-    set(CHK_TARGET_BUILD TRUE PARENT_SCOPE)
+  if(${CHKISA_TARGET_BUILD_${TEST_TARGET}})
+    set(CHKISA_TARGET_BUILD TRUE PARENT_SCOPE)
 
-    if(${CHK_TARGET_RUN_${TEST_TARGET}} STREQUAL "0")
-      set(CHK_TARGET_RUN TRUE PARENT_SCOPE)
+    if(${CHKISA_TARGET_RUN_${TEST_TARGET}} STREQUAL "0")
+      set(CHKISA_TARGET_RUN TRUE PARENT_SCOPE)
     else()
-      set(CHK_TARGET_RUN FALSE PARENT_SCOPE)
+      set(CHKISA_TARGET_RUN FALSE PARENT_SCOPE)
     endif()
 
   else()
-    set(CHK_TARGET_BUILD FALSE PARENT_SCOPE)
-    set(CHK_TARGET_OUTPUT ${CHK_OUTPUT${TEST_TARGET}} PARENT_SCOPE)
+    set(CHKISA_TARGET_BUILD FALSE PARENT_SCOPE)
+    set(CHKISA_TARGET_OUTPUT ${CHK_OUTPUT_${TEST_TARGET}} PARENT_SCOPE)
   endif()
 
 endfunction()


### PR DESCRIPTION
This adds CMake tests to compile and run with the intrinsics for supported architectures. It uses the same C flags that the main code will use, so it should detect problems with the flags.

Note: Only the X64 intrinsics are added currently. In the future the ARM intrinsics could be added, but since they aren't actually used in the code at all they don't have to be here (it should still pass the test).