### PR TITLE
define uintptr_t for MicroAutoBox II

### DIFF
--- a/kernel/generic/kernel_align_generic.c
+++ b/kernel/generic/kernel_align_generic.c
@@ -33,8 +33,12 @@
 *                                                                                                 *
 **************************************************************************************************/
 
+#ifdef __MABX2__
+// dSPACE MicroAutoBox II does not provide stdint
+typedef unsigned int uintptr_t;
+#else
 #include <stdint.h>
-
+#endif
 
 
 void blasfeo_align_4096_byte(void *ptr, void **ptr_align)

--- a/kernel/generic/kernel_align_generic.c
+++ b/kernel/generic/kernel_align_generic.c
@@ -34,7 +34,7 @@
 **************************************************************************************************/
 
 #ifdef __MABX2__
-// dSPACE MicroAutoBox II does not provide stdint
+// dSPACE MicroAutoBox II (32-bit) does not provide stdint
 typedef unsigned int uintptr_t;
 #else
 #include <stdint.h>


### PR DESCRIPTION
Minor change to make BLASFEO work on the MicroAutoBox II

Compare:
https://github.com/acados/acados/pull/723
I will update the "update BLASFEO" commit there with the latest BLASFEO master, if this is merged.