### PR TITLE
Export BLASFEO_PATH and BLASFEO_INCLUDE_DIR in blasfeoConfig.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1111,13 +1111,21 @@ target_include_directories(blasfeo
 #		$<INSTALL_INTERFACE:include/blasfeo/include>)
 
 
-install(TARGETS blasfeo EXPORT blasfeoConfig
+install(TARGETS blasfeo EXPORT blasfeo_export
 	LIBRARY DESTINATION lib
 	ARCHIVE DESTINATION lib
 	RUNTIME DESTINATION bin)
 
 
-install(EXPORT blasfeoConfig DESTINATION cmake)
+install(EXPORT blasfeo_export DESTINATION cmake)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  cmake/blasfeoConfig.cmake.in
+  ${PROJECT_BINARY_DIR}/blasfeoConfig.cmake
+  INSTALL_DESTINATION cmake
+)
+install(FILES ${PROJECT_BINARY_DIR}/blasfeoConfig.cmake DESTINATION cmake)
 
 file(GLOB_RECURSE BLASFEO_HEADERS "include/*.h")
 install(FILES ${BLASFEO_HEADERS} DESTINATION ${BLASFEO_HEADERS_INSTALLATION_DIRECTORY})

--- a/cmake/blasfeoConfig.cmake.in
+++ b/cmake/blasfeoConfig.cmake.in
@@ -1,0 +1,10 @@
+@PACKAGE_INIT@
+
+include(${CMAKE_CURRENT_LIST_DIR}/blasfeo_export.cmake)
+
+get_target_property(tmp_blasfeo_INCLUDE_DIR blasfeo INTERFACE_INCLUDE_DIRECTORIES)
+
+set(BLASFEO_PATH ${PACKAGE_PREFIX_DIR} CACHE STRING "BLASFEO installation path")
+set(BLASFEO_INCLUDE_DIR ${tmp_blasfeo_INCLUDE_DIR} CACHE STRING "Path to BLASFEO header files.")
+
+unset(tmp_blasfeo_INCLUDE_DIR)


### PR DESCRIPTION
I have extended the export configuration a bit such that `BLASFEO_PATH` and `BLASFEO_INCLUDE_DIR` can be automatically deduced if one would use `find_package(blasfeo)`. This is especially relevant for `hpipm`, a related PR will follow there (will reference to it once created).