### PR TITLE
More work on Skylake-X target with AVX512 ISA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,6 +241,7 @@ KERNEL_OBJS = \
 		kernel/avx512/kernel_dgemv_16_lib8.o \
 		kernel/avx512/kernel_dpack_lib8.o \
 		kernel/avx512/kernel_dgeqrf_8_lib8.o \
+		kernel/avx512/kernel_dgelqf_lib8.o \
 		\
 		kernel/sse3/kernel_align_x64.o \
 		\

--- a/Makefile
+++ b/Makefile
@@ -235,6 +235,7 @@ ifeq ($(TARGET), X64_INTEL_SKYLAKE_X)
 
 ### KERNELS ###
 KERNEL_OBJS = \
+		kernel/avx512/kernel_dgemm_24x8_lib8.o \
 		kernel/avx512/kernel_dgemm_16x8_lib8.o \
 		kernel/avx512/kernel_dgemm_8x8_lib8.o \
 		kernel/avx512/kernel_dgemv_8_lib8.o \

--- a/Makefile
+++ b/Makefile
@@ -240,6 +240,7 @@ KERNEL_OBJS = \
 		kernel/avx512/kernel_dgemv_8_lib8.o \
 		kernel/avx512/kernel_dgemv_16_lib8.o \
 		kernel/avx512/kernel_dpack_lib8.o \
+		kernel/avx512/kernel_dgeqrf_8_lib8.o \
 		\
 		kernel/sse3/kernel_align_x64.o \
 		\

--- a/Makefile.external_blas
+++ b/Makefile.external_blas
@@ -63,8 +63,10 @@ ifeq ($(EXTERNAL_BLAS), MKL)
 #LIBS_EXTERNAL_BLAS += -Wl,--start-group /opt/intel/mkl/lib/intel64/libmkl_gf_lp64.a /opt/intel/mkl/lib/intel64/libmkl_core.a /opt/intel/mkl/lib/intel64/libmkl_sequential.a -Wl,--end-group -ldl -lpthread -lm
 #INCLUDE_EXTERNAL_BLAS += -I/opt/intel/compilers_and_libraries_2019.1.144/linux/mkl/include
 #LIBS_EXTERNAL_BLAS += -Wl,--start-group /opt/intel/compilers_and_libraries_2019.1.144/linux/mkl/lib/intel64/libmkl_gf_lp64.a /opt/intel/compilers_and_libraries_2019.1.144/linux/mkl/lib/intel64/libmkl_core.a /opt/intel/compilers_and_libraries_2019.1.144/linux/mkl/lib/intel64/libmkl_sequential.a -Wl,--end-group -ldl -lpthread -lm
-INCLUDE_EXTERNAL_BLAS += -I/opt/intel/compilers_and_libraries_2020.3.279/linux/mkl/include
-LIBS_EXTERNAL_BLAS += -Wl,--start-group /opt/intel/compilers_and_libraries_2020.3.279/linux/mkl/lib/intel64/libmkl_gf_lp64.a /opt/intel/compilers_and_libraries_2020.3.279/linux/mkl/lib/intel64/libmkl_core.a /opt/intel/compilers_and_libraries_2020.3.279/linux/mkl/lib/intel64/libmkl_sequential.a -Wl,--end-group -ldl -lpthread -lm
+#INCLUDE_EXTERNAL_BLAS += -I/opt/intel/compilers_and_libraries_2020.3.279/linux/mkl/include
+#LIBS_EXTERNAL_BLAS += -Wl,--start-group /opt/intel/compilers_and_libraries_2020.3.279/linux/mkl/lib/intel64/libmkl_gf_lp64.a /opt/intel/compilers_and_libraries_2020.3.279/linux/mkl/lib/intel64/libmkl_core.a /opt/intel/compilers_and_libraries_2020.3.279/linux/mkl/lib/intel64/libmkl_sequential.a -Wl,--end-group -ldl -lpthread -lm
+INCLUDE_EXTERNAL_BLAS += -I ~/intel/oneapi/mkl/latest/include
+LIBS_EXTERNAL_BLAS += -Wl,--start-group ~/intel/oneapi/mkl/latest/lib/intel64/libmkl_gf_lp64.a ~/intel/oneapi/mkl/latest/lib/intel64/libmkl_core.a ~/intel/oneapi/mkl/latest/lib/intel64/libmkl_sequential.a -Wl,--end-group -ldl -lpthread -lm
 endif
 
 ifeq ($(EXTERNAL_BLAS), ATLAS)

--- a/Makefile.rule
+++ b/Makefile.rule
@@ -487,7 +487,7 @@ endif
 
 # Architecture-specific flags
 ifeq ($(TARGET), X64_INTEL_SKYLAKE_X)
-CFLAGS  += -m64 -mavx512f -mavx512vl -DTARGET_X64_INTEL_SKYLAKE_X
+CFLAGS  += -m64 -mavx512f -mavx512vl -mfma -DTARGET_X64_INTEL_SKYLAKE_X
 endif
 ifeq ($(TARGET), X64_INTEL_HASWELL)
 CFLAGS  += -m64 -mavx2 -mfma -DTARGET_X64_INTEL_HASWELL

--- a/Makefile.rule
+++ b/Makefile.rule
@@ -49,7 +49,7 @@ CURRENT_DIR := $(patsubst %/,%,$(dir $(MAKEFILE_PATH)))
 
 # Select target architecture (TARGET)
 #
-# X64_INTEL_SKYLAKE_X: x86_64 architecture with AVX512F ISA (64 bit OS)
+# X64_INTEL_SKYLAKE_X: x86_64 architecture with AVX512 (F+VL) ISA (64 bit OS)
 # Code optimized for Intel Skylake-X architecture with 2 512-bit FMA pipes.
 #
 # X64_INTEL_HASWELL: x86_64 architecture with AVX2 and FMA ISAs (64 bit OS)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Currently BLASFEO supports the following architectures:
 
 | TARGET                       | Description |
 | ---------------------------- | ------------------------------------------------------------- |
-| ```X64_INTEL_SKYLAKE_X```    | Intel Skylake-X architecture or newer (optimized for 2 512-bit FMA pipes). x86_64 with AVX512 ISA, 64-bit OS |
+| ```X64_INTEL_SKYLAKE_X```    | Intel Skylake-X architecture or newer (optimized for 2 512-bit FMA pipes). x86_64 with AVX512 (F+VL) ISA, 64-bit OS |
 | ```X64_INTEL_HASWELL```      | Intel Haswell, Intel Skylake, AMD Zen, AMD Zen2, AMD Zen3 architectures or newer. x86_64 with AVX2 and FMA ISA, 64-bit OS |
 | ```X64_INTEL_SANDY_BRIDGE``` | Intel Sandy-Bridge architecture. x86_64 with AVX ISA, 64-bit OS |
 | ```X64_INTEL_CORE```         | Intel Core architecture. x86_64 with SSE3 ISA, 64-bit OS |

--- a/benchmarks/benchmark_d_blas_api.c
+++ b/benchmarks/benchmark_d_blas_api.c
@@ -108,7 +108,10 @@ openblas_set_num_threads(1);
 	printf("\n");
 
 	// maximum flops per cycle, double precision
-#if defined(TARGET_X64_INTEL_HASWELL)
+#if defined(TARGET_X64_INTEL_SKYLAKE_X)
+	const float flops_max = 32;
+	printf("Testing BLASFEO version for AVX512F instruction set, 64 bit (optimized for Intel Skylake-X): theoretical peak %5.1f Gflops\n", flops_max*GHz_max);
+#elif defined(TARGET_X64_INTEL_HASWELL)
 	const float flops_max = 16;
 	printf("Testing BLAS version for AVX2 and FMA instruction sets, 64 bit (optimized for Intel Haswell): theoretical peak %5.1f Gflops\n", flops_max*GHz_max);
 #elif defined(TARGET_X64_INTEL_SANDY_BRIDGE)

--- a/benchmarks/benchmark_d_blasfeo_api.c
+++ b/benchmarks/benchmark_d_blasfeo_api.c
@@ -785,7 +785,7 @@ int main()
 
 
 //				blasfeo_dgemm_nn(m0, n0, k0, 1.0, &sA, 0, 0, &sB, 0, 0, 0.0, &sD, 0, 0, &sD, 0, 0);
-				blasfeo_dgemm_nt(m0, n0, k0, 1.0, &sA, 0, 0, &sB, 0, 0, 0.0, &sD, 0, 0, &sD, 0, 0);
+//				blasfeo_dgemm_nt(m0, n0, k0, 1.0, &sA, 0, 0, &sB, 0, 0, 0.0, &sD, 0, 0, &sD, 0, 0);
 //				blasfeo_dgemm_tn(m0, n0, k0, 1.0, &sA, 0, 0, &sB, 0, 0, 0.0, &sD, 0, 0, &sD, 0, 0);
 //				blasfeo_dgemm_tt(m0, n0, k0, 1.0, &sA, 0, 0, &sB, 0, 0, 0.0, &sD, 0, 0, &sD, 0, 0);
 
@@ -823,7 +823,7 @@ int main()
 //				blasfeo_dtrsm2_llnu(n, n, 1.0, &sD, 0, 0, &sB, 0, 0);
 //				blasfeo_dtrsm2_rutu(n, n, 1.0, &sD, 0, 0, &sB, 0, 0);
 //				blasfeo_dtrsm_lunn(n, n, 1.0, &sD, 0, 0, &sB, 0, 0, &sB, 0, 0);
-//				blasfeo_dtrsm_rltn(n, n, 1.0, &sB2, 0, 0, &sD, 0, 0, &sD, 0, 0); //
+				blasfeo_dtrsm_rltn(n, n, 1.0, &sB, 0, 0, &sD, 0, 0, &sD, 0, 0); // B2?
 //				blasfeo_dtrsm_rltu(n, n, 1.0, &sD, 0, 0, &sB, 0, 0, &sB, 0, 0);
 //				blasfeo_dtrsm_rutn(n, n, 1.0, &sD, 0, 0, &sB, 0, 0, &sB, 0, 0);
 //				blasfeo_dgemv_n(n, n, 1.0, &sA, 0, 0, &sx, 0, 0.0, &sy, 0, &sz, 0);
@@ -892,10 +892,10 @@ int main()
 //		float flop_operation = 1*16.0*2*n; // kernel 4x4
 //		float flop_operation = 0.5*16.0*2*n; // kernel 2x4
 
-		float flop_operation = 2.0*m0*n0*k0; // gemm
+//		float flop_operation = 2.0*m0*n0*k0; // gemm
 
 //		float flop_operation = 2.0*n*n*n; // gemm
-//		float flop_operation = 1.0*n*n*n; // syrk trmm trsm
+		float flop_operation = 1.0*n*n*n; // syrk trmm trsm
 //		float flop_operation = 1.0/3.0*n*n*n; // potrf trtri
 //		float flop_operation = 2.0/3.0*n*n*n; // getrf
 //		float flop_operation = 4.0/3.0*n*n*n; // geqrf gelqf

--- a/benchmarks/benchmark_d_blasfeo_api.c
+++ b/benchmarks/benchmark_d_blasfeo_api.c
@@ -586,6 +586,7 @@ int main()
 
 		int n = nn[ll];
 		int nrep = nnrep[ll];
+//		nrep = nrep>1 ? nrep : 1;
 //		int n = ll+1;
 //		int nrep = nnrep[0];
 //		n = n<12 ? 12 : n;
@@ -671,6 +672,8 @@ int main()
 		struct blasfeo_dmat sB; blasfeo_allocate_dmat(n, n, &sB);
 		struct blasfeo_dmat sB2; blasfeo_allocate_dmat(n, n, &sB2);
 		struct blasfeo_dmat sB3; blasfeo_allocate_dmat(n, n, &sB3);
+		struct blasfeo_dmat sB4; blasfeo_allocate_dmat(n, 2*n, &sB4);
+		struct blasfeo_dmat sB5; blasfeo_allocate_dmat(n, 3*n, &sB5);
 		struct blasfeo_dmat sC; blasfeo_allocate_dmat(n, n, &sC);
 		struct blasfeo_dmat sD; blasfeo_allocate_dmat(n, n, &sD);
 		struct blasfeo_dmat sE; blasfeo_allocate_dmat(n, n, &sE);
@@ -697,13 +700,21 @@ int main()
 		blasfeo_pack_dvec(n, x, 1, &sx, 0);
 		int ii;
 
+		blasfeo_dgese(n, n, 1e-3, &sB3, 0, 0);
 		for(ii=0; ii<n; ii++)
 			{
 			BLASFEO_DMATEL(&sB3, ii, ii) = 1.0;
-			// BLASFEO_DMATEL(&sB3, n-1, ii) = 1.0;
+			BLASFEO_DMATEL(&sB3, n-1, ii) = 1.0;
 			BLASFEO_DMATEL(&sB3, ii, n-1) = 1.0;
 			BLASFEO_DVECEL(&sx, ii) = 1.0;
 			}
+		// B4
+		blasfeo_dgecp(n, n, &sB3, 0, 0, &sB4, 0, 0);
+		blasfeo_dgecp(n, n, &sA, 0, 0, &sB4, 0, n);
+		// B5
+		blasfeo_dgecp(n, n, &sB3, 0, 0, &sB5, 0, 0);
+		blasfeo_dgecp(n, n, &sB, 0, 0, &sB5, 0, n);
+		blasfeo_dgecp(n, n, &sA, 0, 0, &sB5, 0, 2*n);
 
 		int qr_work_size = blasfeo_dgeqrf_worksize(n, n);
 		void *qr_work;
@@ -802,19 +813,24 @@ int main()
 //				blasfeo_dsyrk3_un(n, n, 1.0, &sA, 0, 0, 0.0, &sD, 0, 0, &sD, 0, 0);
 //				blasfeo_dsyrk_ut(n, n, 1.0, &sA, 0, 0, &sA, 0, 0, 0.0, &sD, 0, 0, &sD, 0, 0);
 //				blasfeo_dsyrk3_ut(n, n, 1.0, &sA, 0, 0, 0.0, &sD, 0, 0, &sD, 0, 0);
-//				blasfeo_dpotrf_l(n, &sB, 0, 0, &sB, 0, 0);
+//				blasfeo_dpotrf_l(n, &sD, 0, 0, &sD, 0, 0);
 //				blasfeo_dpotrf_l_mn(n, n, &sB, 0, 0, &sB, 0, 0);
 //				blasfeo_dpotrf_u(n, &sB, 0, 0, &sB, 0, 0);
+//				blasfeo_dsyrk_dpotrf_ln(n, n, &sA, 0, 0, &sA, 0, 0, &sB, 0, 0, &sD, 0, 0);
 //				blasfeo_dgetrf_np(n, n, &sB, 0, 0, &sB, 0, 0);
 //				blasfeo_dgetrf_np_test(n, n, &sB, 0, 0, &sB, 0, 0);
 //				blasfeo_dgetrf_rp(n, n, &sB, 0, 0, &sB, 0, 0, ipiv);
 //				blasfeo_dgetrf_rp_test(n, n, &sB, 0, 0, &sB, 0, 0, ipiv);
 //				blasfeo_dgeqrf(n, n, &sC, 0, 0, &sD, 0, 0, qr_work);
-//				blasfeo_dcolin(n, &sx, 0, &sB3, 0, n-1);
+				blasfeo_dcolin(n, &sx, 0, &sB3, 0, n-1);
 //				blasfeo_dgelqf(n, n, &sB3, 0, 0, &sB3, 0, 0, lq_work);
-//				blasfeo_dgelqf_pd(n, n, &sB3, 0, 0, &sB3, 0, 0, lq_work);
-//				blasfeo_dgelqf_pd_la(n, n, &sB3, 0, 0, &sA, 0, 0, lq_work);
-//				blasfeo_dgelqf_pd_lla(n, n, &sB3, 0, 0, &sB, 0, 0, &sA, 0, 0, lq_work);
+				blasfeo_dgelqf_pd(n, n, &sB3, 0, 0, &sB3, 0, 0, lq_work);
+//				blasfeo_dcolin(n, &sx, 0, &sB4, 0, 2*n-1);
+//				blasfeo_dgelqf_pd_la(n, n, &sB4, 0, 0, &sB4, 0, n, lq_work);
+//				blasfeo_dgelqf_pd(n, 2*n, &sB4, 0, 0, &sB4, 0, 0, lq_work);
+//				blasfeo_dcolin(n, &sx, 0, &sB5, 0, 3*n-1);
+//				blasfeo_dgelqf_pd_lla(n, n, &sB5, 0, 0, &sB5, 0, n, &sB5, 0, 2*n, lq_work);
+//				blasfeo_dgelqf_pd(n, 3*n, &sB5, 0, 0, &sB5, 0, 0, lq_work);
 //				blasfeo_dtrmm_rlnn(n, n, 1.0, &sA, 0, 0, &sD, 0, 0, &sD, 0, 0); //
 //				blasfeo_dtrmm_rutn(n, n, 1.0, &sA, 0, 0, &sB, 0, 0, &sD, 0, 0);
 //				blasfeo_dtrsm_llnn(n, n, 1.0, &sD, 0, 0, &sB, 0, 0, &sB, 0, 0);
@@ -823,13 +839,17 @@ int main()
 //				blasfeo_dtrsm2_llnu(n, n, 1.0, &sD, 0, 0, &sB, 0, 0);
 //				blasfeo_dtrsm2_rutu(n, n, 1.0, &sD, 0, 0, &sB, 0, 0);
 //				blasfeo_dtrsm_lunn(n, n, 1.0, &sD, 0, 0, &sB, 0, 0, &sB, 0, 0);
-				blasfeo_dtrsm_rltn(n, n, 1.0, &sB, 0, 0, &sD, 0, 0, &sD, 0, 0); // B2?
+//				blasfeo_dtrsm_rltn(n, n, 1.0, &sB, 0, 0, &sD, 0, 0, &sD, 0, 0); // B2?
 //				blasfeo_dtrsm_rltu(n, n, 1.0, &sD, 0, 0, &sB, 0, 0, &sB, 0, 0);
 //				blasfeo_dtrsm_rutn(n, n, 1.0, &sD, 0, 0, &sB, 0, 0, &sB, 0, 0);
 //				blasfeo_dgemv_n(n, n, 1.0, &sA, 0, 0, &sx, 0, 0.0, &sy, 0, &sz, 0);
 //				blasfeo_dgemv_t(n, n, 1.0, &sA, 0, 0, &sx, 0, 0.0, &sy, 0, &sz, 0);
-//				blasfeo_dsymv_l(n, 1.0, &sA, 0, 0, &sx, 0, 0.0, &sy, 0, &sz, 0);
 //				blasfeo_dgemv_nt(n, n, 1.0, 1.0, &sA, 0, 0, &sx, 0, &sx, 0, 0.0, 0.0, &sy, 0, &sy, 0, &sz, 0, &sz, 0);
+//				blasfeo_dsymv_l(n, 1.0, &sA, 0, 0, &sx, 0, 0.0, &sz, 0, &sz, 0);
+//				blasfeo_dtrmv_lnn(n, &sB, 0, 0, &sx, 0, &sz, 0);
+//				blasfeo_dtrmv_ltn(n, &sB, 0, 0, &sx, 0, &sz, 0);
+//				blasfeo_dtrsv_lnn(n, &sB, 0, 0, &sx, 0, &sz, 0);
+//				blasfeo_dtrsv_ltn(n, &sB, 0, 0, &sx, 0, &sz, 0);
 				}
 
 			tmp_time_blasfeo = blasfeo_toc(&timer) / nrep;
@@ -895,10 +915,10 @@ int main()
 //		float flop_operation = 2.0*m0*n0*k0; // gemm
 
 //		float flop_operation = 2.0*n*n*n; // gemm
-		float flop_operation = 1.0*n*n*n; // syrk trmm trsm
+//		float flop_operation = 1.0*n*n*n; // syrk trmm trsm
 //		float flop_operation = 1.0/3.0*n*n*n; // potrf trtri
 //		float flop_operation = 2.0/3.0*n*n*n; // getrf
-//		float flop_operation = 4.0/3.0*n*n*n; // geqrf gelqf
+		float flop_operation = 4.0/3.0*n*n*n; // geqrf gelqf
 //		float flop_operation = 2.0*n*n*n; // geqrf_la
 //		float flop_operation = 8.0/3.0*n*n*n; // geqrf_lla
 //		float flop_operation = 2.0*n*n; // gemv symv
@@ -942,6 +962,8 @@ int main()
 		blasfeo_free_dmat(&sB);
 		blasfeo_free_dmat(&sB2);
 		blasfeo_free_dmat(&sB3);
+		blasfeo_free_dmat(&sB4);
+		blasfeo_free_dmat(&sB5);
 		blasfeo_free_dmat(&sC);
 		blasfeo_free_dmat(&sD);
 		blasfeo_free_dmat(&sE);

--- a/blasfeo_hp_cm/dgemm.c
+++ b/blasfeo_hp_cm/dgemm.c
@@ -719,7 +719,7 @@ nn_m0_left_8:
 #if defined(TARGET_X64_INTEL_SKYLAKE_X)
 nn_m0_left_8:
 	kernel_dpack_nn_8_vs_lib8(k, A+ii, lda, pU, m-ii);
-	for(jj=0; jj<n; jj+=4)
+	for(jj=0; jj<n; jj+=8)
 		{
 		kernel_dgemm_nn_8x8_vs_lib8ccc(k, &alpha, pU, B+jj*ldb, ldb, &beta, C+ii+jj*ldc, ldc, D+ii+jj*ldd, ldd, m-ii, n-jj);
 		}

--- a/blasfeo_hp_pm/d_blas3_lib8.c
+++ b/blasfeo_hp_pm/d_blas3_lib8.c
@@ -1320,8 +1320,6 @@ void blasfeo_hp_dtrsm_rltn(int m, int n, double alpha, struct blasfeo_dmat *sA, 
 	// invalidate stored inverse diagonal of result matrix
 	sD->use_dA = 0;
 
-	// TODO alpha !!!!!
-
 	int sda = sA->cn;
 	int sdb = sB->cn;
 	int sdd = sD->cn;
@@ -1332,13 +1330,13 @@ void blasfeo_hp_dtrsm_rltn(int m, int n, double alpha, struct blasfeo_dmat *sA, 
 	double *pD = sD->pA + dj*ps + (di-dir)*sdd;
 	double *dA = sA->dA;
 
-	if(ai!=0 | bir!=0 | dir!=0 | alpha!=1.0)
+	if(ai!=0 | bir!=0 | dir!=0)
 		{
 #if defined(BLASFEO_REF_API)
 		blasfeo_ref_dtrsm_rltn(m, n, alpha, sA, ai, aj, sB, bi, bj, sD, di, dj);
 		return;
 #else
-		printf("\nblasfeo_dtrsm_rltn: feature not implemented yet: ai=%d, bi=%d, di=%d, alpha=%f\n", ai, bi, di, alpha);
+		printf("\nblasfeo_dtrsm_rltn: feature not implemented yet: ai=%d, bi=%d, di=%d\n", ai, bi, di);
 		exit(1);
 #endif
 		}
@@ -1370,6 +1368,34 @@ void blasfeo_hp_dtrsm_rltn(int m, int n, double alpha, struct blasfeo_dmat *sA, 
 
 	i = 0;
 #if 1
+	for(; i<m-23; i+=24)
+		{
+		j = 0;
+		for(; j<n-7; j+=8)
+			{
+			kernel_dtrsm_nt_rl_inv_24x8_lib8(j, &pD[i*sdd], sdd, &pA[j*sda], &alpha, &pB[j*ps+i*sdb], sdb, &pD[j*ps+i*sdd], sdd, &pA[j*ps+j*sda], &dA[j]);
+			}
+		if(j<n)
+			{
+			kernel_dtrsm_nt_rl_inv_24x8_vs_lib8(j, &pD[i*sdd], sdd, &pA[j*sda], &alpha, &pB[j*ps+i*sdb], sdb, &pD[j*ps+i*sdd], sdd, &pA[j*ps+j*sda], &dA[j], m-i, n-j);
+			}
+		}
+	if(m>i)
+		{
+		if(m-i<=8)
+			{
+			goto left_8;
+			}
+		else if(m-i<=16)
+			{
+			goto left_16;
+			}
+		else
+			{
+			goto left_24;
+			}
+		}
+#elif 1
 	for(; i<m-15; i+=16)
 		{
 		j = 0;
@@ -1414,6 +1440,16 @@ void blasfeo_hp_dtrsm_rltn(int m, int n, double alpha, struct blasfeo_dmat *sA, 
 
 	// common return if i==m
 	return;
+
+#if 1
+	left_24:
+	j = 0;
+	for(; j<n; j+=8)
+		{
+		kernel_dtrsm_nt_rl_inv_24x8_vs_lib8(j, &pD[i*sdd], sdd, &pA[j*sda], &alpha, &pB[j*ps+i*sdb], sdb, &pD[j*ps+i*sdd], sdd, &pA[j*ps+j*sda], &dA[j], m-i, n-j);
+		}
+	return;
+#endif
 
 #if 1
 	left_16:

--- a/blasfeo_hp_pm/d_blas3_lib8.c
+++ b/blasfeo_hp_pm/d_blas3_lib8.c
@@ -404,6 +404,48 @@ clear_air:
 loop_00:
 	i = 0;
 #if 1
+	for(; i<m-23; i+=24)
+		{
+		j = 0;
+		idxB = 0;
+		// clean up at the beginning
+		if(bir!=0)
+			{
+#if 0
+			kernel_dgemm_nt_24x8_gen_lib8(k, &alpha, &pA[i*sda], sda, &pB[idxB*sdb], &beta, offsetC, &pC[j*ps+i*sdc]-bir*ps, sdc, offsetD, &pD[j*ps+i*sdd]-bir*ps, sdd, 0, m-i, bir, bir+n-j);
+#else
+			kernel_dgemm_nt_16x8_gen_lib8(k, &alpha, &pA[(i+0)*sda], sda, &pB[idxB*sdb], &beta, 0, &pC[j*ps+(i+0)*sdc]-bir*ps, sdc, 0, &pD[j*ps+(i+0)*sdd]-bir*ps, sdd, 0, m-(i+0), bir, bir+n-j);
+			kernel_dgemm_nt_8x8_gen_lib8(k, &alpha, &pA[(i+16)*sda], &pB[idxB*sdb], &beta, 0, &pC[j*ps+(i+16)*sdc]-bir*ps, sdc, 0, &pD[j*ps+(i+16)*sdd]-bir*ps, sdd, 0, m-(i+16), bir, bir+n-j);
+#endif
+			j += ps-bir;
+			idxB += 8;
+			}
+		// main loop
+		for(; j<n-7; j+=8, idxB+=8)
+			{
+			kernel_dgemm_nt_24x8_lib8(k, &alpha, &pA[i*sda], sda, &pB[idxB*sdb], &beta, &pC[j*ps+i*sdc], sdc, &pD[j*ps+i*sdd], sdd);
+			}
+		if(j<n)
+			{
+			kernel_dgemm_nt_24x8_vs_lib8(k, &alpha, &pA[i*sda], sda, &pB[idxB*sdb], &beta, &pC[j*ps+i*sdc], sdc, &pD[j*ps+i*sdd], sdd, m-i, n-j);
+			}
+		}
+	if(m>i)
+		{
+		if(m-i<=8)
+			{
+			goto left_8;
+			}
+		else if(m-i<=16)
+			{
+			goto left_16;
+			}
+		else
+			{
+			goto left_24;
+			}
+		}
+#elif 1
 	for(; i<m-15; i+=16)
 		{
 		j = 0;
@@ -523,6 +565,30 @@ loop_CD:
 
 
 	// clean up loops definitions
+
+	left_24:
+	j = 0;
+	idxB = 0;
+	// clean up at the beginning
+	if(bir!=0)
+		{
+#if 0
+		kernel_dgemm_nt_24x8_gen_lib8(k, &alpha, &pA[i*sda], sda, &pB[idxB*sdb], &beta, offsetC, &pC[j*ps+i*sdc]-bir*ps, sdc, offsetD, &pD[j*ps+i*sdd]-bir*ps, sdd, 0, m-i, bir, bir+n-j);
+#else
+		kernel_dgemm_nt_16x8_gen_lib8(k, &alpha, &pA[(i+0)*sda], sda, &pB[idxB*sdb], &beta, offsetC, &pC[j*ps+(i+0)*sdc]-bir*ps, sdc, offsetD, &pD[j*ps+(i+0)*sdd]-bir*ps, sdd, 0, m-(i+0), bir, bir+n-j);
+		kernel_dgemm_nt_8x8_gen_lib8(k, &alpha, &pA[(i+16)*sda], &pB[idxB*sdb], &beta, offsetC, &pC[j*ps+(i+16)*sdc]-bir*ps, sdc, offsetD, &pD[j*ps+(i+16)*sdd]-bir*ps, sdd, 0, m-(i+16), bir, bir+n-j);
+#endif
+		j += ps-bir;
+		idxB += 8;
+		}
+	// main loop
+	for(; j<n; j+=8, idxB+=8)
+		{
+		kernel_dgemm_nt_24x8_vs_lib8(k, &alpha, &pA[i*sda], sda, &pB[idxB*sdb], &beta, &pC[j*ps+i*sdc], sdc, &pD[j*ps+i*sdd], sdd, m-i, n-j);
+		}
+	return;
+
+
 
 	left_16:
 	j = 0;

--- a/blasfeo_hp_pm/d_lapack_lib4.c
+++ b/blasfeo_hp_pm/d_lapack_lib4.c
@@ -4029,8 +4029,16 @@ void blasfeo_hp_dgelqf_pd_la(int m, int n1, struct blasfeo_dmat *sD, int di, int
 	// different block alignment
 	if( (di&(ps-1)) != (ai&(ps-1)) )
 		{
-		kernel_dgelqf_pd_la_vs_lib4(m, n1, imax, di&(ps-1), pD, sdd, dD, ai&(ps-1), pA, sda);
+		// XXX vecorized kernel requires same offset modulo ps
+//		kernel_dgelqf_pd_la_vs_lib4(m, n1, imax, di&(ps-1), pD, sdd, dD, ai&(ps-1), pA, sda);
+//		return;
+#if defined(BLASFEO_REF_API)
+		blasfeo_ref_dgelqf_pd_la(m, n1, sD, di, dj, sA, ai, aj, work);
 		return;
+#else
+		printf("\nblasfeo_dgelqf_pd_la: feature not implemented yet: ai!=di\n");
+		exit(1);
+#endif
 		}
 	// same block alignment
 #if 0

--- a/blasfeo_hp_pm/d_lapack_lib4.c
+++ b/blasfeo_hp_pm/d_lapack_lib4.c
@@ -4158,8 +4158,15 @@ void blasfeo_hp_dgelqf_pd_lla(int m, int n1, struct blasfeo_dmat *sD, int di, in
 	// different block alignment
 	if( (di&(ps-1)) != (ai&(ps-1)) | imax0>0 )
 		{
-		kernel_dgelqf_pd_lla_vs_lib4(m, 0, n1, imax, di&(ps-1), pD, sdd, dD, li&(ps-1), pL, sdl, ai&(ps-1), pA, sda);
+//		kernel_dgelqf_pd_lla_vs_lib4(m, 0, n1, imax, di&(ps-1), pD, sdd, dD, li&(ps-1), pL, sdl, ai&(ps-1), pA, sda);
+//		return;
+#if defined(BLASFEO_REF_API)
+		blasfeo_ref_dgelqf_pd_lla(m, n1, sD, di, dj, sL, li, lj, sA, ai, aj, work);
 		return;
+#else
+		printf("\nblasfeo_dgelqf_pd_lla: feature not implemented yet: ai!=di\n");
+		exit(1);
+#endif
 		}
 	// same block alignment
 #if 0

--- a/blasfeo_hp_pm/d_lapack_lib8.c
+++ b/blasfeo_hp_pm/d_lapack_lib8.c
@@ -800,7 +800,7 @@ void blasfeo_hp_dgelqf(int m, int n, struct blasfeo_dmat *sC, int ci, int cj, st
 //d_print_mat(1, 8, dD+ii, 1);
 //d_print_mat(8, 8, pT, 8);
 		jj = ii+8;
-#if 0
+#if 1
 		for(; jj<m-15; jj+=16)
 			{
 			kernel_dlarfb8_rn_16_lib8(n-ii, pD+ii*sdd+ii*ps, pT, pD+jj*sdd+ii*ps, sdd);
@@ -920,7 +920,7 @@ void blasfeo_hp_dgelqf_pd(int m, int n, struct blasfeo_dmat *sC, int ci, int cj,
 		jj = ii+8;
 //d_print_mat(1, 8, dD+ii, 1);
 //d_print_mat(8, 8, pT, 8);
-#if 0
+#if 1
 		for(; jj<m-15; jj+=16)
 			{
 			kernel_dlarfb8_rn_16_lib8(n-ii, pD+ii*sdd+ii*ps, pT, pD+jj*sdd+ii*ps, sdd);

--- a/blasfeo_hp_pm/d_lapack_lib8.c
+++ b/blasfeo_hp_pm/d_lapack_lib8.c
@@ -84,6 +84,33 @@ void blasfeo_hp_dpotrf_l(int m, struct blasfeo_dmat *sC, int ci, int cj, struct 
 
 	i = 0;
 #if 1
+	for(; i<m-23; i+=24)
+		{
+		j = 0;
+		for(; j<i; j+=8)
+			{
+			kernel_dtrsm_nt_rl_inv_24x8_lib8(j, &pD[i*sdd], sdd, &pD[j*sdd], &alpha, &pC[j*ps+i*sdc], sdc, &pD[j*ps+i*sdd], sdd, &pD[j*ps+j*sdd], &dD[j]);
+			}
+		kernel_dpotrf_nt_l_24x8_lib8(j, &pD[i*sdd], sdd, &pD[j*sdd], &pC[j*ps+j*sdc], sdc, &pD[j*ps+j*sdd], sdd, &dD[j]);
+		kernel_dpotrf_nt_l_16x8_lib8(j+8, &pD[(i+8)*sdd], sdd, &pD[(j+8)*sdd], &pC[(j+8)*ps+(j+8)*sdc], sdc, &pD[(j+8)*ps+(j+8)*sdd], sdd, &dD[j+8]);
+		kernel_dpotrf_nt_l_8x8_lib8(j+16, &pD[(i+16)*sdd], &pD[(j+16)*sdd], &pC[(j+16)*ps+(i+16)*sdc], &pD[(j+16)*ps+(i+16)*sdd], &dD[j+16]);
+		}
+	if(m>i)
+		{
+		if(m-i<=8)
+			{
+			goto left_8;
+			}
+		else if(m-i<=16)
+			{
+			goto left_16;
+			}
+		else
+			{
+			goto left_24;
+			}
+		}
+#elif 1
 	for(; i<m-15; i+=16)
 		{
 		j = 0;
@@ -134,6 +161,17 @@ void blasfeo_hp_dpotrf_l(int m, struct blasfeo_dmat *sC, int ci, int cj, struct 
 		}
 	kernel_dpotrf_nt_l_16x8_vs_lib8(j, &pD[i*sdd], sdd, &pD[j*sdd], &pC[j*ps+j*sdc], sdc, &pD[j*ps+j*sdd], sdd, &dD[j], m-i, m-j);
 	kernel_dpotrf_nt_l_8x8_vs_lib8(j+8, &pD[(i+8)*sdd], &pD[(j+8)*sdd], &pC[(j+8)*ps+(i+8)*sdc], &pD[(j+8)*ps+(i+8)*sdd], &dD[j+8], m-i-8, m-j-8);
+	return;
+
+	left_24:
+	j = 0;
+	for(; j<i; j+=8)
+		{
+		kernel_dtrsm_nt_rl_inv_24x8_vs_lib8(j, &pD[i*sdd], sdd, &pD[j*sdd], &alpha, &pC[j*ps+i*sdc], sdc, &pD[j*ps+i*sdd], sdd, &pD[j*ps+j*sdd], &dD[j], m-i, m-j);
+		}
+	kernel_dpotrf_nt_l_24x8_vs_lib8(j, &pD[i*sdd], sdd, &pD[j*sdd], &pC[j*ps+j*sdc], sdc, &pD[j*ps+j*sdd], sdd, &dD[j], m-i, m-j);
+	kernel_dpotrf_nt_l_16x8_vs_lib8(j+8, &pD[(i+8)*sdd], sdd, &pD[(j+8)*sdd], &pC[(j+8)*ps+(i+8)*sdc], sdc, &pD[(j+8)*ps+(i+8)*sdd], sdd, &dD[j+8], m-i-8, m-j-8);
+	kernel_dpotrf_nt_l_8x8_vs_lib8(j+16, &pD[(i+16)*sdd], &pD[(j+16)*sdd], &pC[(j+16)*ps+(i+16)*sdc], &pD[(j+16)*ps+(i+16)*sdd], &dD[j+16], m-i-16, m-j-16);
 	return;
 
 #if 0

--- a/blasfeo_hp_pm/d_lapack_lib8.c
+++ b/blasfeo_hp_pm/d_lapack_lib8.c
@@ -92,8 +92,12 @@ void blasfeo_hp_dpotrf_l(int m, struct blasfeo_dmat *sC, int ci, int cj, struct 
 			kernel_dtrsm_nt_rl_inv_24x8_lib8(j, &pD[i*sdd], sdd, &pD[j*sdd], &alpha, &pC[j*ps+i*sdc], sdc, &pD[j*ps+i*sdd], sdd, &pD[j*ps+j*sdd], &dD[j]);
 			}
 		kernel_dpotrf_nt_l_24x8_lib8(j, &pD[i*sdd], sdd, &pD[j*sdd], &pC[j*ps+j*sdc], sdc, &pD[j*ps+j*sdd], sdd, &dD[j]);
+#if 0 // TODO
+		kernel_dpotrf_nt_l_16x16_lib8(j+8, &pD[(i+8)*sdd], sdd, &pD[(j+8)*sdd], sdd, &pC[(j+8)*ps+(i+8)*sdc], sdc, &pD[(j+8)*ps+(i+8)*sdd], sdd, &dD[j+8]);
+#else
 		kernel_dpotrf_nt_l_16x8_lib8(j+8, &pD[(i+8)*sdd], sdd, &pD[(j+8)*sdd], &pC[(j+8)*ps+(j+8)*sdc], sdc, &pD[(j+8)*ps+(j+8)*sdd], sdd, &dD[j+8]);
 		kernel_dpotrf_nt_l_8x8_lib8(j+16, &pD[(i+16)*sdd], &pD[(j+16)*sdd], &pC[(j+16)*ps+(i+16)*sdc], &pD[(j+16)*ps+(i+16)*sdd], &dD[j+16]);
+#endif
 		}
 	if(m>i)
 		{
@@ -153,16 +157,6 @@ void blasfeo_hp_dpotrf_l(int m, struct blasfeo_dmat *sC, int ci, int cj, struct 
 
 	// clean up loops definitions
 
-	left_16:
-	j = 0;
-	for(; j<i; j+=8)
-		{
-		kernel_dtrsm_nt_rl_inv_16x8_vs_lib8(j, &pD[i*sdd], sdd, &pD[j*sdd], &alpha, &pC[j*ps+i*sdc], sdc, &pD[j*ps+i*sdd], sdd, &pD[j*ps+j*sdd], &dD[j], m-i, m-j);
-		}
-	kernel_dpotrf_nt_l_16x8_vs_lib8(j, &pD[i*sdd], sdd, &pD[j*sdd], &pC[j*ps+j*sdc], sdc, &pD[j*ps+j*sdd], sdd, &dD[j], m-i, m-j);
-	kernel_dpotrf_nt_l_8x8_vs_lib8(j+8, &pD[(i+8)*sdd], &pD[(j+8)*sdd], &pC[(j+8)*ps+(i+8)*sdc], &pD[(j+8)*ps+(i+8)*sdd], &dD[j+8], m-i-8, m-j-8);
-	return;
-
 	left_24:
 	j = 0;
 	for(; j<i; j+=8)
@@ -170,8 +164,26 @@ void blasfeo_hp_dpotrf_l(int m, struct blasfeo_dmat *sC, int ci, int cj, struct 
 		kernel_dtrsm_nt_rl_inv_24x8_vs_lib8(j, &pD[i*sdd], sdd, &pD[j*sdd], &alpha, &pC[j*ps+i*sdc], sdc, &pD[j*ps+i*sdd], sdd, &pD[j*ps+j*sdd], &dD[j], m-i, m-j);
 		}
 	kernel_dpotrf_nt_l_24x8_vs_lib8(j, &pD[i*sdd], sdd, &pD[j*sdd], &pC[j*ps+j*sdc], sdc, &pD[j*ps+j*sdd], sdd, &dD[j], m-i, m-j);
+#if 0 // TODO
+	kernel_dpotrf_nt_l_16x16_vs_lib8(j+8, &pD[(i+8)*sdd], sdd, &pD[(j+8)*sdd], sdd, &pC[(j+8)*ps+(i+8)*sdc], sdc, &pD[(j+8)*ps+(i+8)*sdd], sdd, &dD[j+8], m-i-8, m-j-8);
+#else
 	kernel_dpotrf_nt_l_16x8_vs_lib8(j+8, &pD[(i+8)*sdd], sdd, &pD[(j+8)*sdd], &pC[(j+8)*ps+(i+8)*sdc], sdc, &pD[(j+8)*ps+(i+8)*sdd], sdd, &dD[j+8], m-i-8, m-j-8);
 	kernel_dpotrf_nt_l_8x8_vs_lib8(j+16, &pD[(i+16)*sdd], &pD[(j+16)*sdd], &pC[(j+16)*ps+(i+16)*sdc], &pD[(j+16)*ps+(i+16)*sdd], &dD[j+16], m-i-16, m-j-16);
+#endif
+	return;
+
+	left_16:
+	j = 0;
+	for(; j<i; j+=8)
+		{
+		kernel_dtrsm_nt_rl_inv_16x8_vs_lib8(j, &pD[i*sdd], sdd, &pD[j*sdd], &alpha, &pC[j*ps+i*sdc], sdc, &pD[j*ps+i*sdd], sdd, &pD[j*ps+j*sdd], &dD[j], m-i, m-j);
+		}
+#if 0 // TODO
+	kernel_dpotrf_nt_l_16x16_vs_lib8(j, &pD[i*sdd], sdd, &pD[j*sdd], sdd, &pC[j*ps+j*sdc], sdc, &pD[j*ps+j*sdd], sdd, &dD[j], m-i, m-j);
+#else
+	kernel_dpotrf_nt_l_16x8_vs_lib8(j, &pD[i*sdd], sdd, &pD[j*sdd], &pC[j*ps+j*sdc], sdc, &pD[j*ps+j*sdd], sdd, &dD[j], m-i, m-j);
+	kernel_dpotrf_nt_l_8x8_vs_lib8(j+8, &pD[(i+8)*sdd], &pD[(j+8)*sdd], &pC[(j+8)*ps+(i+8)*sdc], &pD[(j+8)*ps+(i+8)*sdd], &dD[j+8], m-i-8, m-j-8);
+#endif
 	return;
 
 #if 0
@@ -255,6 +267,62 @@ void blasfeo_hp_dpotrf_l_mn(int m, int n, struct blasfeo_dmat *sC, int ci, int c
 
 	i = 0;
 #if 1
+	for(; i<m-23; i+=24)
+		{
+		j = 0;
+		for(; j<i & j<n-7; j+=8)
+			{
+			kernel_dtrsm_nt_rl_inv_24x8_lib8(j, &pD[i*sdd], sdd, &pD[j*sdd], &alpha, &pC[j*ps+i*sdc], sdc, &pD[j*ps+i*sdd], sdd, &pD[j*ps+j*sdd], &dD[j]);
+			}
+		if(j<n)
+			{
+			if(j<i) // dtrsm
+				{
+				kernel_dtrsm_nt_rl_inv_24x8_vs_lib8(j, &pD[i*sdd], sdd, &pD[j*sdd], &alpha, &pC[j*ps+i*sdc], sdc, &pD[j*ps+i*sdd], sdd, &pD[j*ps+j*sdd], &dD[j], m-i, n-j);
+				}
+			else // dpptrf
+				{
+				if(j<n-23)
+					{
+					kernel_dpotrf_nt_l_24x8_lib8(j, &pD[i*sdd], sdd, &pD[j*sdd], &pC[j*ps+j*sdc], sdc, &pD[j*ps+j*sdd], sdd, &dD[j]);
+#if 0 // TODO ???
+					kernel_dpotrf_nt_l_16x16_lib8(j+8, &pD[(i+8)*sdd], sdd, &pD[(j+8)*sdd], sdd, &pC[(j+8)*ps+(i+8)*sdc], sdc, &pD[(j+8)*ps+(i+8)*sdd], sdd, &dD[j+8]);
+#else
+					kernel_dpotrf_nt_l_16x8_lib8(j+8, &pD[(i+8)*sdd], sdd, &pD[(j+8)*sdd], &pC[(j+8)*ps+(i+8)*sdc], sdc, &pD[(j+8)*ps+(i+8)*sdd], sdd, &dD[j+8]);
+					kernel_dpotrf_nt_l_8x8_lib8(j+16, &pD[(i+16)*sdd], &pD[(j+16)*sdd], &pC[(j+16)*ps+(i+16)*sdc], &pD[(j+16)*ps+(i+16)*sdd], &dD[j+16]);
+#endif
+					}
+				else
+					{
+					kernel_dpotrf_nt_l_24x8_vs_lib8(j, &pD[i*sdd], sdd, &pD[j*sdd], &pC[j*ps+j*sdc], sdc, &pD[j*ps+j*sdd], sdd, &dD[j], m-i, n-j);
+					if(j<n-8)
+						{
+						kernel_dpotrf_nt_l_16x8_vs_lib8(j+8, &pD[(i+8)*sdd], sdd, &pD[(j+8)*sdd], &pC[(j+8)*ps+(i+8)*sdc], sdc, &pD[(j+8)*ps+(i+8)*sdd], sdd, &dD[j+8], m-i-8, n-j-8);
+						if(j<n-16)
+							{
+							kernel_dpotrf_nt_l_8x8_vs_lib8(j+16, &pD[(i+16)*sdd], &pD[(j+16)*sdd], &pC[(j+16)*ps+(i+16)*sdc], &pD[(j+16)*ps+(i+16)*sdd], &dD[j+16], m-i-16, n-j-16);
+							}
+						}
+					}
+				}
+			}
+		}
+	if(m>i)
+		{
+		if(m-i<=8)
+			{
+			goto left_8;
+			}
+		else if(m-i<=16)
+			{
+			goto left_16;
+			}
+		else
+			{
+			goto left_24;
+			}
+		}
+#elif 0
 	for(; i<m-15; i+=16)
 		{
 		j = 0;
@@ -335,6 +403,26 @@ void blasfeo_hp_dpotrf_l_mn(int m, int n, struct blasfeo_dmat *sC, int ci, int c
 	return;
 
 	// clean up loops definitions
+
+	left_24:
+	j = 0;
+	for(; j<i & j<n; j+=8)
+		{
+		kernel_dtrsm_nt_rl_inv_24x8_vs_lib8(j, &pD[i*sdd], sdd, &pD[j*sdd], &alpha, &pC[j*ps+i*sdc], sdc, &pD[j*ps+i*sdd], sdd, &pD[j*ps+j*sdd], &dD[j], m-i, n-j);
+		}
+	if(j<n)
+		{
+		kernel_dpotrf_nt_l_24x8_vs_lib8(j, &pD[i*sdd], sdd, &pD[j*sdd], &pC[j*ps+j*sdc], sdc, &pD[j*ps+j*sdd], sdd, &dD[j], m-i, n-j);
+		if(j<n-8)
+			{
+			kernel_dpotrf_nt_l_16x8_vs_lib8(j+8, &pD[(i+8)*sdd], sdd, &pD[(j+8)*sdd], &pC[(j+8)*ps+(i+8)*sdc], sdc, &pD[(j+8)*ps+(i+8)*sdd], sdd, &dD[j+8], m-i-8, n-j-8);
+			if(j<n-16)
+				{
+				kernel_dpotrf_nt_l_8x8_vs_lib8(j+16, &pD[(i+16)*sdd], &pD[(j+16)*sdd], &pC[(j+16)*ps+(i+16)*sdc], &pD[(j+16)*ps+(i+16)*sdd], &dD[j+16], m-i-16, n-j-16);
+				}
+			}
+		}
+	return;
 
 	left_16:
 	j = 0;
@@ -444,6 +532,37 @@ void blasfeo_hp_dsyrk_dpotrf_ln(int m, int k, struct blasfeo_dmat *sA, int ai, i
 	i = 0;
 
 #if 1
+	for(; i<m-23; i+=24)
+		{
+		j = 0;
+		for(; j<i; j+=8)
+			{
+			kernel_dgemm_dtrsm_nt_rl_inv_24x8_lib8(k, &pA[i*sda], sda, &pB[j*sdb], j, &pD[i*sdd], sdd, &pD[j*sdd], &pC[j*ps+i*sdc], sdc, &pD[j*ps+i*sdd], sdd, &pD[j*ps+j*sdd], &dD[j]);
+			}
+		kernel_dsyrk_dpotrf_nt_l_24x8_lib8(k, &pA[i*sda], sda, &pB[j*sdb], j, &pD[i*sdd], sdd, &pD[j*sdd], &pC[j*ps+j*sdc], sdc, &pD[j*ps+j*sdd], sdd, &dD[j]);
+#if 0
+		kernel_dsyrk_dpotrf_nt_l_16x16_lib8(k, &pA[(i+8)*sda], sda, &pB[(j+8)*sdb], sdb, j+8, &pD[(i+8)*sdd], sdd, &pD[(j+8)*sdd], sdd, &pC[(j+8)*ps+(i+8)*sdc], sdc, &pD[(j+8)*ps+(i+8)*sdd], sdd, &dD[j+8]);
+#else
+		kernel_dsyrk_dpotrf_nt_l_16x8_lib8(k, &pA[(i+8)*sda], sda, &pB[(j+8)*sdb], j+8, &pD[(i+8)*sdd], sdd, &pD[(j+8)*sdd], &pC[(j+8)*ps+(i+8)*sdc], sdc, &pD[(j+8)*ps+(i+8)*sdd], sdd, &dD[j+8]);
+		kernel_dsyrk_dpotrf_nt_l_8x8_lib8(k, &pA[(i+16)*sda], &pB[(j+16)*sdb], j+16, &pD[(i+16)*sdd], &pD[(j+16)*sdd], &pC[(j+16)*ps+(i+16)*sdc], &pD[(j+16)*ps+(i+16)*sdd], &dD[j+16]);
+#endif
+		}
+	if(m>i)
+		{
+		if(m-i<=8)
+			{
+			goto left_8;
+			}
+		else if(m-i<=16)
+			{
+			goto left_16;
+			}
+		else
+			{
+			goto left_24;
+			}
+		}
+#elif 0
 	for(; i<m-15; i+=16)
 		{
 		j = 0;
@@ -485,6 +604,21 @@ void blasfeo_hp_dsyrk_dpotrf_ln(int m, int k, struct blasfeo_dmat *sA, int ai, i
 	return;
 
 	// clean up loops definitions
+
+	left_24:
+	j = 0;
+	for(; j<i; j+=8)
+		{
+		kernel_dgemm_dtrsm_nt_rl_inv_24x8_vs_lib8(k, &pA[i*sda], sda, &pB[j*sdb], j, &pD[i*sdd], sdd, &pD[j*sdd], &pC[j*ps+i*sdc], sdc, &pD[j*ps+i*sdd], sdd, &pD[j*ps+j*sdd], &dD[j], m-i, m-j);
+		}
+	kernel_dsyrk_dpotrf_nt_l_24x8_vs_lib8(k, &pA[i*sda], sda, &pB[j*sdb], j, &pD[i*sdd], sdd, &pD[j*sdd], &pC[j*ps+j*sdc], sdc, &pD[j*ps+j*sdd], sdd, &dD[j], m-i, m-j);
+#if 0
+	kernel_dsyrk_dpotrf_nt_l_16x16_vs_lib8(k, &pA[(i+8)*sda], sda, &pB[(j+8)*sdb], sdb, j+8, &pD[(i+8)*sdd], sdd, &pD[(j+8)*sdd], sdd, &pC[(j+8)*ps+(i+8)*sdc], sdc, &pD[(j+8)*ps+(i+8)*sdd], sdd, &dD[j+8], m-i-8, m-j-8);
+#else
+	kernel_dsyrk_dpotrf_nt_l_16x8_vs_lib8(k, &pA[(i+8)*sda], sda, &pB[(j+8)*sdb], j+8, &pD[(i+8)*sdd], sdd, &pD[(j+8)*sdd], &pC[(j+8)*ps+(i+8)*sdc], sdc, &pD[(j+8)*ps+(i+8)*sdd], sdd, &dD[j+8], m-i-8, m-j-8);
+	kernel_dsyrk_dpotrf_nt_l_8x8_vs_lib8(k, &pA[(i+16)*sda], &pB[(j+16)*sdb], j+16, &pD[(i+16)*sdd], &pD[(j+16)*sdd], &pC[(j+16)*ps+(i+16)*sdc], &pD[(j+16)*ps+(i+16)*sdd], &dD[j+16], m-i-16, m-j-16);
+#endif
+	return;
 
 	left_16:
 	j = 0;
@@ -581,6 +715,62 @@ void blasfeo_hp_dsyrk_dpotrf_ln_mn(int m, int n, int k, struct blasfeo_dmat *sA,
 	i = 0;
 
 #if 1
+	for(; i<m-23; i+=24)
+		{
+		j = 0;
+		for(; j<i & j<n-7; j+=8)
+			{
+			kernel_dgemm_dtrsm_nt_rl_inv_24x8_lib8(k, &pA[i*sda], sda, &pB[j*sdb], j, &pD[i*sdd], sdd, &pD[j*sdd], &pC[j*ps+i*sdc], sdc, &pD[j*ps+i*sdd], sdd, &pD[j*ps+j*sdd], &dD[j]);
+			}
+		if(j<n)
+			{
+			if(j<i) // dgemm
+				{
+				kernel_dgemm_dtrsm_nt_rl_inv_24x8_vs_lib8(k, &pA[i*sda], sda, &pB[j*sdb], j, &pD[i*sdd], sdd, &pD[j*sdd], &pC[j*ps+i*sdc], sdc, &pD[j*ps+i*sdd], sdd, &pD[j*ps+j*sdd], &dD[j], m-i, n-j);
+				}
+			else // dsyrk
+				{
+				if(j<n-23)
+					{
+					kernel_dsyrk_dpotrf_nt_l_24x8_lib8(k, &pA[i*sda], sda, &pB[j*sdb], j, &pD[i*sdd], sdd, &pD[j*sdd], &pC[j*ps+j*sdc], sdc, &pD[j*ps+j*sdd], sdd, &dD[j]);
+#if 0
+					kernel_dsyrk_dpotrf_nt_l_16x16_lib8(k, &pA[(i+8)*sda], sda, &pB[(j+8)*sdb], sdb, j+8, &pD[(i+8)*sdd], sdd, &pD[(j+8)*sdd], sdd, &pC[(j+8)*ps+(i+8)*sdc], sdc, &pD[(j+8)*ps+(i+8)*sdd], sdd, &dD[j+8]);
+#else
+					kernel_dsyrk_dpotrf_nt_l_16x8_lib8(k, &pA[(i+8)*sda], sda, &pB[(j+8)*sdb], j+8, &pD[(i+8)*sdd], sdd, &pD[(j+8)*sdd], &pC[(j+8)*ps+(i+8)*sdc], sdc, &pD[(j+8)*ps+(i+8)*sdd], sdd, &dD[j+8]);
+					kernel_dsyrk_dpotrf_nt_l_8x8_lib8(k, &pA[(i+16)*sda], &pB[(j+16)*sdb], j+16, &pD[(i+16)*sdd], &pD[(j+16)*sdd], &pC[(j+16)*ps+(i+16)*sdc], &pD[(j+16)*ps+(i+16)*sdd], &dD[j+16]);
+#endif
+					}
+				else
+					{
+					kernel_dsyrk_dpotrf_nt_l_24x8_vs_lib8(k, &pA[i*sda], sda, &pB[j*sdb], j, &pD[i*sdd], sdd, &pD[j*sdd], &pC[j*ps+j*sdc], sdc, &pD[j*ps+j*sdd], sdd, &dD[j], m-i, n-j);
+					if(j<n-8)
+						{
+						kernel_dsyrk_dpotrf_nt_l_16x8_vs_lib8(k, &pA[(i+8)*sda], sda, &pB[(j+8)*sdb], j+8, &pD[(i+8)*sdd], sdd, &pD[(j+8)*sdd], &pC[(j+8)*ps+(i+8)*sdc], sdc, &pD[(j+8)*ps+(i+8)*sdd], sdd, &dD[j+8], m-i-8, n-j-8);
+						if(j<n-16)
+							{
+							kernel_dsyrk_dpotrf_nt_l_8x8_vs_lib8(k, &pA[(i+16)*sda], &pB[(j+16)*sdb], j+16, &pD[(i+16)*sdd], &pD[(j+16)*sdd], &pC[(j+16)*ps+(i+16)*sdc], &pD[(j+16)*ps+(i+16)*sdd], &dD[j+16], m-i-16, n-j-16);
+							}
+						}
+					}
+				}
+			}
+		}
+	if(m>i)
+		{
+		if(m-i<=8)
+			{
+			goto left_8;
+			}
+		else if(m-i<=16)
+			{
+			goto left_16;
+			}
+		else
+			{
+			goto left_24;
+			}
+		}
+#elif 0
 	for(; i<m-15; i+=16)
 		{
 		j = 0;
@@ -661,6 +851,26 @@ void blasfeo_hp_dsyrk_dpotrf_ln_mn(int m, int n, int k, struct blasfeo_dmat *sA,
 	return;
 
 	// clean up loops definitions
+
+	left_24:
+	j = 0;
+	for(; j<i & j<n; j+=8)
+		{
+		kernel_dgemm_dtrsm_nt_rl_inv_24x8_vs_lib8(k, &pA[i*sda], sda, &pB[j*sdb], j, &pD[i*sdd], sdd, &pD[j*sdd], &pC[j*ps+i*sdc], sdc, &pD[j*ps+i*sdd], sdd, &pD[j*ps+j*sdd], &dD[j], m-i, n-j);
+		}
+	if(j<n)
+		{
+		kernel_dsyrk_dpotrf_nt_l_24x8_vs_lib8(k, &pA[i*sda], sda, &pB[j*sdb], j, &pD[i*sdd], sdd, &pD[j*sdd], &pC[j*ps+j*sdc], sdc, &pD[j*ps+j*sdd], sdd, &dD[j], m-i, n-j);
+		if(j<n-8)
+			{
+			kernel_dsyrk_dpotrf_nt_l_16x8_vs_lib8(k, &pA[(i+8)*sda], sda, &pB[(j+8)*sdb], j+8, &pD[(i+8)*sdd], sdd, &pD[(j+8)*sdd], &pC[(j+8)*ps+(i+8)*sdc], sdc, &pD[(j+8)*ps+(i+8)*sdd], sdd, &dD[j+8], m-i-8, n-j-8);
+			if(j<n-16)
+				{
+				kernel_dsyrk_dpotrf_nt_l_8x8_vs_lib8(k, &pA[(i+16)*sda], &pB[(j+16)*sdb], j+16, &pD[(i+16)*sdd], &pD[(j+16)*sdd], &pC[(j+16)*ps+(i+16)*sdc], &pD[(j+16)*ps+(i+16)*sdd], &dD[j+16], m-i-16, n-j-16);
+				}
+			}
+		}
+	return;
 
 	left_16:
 	j = 0;

--- a/blasfeo_hp_pm/d_lapack_lib8.c
+++ b/blasfeo_hp_pm/d_lapack_lib8.c
@@ -1407,10 +1407,10 @@ void blasfeo_hp_dgelqf_pd_lla(int m, int n1, struct blasfeo_dmat *sD, int di, in
 	ii = 0;
 	for(ii=0; ii<imax-8; ii+=8)
 		{
-		kernel_dgelqf_pd_lla_vs_lib8(8, imax0+ii, n1, 8, 0, pD+ii*sdd+ii*ps, sdd, dD+ii, 0, pL+ii*sdl+0*ps, sdl, 0, pA+ii*sda+0*ps, sda);
+//		kernel_dgelqf_pd_lla_vs_lib8(8, imax0+ii, n1, 8, 0, pD+ii*sdd+ii*ps, sdd, dD+ii, 0, pL+ii*sdl+0*ps, sdl, 0, pA+ii*sda+0*ps, sda);
 //		kernel_dgelqf_pd_lla_8_lib8(n-ii, pD+ii*sdd+ii*ps, dD+ii);
-		kernel_dlarft_lla_8_lib8(imax0+ii, n1, dD+ii, pL+ii*sdl+0*ps, pA+ii*sda+0*ps, pT);
-//		kernel_dgelqf_pd_lla_dlarft8_8_lib8(n-ii, pD+ii*sdd+ii*ps, dD+ii, pT);
+//		kernel_dlarft_lla_8_lib8(imax0+ii, n1, dD+ii, pL+ii*sdl+0*ps, pA+ii*sda+0*ps, pT);
+		kernel_dgelqf_pd_lla_dlarft8_8_lib8(imax0+ii, n1, pD+ii*sdd+ii*ps, dD+ii, pL+ii*sdl+0*ps, pA+ii*sda+0*ps, pT);
 		jj = ii+8;
 //d_print_mat(1, 8, dD+ii, 1);
 //d_print_mat(8, 8, pT, 8);

--- a/blasfeo_hp_pm/d_lapack_lib8.c
+++ b/blasfeo_hp_pm/d_lapack_lib8.c
@@ -1013,12 +1013,12 @@ void blasfeo_hp_dgelqf_pd_la(int m, int n1, struct blasfeo_dmat *sD, int di, int
 #endif
 		}
 	// same block alignment
-#if 1
+#if 0
 	kernel_dgelqf_pd_la_vs_lib8(m, n1, imax, dir, pD, sdd, dD, air, pA, sda);
 #else
 	if(imax0>0)
 		{
-		kernel_dgelqf_pd_la_vs_lib4(m, n1, imax0, di&(ps-1), pD, sdd, dD, ai&(ps-1), pA, sda);
+		kernel_dgelqf_pd_la_vs_lib8(m, n1, imax0, dir, pD, sdd, dD, air, pA, sda);
 		pD += imax0-ps+ps*sdd+imax0*ps;
 		dD += imax0;
 		pA += imax0-ps+ps*sda+0*ps;
@@ -1026,37 +1026,40 @@ void blasfeo_hp_dgelqf_pd_la(int m, int n1, struct blasfeo_dmat *sD, int di, int
 		imax -= imax0;
 		}
 	ii = 0;
-	for(ii=0; ii<imax-4; ii+=4)
+	for(ii=0; ii<imax-8; ii+=8)
 		{
-		kernel_dgelqf_pd_la_vs_lib4(4, n1, 4, 0, pD+ii*sdd+ii*ps, sdd, dD+ii, 0, pA+ii*sda+0*ps, sda);
-//		kernel_dgelqf_4_lib4(n-ii, pD+ii*sdd+ii*ps, dD+ii);
-		kernel_dlarft_4_la_lib4(n1, dD+ii, pA+ii*sda+0*ps, pT);
-//		kernel_dgelqf_pd_dlarft4_4_lib4(n-ii, pD+ii*sdd+ii*ps, dD+ii, pT);
-		jj = ii+4;
+		kernel_dgelqf_pd_la_vs_lib8(8, n1, 8, 0, pD+ii*sdd+ii*ps, sdd, dD+ii, 0, pA+ii*sda+0*ps, sda);
+//		kernel_dgelqf_pd_la_8_lib8(n-ii, pD+ii*sdd+ii*ps, dD+ii);
+		kernel_dlarft_la_8_lib8(n1, dD+ii, pA+ii*sda+0*ps, pT);
+//		kernel_dgelqf_pd_la_dlarft8_8_lib8(n-ii, pD+ii*sdd+ii*ps, dD+ii, pT);
+		jj = ii+8;
+//d_print_mat(1, 8, dD+ii, 1);
+//d_print_mat(8, 8, pT, 8);
+//return;
 #if 0
-		for(; jj<m-7; jj+=8)
+		for(; jj<m-15; jj+=16)
 			{
-			kernel_dlarfb4_rn_8_la_lib4(n1, pA+ii*sda+0*ps, pT, pD+jj*sdd+ii*ps, sdd, pA+jj*sda+0*ps, sda);
+			kernel_dlarfb8_rn_la_16_lib8(n1, pA+ii*sda+0*ps, pT, pD+jj*sdd+ii*ps, sdd, pA+jj*sda+0*ps, sda);
 			}
 #endif
-		for(; jj<m-3; jj+=4)
+		for(; jj<m-7; jj+=8)
 			{
-			kernel_dlarfb4_rn_4_la_lib4(n1, pA+ii*sda+0*ps, pT, pD+jj*sdd+ii*ps, pA+jj*sda+0*ps);
+			kernel_dlarfb8_rn_la_8_lib8(n1, pA+ii*sda+0*ps, pT, pD+jj*sdd+ii*ps, pA+jj*sda+0*ps);
 			}
 		for(ll=0; ll<m-jj; ll++)
 			{
-			kernel_dlarfb4_rn_1_la_lib4(n1, pA+ii*sda+0*ps, pT, pD+ll+jj*sdd+ii*ps, pA+ll+jj*sda+0*ps);
+			kernel_dlarfb8_rn_la_1_lib8(n1, pA+ii*sda+0*ps, pT, pD+ll+jj*sdd+ii*ps, pA+ll+jj*sda+0*ps);
 			}
 		}
 	if(ii<imax)
 		{
-//		if(ii==imax-4)
+//		if(ii==imax-8)
 //			{
-//			kernel_dgelqf_pd_4_lib4(n-ii, pD+ii*sdd+ii*ps, dD+ii);
+//			kernel_dgelqf_pd_la_8_lib8(n-ii, pD+ii*sdd+ii*ps, dD+ii);
 //			}
 //		else
 //			{
-			kernel_dgelqf_pd_la_vs_lib4(m-ii, n1, imax-ii, 0, pD+ii*sdd+ii*ps, sdd, dD+ii, 0, pA+ii*sda+0*ps, sda);
+			kernel_dgelqf_pd_la_vs_lib8(m-ii, n1, imax-ii, 0, pD+ii*sdd+ii*ps, sdd, dD+ii, 0, pA+ii*sda+0*ps, sda);
 //			}
 		}
 #endif
@@ -1138,7 +1141,7 @@ void blasfeo_hp_dgelqf_pd_lla(int m, int n1, struct blasfeo_dmat *sD, int di, in
 #else
 	if(imax0>0)
 		{
-		kernel_dgelqf_pd_lla_vs_lib4(m, 0, n1, imax0, dir, pD, sdd, dD, lir, pL, sdl, air, pA, sda);
+		kernel_dgelqf_pd_lla_vs_lib8(m, 0, n1, imax0, dir, pD, sdd, dD, lir, pL, sdl, air, pA, sda);
 		pD += imax0-ps+ps*sdd+imax0*ps;
 		dD += imax0;
 		pA += imax0-ps+ps*sda+0*ps;
@@ -1147,12 +1150,12 @@ void blasfeo_hp_dgelqf_pd_lla(int m, int n1, struct blasfeo_dmat *sD, int di, in
 		imax -= imax0;
 		}
 	ii = 0;
-	for(ii=0; ii<imax-4; ii+=4)
+	for(ii=0; ii<imax-8; ii+=8)
 		{
-		kernel_dgelqf_pd_lla_vs_lib4(4, imax0+ii, n1, 4, 0, pD+ii*sdd+ii*ps, sdd, dD+ii, 0, pL+ii*sdl+0*ps, sdl, 0, pA+ii*sda+0*ps, sda);
-//		kernel_dgelqf_4_lib4(n-ii, pD+ii*sdd+ii*ps, dD+ii);
-		kernel_dlarft_4_lla_lib4(imax0+ii, n1, dD+ii, pL+ii*sdl+0*ps, pA+ii*sda+0*ps, pT);
-//		kernel_dgelqf_pd_dlarft4_4_lib4(n-ii, pD+ii*sdd+ii*ps, dD+ii, pT);
+		kernel_dgelqf_pd_lla_vs_lib8(4, imax0+ii, n1, 4, 0, pD+ii*sdd+ii*ps, sdd, dD+ii, 0, pL+ii*sdl+0*ps, sdl, 0, pA+ii*sda+0*ps, sda);
+//		kernel_dgelqf_pd_lla_8_lib8(n-ii, pD+ii*sdd+ii*ps, dD+ii);
+		kernel_dlarft_lla_8_lib8(imax0+ii, n1, dD+ii, pL+ii*sdl+0*ps, pA+ii*sda+0*ps, pT);
+//		kernel_dgelqf_pd_lla_dlarft8_8_lib8(n-ii, pD+ii*sdd+ii*ps, dD+ii, pT);
 		jj = ii+4;
 #if 0
 		for(; jj<m-7; jj+=8)

--- a/blasfeo_hp_pm/d_lapack_lib8.c
+++ b/blasfeo_hp_pm/d_lapack_lib8.c
@@ -1136,7 +1136,7 @@ void blasfeo_hp_dgelqf_pd_lla(int m, int n1, struct blasfeo_dmat *sD, int di, in
 #endif
 		}
 	// same block alignment
-#if 1
+#if 0
 	kernel_dgelqf_pd_lla_vs_lib8(m, 0, n1, imax, dir, pD, sdd, dD, lir, pL, sdl, air, pA, sda);
 #else
 	if(imax0>0)
@@ -1152,35 +1152,38 @@ void blasfeo_hp_dgelqf_pd_lla(int m, int n1, struct blasfeo_dmat *sD, int di, in
 	ii = 0;
 	for(ii=0; ii<imax-8; ii+=8)
 		{
-		kernel_dgelqf_pd_lla_vs_lib8(4, imax0+ii, n1, 4, 0, pD+ii*sdd+ii*ps, sdd, dD+ii, 0, pL+ii*sdl+0*ps, sdl, 0, pA+ii*sda+0*ps, sda);
+		kernel_dgelqf_pd_lla_vs_lib8(8, imax0+ii, n1, 8, 0, pD+ii*sdd+ii*ps, sdd, dD+ii, 0, pL+ii*sdl+0*ps, sdl, 0, pA+ii*sda+0*ps, sda);
 //		kernel_dgelqf_pd_lla_8_lib8(n-ii, pD+ii*sdd+ii*ps, dD+ii);
 		kernel_dlarft_lla_8_lib8(imax0+ii, n1, dD+ii, pL+ii*sdl+0*ps, pA+ii*sda+0*ps, pT);
 //		kernel_dgelqf_pd_lla_dlarft8_8_lib8(n-ii, pD+ii*sdd+ii*ps, dD+ii, pT);
-		jj = ii+4;
+		jj = ii+8;
+//d_print_mat(1, 8, dD+ii, 1);
+//d_print_mat(8, 8, pT, 8);
+//return;
 #if 0
-		for(; jj<m-7; jj+=8)
+		for(; jj<m-15; jj+=16)
 			{
-			kernel_dlarfb4_rn_8_lla_lib4(imax0+ii, n1, pL+ii*sdl+0*ps, pA+ii*sda+0*ps, pT, pD+jj*sdd+ii*ps, sdd, pL+jj*sdl+0*ps, sdl, pA+jj*sda+0*ps, sda);
+			kernel_dlarfb8_rn_16_lla_lib8(imax0+ii, n1, pL+ii*sdl+0*ps, pA+ii*sda+0*ps, pT, pD+jj*sdd+ii*ps, sdd, pL+jj*sdl+0*ps, sdl, pA+jj*sda+0*ps, sda);
 			}
 #endif
-		for(; jj<m-3; jj+=4)
+		for(; jj<m-7; jj+=8)
 			{
-			kernel_dlarfb4_rn_4_lla_lib4(imax0+ii, n1, pL+ii*sdl+0*ps, pA+ii*sda+0*ps, pT, pD+jj*sdd+ii*ps, pL+jj*sdl+0*ps, pA+jj*sda+0*ps);
+			kernel_dlarfb8_rn_lla_8_lib8(imax0+ii, n1, pL+ii*sdl+0*ps, pA+ii*sda+0*ps, pT, pD+jj*sdd+ii*ps, pL+jj*sdl+0*ps, pA+jj*sda+0*ps);
 			}
 		for(ll=0; ll<m-jj; ll++)
 			{
-			kernel_dlarfb4_rn_1_lla_lib4(imax0+ii, n1, pL+ii*sdl+0*ps, pA+ii*sda+0*ps, pT, pD+ll+jj*sdd+ii*ps, pL+ll+jj*sdl+0*ps, pA+ll+jj*sda+0*ps);
+			kernel_dlarfb8_rn_lla_1_lib8(imax0+ii, n1, pL+ii*sdl+0*ps, pA+ii*sda+0*ps, pT, pD+ll+jj*sdd+ii*ps, pL+ll+jj*sdl+0*ps, pA+ll+jj*sda+0*ps);
 			}
 		}
 	if(ii<imax)
 		{
-//		if(ii==imax-4)
+//		if(ii==imax-8)
 //			{
-//			kernel_dgelqf_pd_4_lib4(n-ii, pD+ii*sdd+ii*ps, dD+ii);
+//			kernel_dgelqf_pd_8_lib8(n-ii, pD+ii*sdd+ii*ps, dD+ii);
 //			}
 //		else
 //			{
-			kernel_dgelqf_pd_lla_vs_lib4(m-ii, imax0+ii, n1, imax-ii, 0, pD+ii*sdd+ii*ps, sdd, dD+ii, 0, pL+ii*sdl+0*ps, sdl, 0, pA+ii*sda+0*ps, sda);
+			kernel_dgelqf_pd_lla_vs_lib8(m-ii, imax0+ii, n1, imax-ii, 0, pD+ii*sdd+ii*ps, sdd, dD+ii, 0, pL+ii*sdl+0*ps, sdl, 0, pA+ii*sda+0*ps, sda);
 //			}
 		}
 #endif

--- a/blasfeo_hp_pm/d_lapack_lib8.c
+++ b/blasfeo_hp_pm/d_lapack_lib8.c
@@ -1036,7 +1036,7 @@ void blasfeo_hp_dgelqf_pd_la(int m, int n1, struct blasfeo_dmat *sD, int di, int
 //d_print_mat(1, 8, dD+ii, 1);
 //d_print_mat(8, 8, pT, 8);
 //return;
-#if 0
+#if 1
 		for(; jj<m-15; jj+=16)
 			{
 			kernel_dlarfb8_rn_la_16_lib8(n1, pA+ii*sda+0*ps, pT, pD+jj*sdd+ii*ps, sdd, pA+jj*sda+0*ps, sda);

--- a/blasfeo_hp_pm/d_lapack_lib8.c
+++ b/blasfeo_hp_pm/d_lapack_lib8.c
@@ -1178,6 +1178,7 @@ void blasfeo_hp_dgelqf_pd(int m, int n, struct blasfeo_dmat *sC, int ci, int cj,
 		jj = ii+8;
 //d_print_mat(1, 8, dD+ii, 1);
 //d_print_mat(8, 8, pT, 8);
+//return;
 #if 1
 		for(; jj<m-15; jj+=16)
 			{
@@ -1282,10 +1283,10 @@ void blasfeo_hp_dgelqf_pd_la(int m, int n1, struct blasfeo_dmat *sD, int di, int
 	ii = 0;
 	for(ii=0; ii<imax-8; ii+=8)
 		{
-		kernel_dgelqf_pd_la_vs_lib8(8, n1, 8, 0, pD+ii*sdd+ii*ps, sdd, dD+ii, 0, pA+ii*sda+0*ps, sda);
+//		kernel_dgelqf_pd_la_vs_lib8(8, n1, 8, 0, pD+ii*sdd+ii*ps, sdd, dD+ii, 0, pA+ii*sda+0*ps, sda);
 //		kernel_dgelqf_pd_la_8_lib8(n-ii, pD+ii*sdd+ii*ps, dD+ii);
-		kernel_dlarft_la_8_lib8(n1, dD+ii, pA+ii*sda+0*ps, pT);
-//		kernel_dgelqf_pd_la_dlarft8_8_lib8(n-ii, pD+ii*sdd+ii*ps, dD+ii, pT);
+//		kernel_dlarft_la_8_lib8(n1, dD+ii, pA+ii*sda+0*ps, pT);
+		kernel_dgelqf_pd_la_dlarft8_8_lib8(n1, pD+ii*sdd+ii*ps, dD+ii, pA+ii*sda+0*ps, pT);
 		jj = ii+8;
 //d_print_mat(1, 8, dD+ii, 1);
 //d_print_mat(8, 8, pT, 8);

--- a/blasfeo_hp_pm/d_lapack_lib8.c
+++ b/blasfeo_hp_pm/d_lapack_lib8.c
@@ -1160,10 +1160,10 @@ void blasfeo_hp_dgelqf_pd_lla(int m, int n1, struct blasfeo_dmat *sD, int di, in
 //d_print_mat(1, 8, dD+ii, 1);
 //d_print_mat(8, 8, pT, 8);
 //return;
-#if 0
+#if 1
 		for(; jj<m-15; jj+=16)
 			{
-			kernel_dlarfb8_rn_16_lla_lib8(imax0+ii, n1, pL+ii*sdl+0*ps, pA+ii*sda+0*ps, pT, pD+jj*sdd+ii*ps, sdd, pL+jj*sdl+0*ps, sdl, pA+jj*sda+0*ps, sda);
+			kernel_dlarfb8_rn_lla_16_lib8(imax0+ii, n1, pL+ii*sdl+0*ps, pA+ii*sda+0*ps, pT, pD+jj*sdd+ii*ps, sdd, pL+jj*sdl+0*ps, sdl, pA+jj*sda+0*ps, sda);
 			}
 #endif
 		for(; jj<m-7; jj+=8)

--- a/blasfeo_hp_pm/d_lapack_lib8.c
+++ b/blasfeo_hp_pm/d_lapack_lib8.c
@@ -279,12 +279,16 @@ void blasfeo_hp_dpotrf_l_mn(int m, int n, struct blasfeo_dmat *sC, int ci, int c
 			if(j<i) // dtrsm
 				{
 				kernel_dtrsm_nt_rl_inv_24x8_vs_lib8(j, &pD[i*sdd], sdd, &pD[j*sdd], &alpha, &pC[j*ps+i*sdc], sdc, &pD[j*ps+i*sdd], sdd, &pD[j*ps+j*sdd], &dD[j], m-i, n-j);
+//				kernel_dtrsm_nt_rl_inv_16x8_vs_lib8(j, &pD[i*sdd], sdd, &pD[j*sdd], &alpha, &pC[j*ps+i*sdc], sdc, &pD[j*ps+i*sdd], sdd, &pD[j*ps+j*sdd], &dD[j], m-i, n-j);
+//				kernel_dtrsm_nt_rl_inv_8x8_vs_lib8(j, &pD[(i+16)*sdd], &pD[j*sdd], &alpha, &pC[j*ps+(i+16)*sdc], &pD[j*ps+(i+16)*sdd], &pD[j*ps+j*sdd], &dD[j], m-(i+16), n-j);
 				}
-			else // dpptrf
+			else // dpotrf
 				{
 				if(j<n-23)
 					{
 					kernel_dpotrf_nt_l_24x8_lib8(j, &pD[i*sdd], sdd, &pD[j*sdd], &pC[j*ps+j*sdc], sdc, &pD[j*ps+j*sdd], sdd, &dD[j]);
+//					kernel_dpotrf_nt_l_16x8_lib8(j, &pD[i*sdd], sdd, &pD[j*sdd], &pC[j*ps+j*sdc], sdc, &pD[j*ps+j*sdd], sdd, &dD[j]);
+//					kernel_dtrsm_nt_rl_inv_8x8_lib8(j, &pD[(i+16)*sdd], &pD[j*sdd], &alpha, &pC[j*ps+(i+16)*sdc], &pD[j*ps+(i+16)*sdd], &pD[j*ps+j*sdd], &dD[j]);
 #if 0 // TODO ???
 					kernel_dpotrf_nt_l_16x16_lib8(j+8, &pD[(i+8)*sdd], sdd, &pD[(j+8)*sdd], sdd, &pC[(j+8)*ps+(i+8)*sdc], sdc, &pD[(j+8)*ps+(i+8)*sdd], sdd, &dD[j+8]);
 #else
@@ -295,6 +299,8 @@ void blasfeo_hp_dpotrf_l_mn(int m, int n, struct blasfeo_dmat *sC, int ci, int c
 				else
 					{
 					kernel_dpotrf_nt_l_24x8_vs_lib8(j, &pD[i*sdd], sdd, &pD[j*sdd], &pC[j*ps+j*sdc], sdc, &pD[j*ps+j*sdd], sdd, &dD[j], m-i, n-j);
+//					kernel_dpotrf_nt_l_16x8_vs_lib8(j, &pD[i*sdd], sdd, &pD[j*sdd], &pC[j*ps+j*sdc], sdc, &pD[j*ps+j*sdd], sdd, &dD[j], m-i, n-j);
+//					kernel_dtrsm_nt_rl_inv_8x8_vs_lib8(j, &pD[(i+16)*sdd], &pD[j*sdd], &alpha, &pC[j*ps+(i+16)*sdc], &pD[j*ps+(i+16)*sdd], &pD[j*ps+j*sdd], &dD[j], m-i-16, n-j);
 					if(j<n-8)
 						{
 						kernel_dpotrf_nt_l_16x8_vs_lib8(j+8, &pD[(i+8)*sdd], sdd, &pD[(j+8)*sdd], &pC[(j+8)*ps+(i+8)*sdc], sdc, &pD[(j+8)*ps+(i+8)*sdd], sdd, &dD[j+8], m-i-8, n-j-8);
@@ -322,7 +328,7 @@ void blasfeo_hp_dpotrf_l_mn(int m, int n, struct blasfeo_dmat *sC, int ci, int c
 			goto left_24;
 			}
 		}
-#elif 0
+#elif 1
 	for(; i<m-15; i+=16)
 		{
 		j = 0;
@@ -433,7 +439,7 @@ void blasfeo_hp_dpotrf_l_mn(int m, int n, struct blasfeo_dmat *sC, int ci, int c
 	if(j<n)
 		{
 		kernel_dpotrf_nt_l_16x8_vs_lib8(j, &pD[i*sdd], sdd, &pD[j*sdd], &pC[j*ps+j*sdc], sdc, &pD[j*ps+j*sdd], sdd, &dD[j], m-i, n-j);
-		if(j<n-4)
+		if(j<n-8)
 			{
 			kernel_dpotrf_nt_l_8x8_vs_lib8(j+8, &pD[(i+8)*sdd], &pD[(j+8)*sdd], &pC[(j+8)*ps+(i+8)*sdc], &pD[(j+8)*ps+(i+8)*sdd], &dD[j+8], m-i-8, n-j-8);
 			}

--- a/blasfeo_hp_pm/d_lapack_lib8.c
+++ b/blasfeo_hp_pm/d_lapack_lib8.c
@@ -1300,9 +1300,9 @@ void blasfeo_hp_dgelqf_pd_la(int m, int n1, struct blasfeo_dmat *sD, int di, int
 			{
 			kernel_dlarfb8_rn_la_8_lib8(n1, pA+ii*sda+0*ps, pT, pD+jj*sdd+ii*ps, pA+jj*sda+0*ps);
 			}
-		for(ll=0; ll<m-jj; ll++)
+		if(jj<m)
 			{
-			kernel_dlarfb8_rn_la_1_lib8(n1, pA+ii*sda+0*ps, pT, pD+ll+jj*sdd+ii*ps, pA+ll+jj*sda+0*ps);
+			kernel_dlarfb8_rn_la_8_vs_lib8(n1, pA+ii*sda+0*ps, pT, pD+jj*sdd+ii*ps, pA+jj*sda+0*ps, m-jj);
 			}
 		}
 	if(ii<imax)
@@ -1424,9 +1424,9 @@ void blasfeo_hp_dgelqf_pd_lla(int m, int n1, struct blasfeo_dmat *sD, int di, in
 			{
 			kernel_dlarfb8_rn_lla_8_lib8(imax0+ii, n1, pL+ii*sdl+0*ps, pA+ii*sda+0*ps, pT, pD+jj*sdd+ii*ps, pL+jj*sdl+0*ps, pA+jj*sda+0*ps);
 			}
-		for(ll=0; ll<m-jj; ll++)
+		if(jj<m)
 			{
-			kernel_dlarfb8_rn_lla_1_lib8(imax0+ii, n1, pL+ii*sdl+0*ps, pA+ii*sda+0*ps, pT, pD+ll+jj*sdd+ii*ps, pL+ll+jj*sdl+0*ps, pA+ll+jj*sda+0*ps);
+			kernel_dlarfb8_rn_lla_8_vs_lib8(imax0+ii, n1, pL+ii*sdl+0*ps, pA+ii*sda+0*ps, pT, pD+jj*sdd+ii*ps, pL+jj*sdl+0*ps, pA+jj*sda+0*ps, m-jj);
 			}
 		}
 	if(ii<imax)

--- a/blasfeo_hp_pm/d_lapack_lib8.c
+++ b/blasfeo_hp_pm/d_lapack_lib8.c
@@ -793,10 +793,12 @@ void blasfeo_hp_dgelqf(int m, int n, struct blasfeo_dmat *sC, int ci, int cj, st
 	// rank 8 update
 	for(; ii<imax-8; ii+=8)
 		{
-		kernel_dgelqf_vs_lib8(8, n-ii, 8, 0, pD+ii*sdd+ii*ps, sdd, dD+ii);
+//		kernel_dgelqf_vs_lib8(8, n-ii, 8, 0, pD+ii*sdd+ii*ps, sdd, dD+ii);
 //		kernel_dgelqf_4_lib4(n-ii, pD+ii*sdd+ii*ps, dD+ii);
-		kernel_dlarft_8_lib8(n-ii, pD+ii*sdd+ii*ps, dD+ii, pT);
-//		kernel_dgelqf_dlarft4_4_lib4(n-ii, pD+ii*sdd+ii*ps, dD+ii, pT);
+//		kernel_dlarft_8_lib8(n-ii, pD+ii*sdd+ii*ps, dD+ii, pT);
+		kernel_dgelqf_dlarft8_8_lib8(n-ii, pD+ii*sdd+ii*ps, dD+ii, pT);
+//d_print_mat(1, 8, dD+ii, 1);
+//d_print_mat(8, 8, pT, 8);
 		jj = ii+8;
 #if 0
 		for(; jj<m-15; jj+=16)

--- a/blasfeo_hp_pm/d_lapack_lib8.c
+++ b/blasfeo_hp_pm/d_lapack_lib8.c
@@ -895,7 +895,7 @@ void blasfeo_hp_dgelqf_pd(int m, int n, struct blasfeo_dmat *sC, int ci, int cj,
 
 	int ii, jj, ll, imax0;
 	int imax = m<n ? m : n;
-#if 1
+#if 0
 	kernel_dgelqf_pd_vs_lib8(m, n, imax, dir, pD, sdd, dD);
 #else
 	if(dir>0)
@@ -911,37 +911,39 @@ void blasfeo_hp_dgelqf_pd(int m, int n, struct blasfeo_dmat *sC, int ci, int cj,
 		}
 	ii = 0;
 	// rank 8 update
-	for(ii=0; ii<imax-4; ii+=4)
+	for(ii=0; ii<imax-8; ii+=8)
 		{
-//		kernel_dgelqf_vs_lib4(4, n-ii, 4, 0, pD+ii*sdd+ii*ps, sdd, dD+ii);
-//		kernel_dgelqf_4_lib4(n-ii, pD+ii*sdd+ii*ps, dD+ii);
-//		kernel_dlarft_4_lib4(n-ii, pD+ii*sdd+ii*ps, dD+ii, pT);
-		kernel_dgelqf_pd_dlarft4_4_lib4(n-ii, pD+ii*sdd+ii*ps, dD+ii, pT);
-		jj = ii+4;
+//		kernel_dgelqf_pd_vs_lib8(8, n-ii, 8, 0, pD+ii*sdd+ii*ps, sdd, dD+ii);
+//		kernel_dgelqf_pd_8_lib8(n-ii, pD+ii*sdd+ii*ps, dD+ii);
+//		kernel_dlarft_8_lib8(n-ii, pD+ii*sdd+ii*ps, dD+ii, pT);
+		kernel_dgelqf_pd_dlarft8_8_lib8(n-ii, pD+ii*sdd+ii*ps, dD+ii, pT);
+		jj = ii+8;
+//d_print_mat(1, 8, dD+ii, 1);
+//d_print_mat(8, 8, pT, 8);
 #if 0
-		for(; jj<m-7; jj+=8)
+		for(; jj<m-15; jj+=16)
 			{
-			kernel_dlarfb4_rn_8_lib4(n-ii, pD+ii*sdd+ii*ps, pT, pD+jj*sdd+ii*ps, sdd);
+			kernel_dlarfb8_rn_16_lib8(n-ii, pD+ii*sdd+ii*ps, pT, pD+jj*sdd+ii*ps, sdd);
 			}
 #endif
-		for(; jj<m-3; jj+=4)
+		for(; jj<m-7; jj+=8)
 			{
-			kernel_dlarfb4_rn_4_lib4(n-ii, pD+ii*sdd+ii*ps, pT, pD+jj*sdd+ii*ps);
+			kernel_dlarfb8_rn_8_lib8(n-ii, pD+ii*sdd+ii*ps, pT, pD+jj*sdd+ii*ps);
 			}
 		for(ll=0; ll<m-jj; ll++)
 			{
-			kernel_dlarfb4_rn_1_lib4(n-ii, pD+ii*sdd+ii*ps, pT, pD+ll+jj*sdd+ii*ps);
+			kernel_dlarfb8_rn_1_lib8(n-ii, pD+ii*sdd+ii*ps, pT, pD+ll+jj*sdd+ii*ps);
 			}
 		}
 	if(ii<imax)
 		{
-		if(ii==imax-4)
+		if(ii==imax-8)
 			{
-			kernel_dgelqf_pd_4_lib4(n-ii, pD+ii*sdd+ii*ps, dD+ii);
+			kernel_dgelqf_pd_8_lib8(n-ii, pD+ii*sdd+ii*ps, dD+ii);
 			}
 		else
 			{
-			kernel_dgelqf_pd_vs_lib4(m-ii, n-ii, imax-ii, ii&(ps-1), pD+ii*sdd+ii*ps, sdd, dD+ii);
+			kernel_dgelqf_pd_vs_lib8(m-ii, n-ii, imax-ii, ii&(ps-1), pD+ii*sdd+ii*ps, sdd, dD+ii);
 			}
 		}
 #endif

--- a/blasfeo_hp_pm/d_lapack_lib8.c
+++ b/blasfeo_hp_pm/d_lapack_lib8.c
@@ -794,7 +794,7 @@ void blasfeo_hp_dgelqf(int m, int n, struct blasfeo_dmat *sC, int ci, int cj, st
 	for(; ii<imax-8; ii+=8)
 		{
 //		kernel_dgelqf_vs_lib8(8, n-ii, 8, 0, pD+ii*sdd+ii*ps, sdd, dD+ii);
-//		kernel_dgelqf_4_lib4(n-ii, pD+ii*sdd+ii*ps, dD+ii);
+//		kernel_dgelqf_8_lib8(n-ii, pD+ii*sdd+ii*ps, dD+ii);
 //		kernel_dlarft_8_lib8(n-ii, pD+ii*sdd+ii*ps, dD+ii, pT);
 		kernel_dgelqf_dlarft8_8_lib8(n-ii, pD+ii*sdd+ii*ps, dD+ii, pT);
 //d_print_mat(1, 8, dD+ii, 1);
@@ -817,14 +817,14 @@ void blasfeo_hp_dgelqf(int m, int n, struct blasfeo_dmat *sC, int ci, int cj, st
 		}
 	if(ii<imax)
 		{
-//		if(ii==imax-8)
-//			{
-//			kernel_dgelqf_8_lib8(n-ii, pD+ii*sdd+ii*ps, dD+ii);
-//			}
-//		else
-//			{
+		if(ii==imax-8)
+			{
+			kernel_dgelqf_8_lib8(n-ii, pD+ii*sdd+ii*ps, dD+ii);
+			}
+		else
+			{
 			kernel_dgelqf_vs_lib8(m-ii, n-ii, imax-ii, ii&(ps-1), pD+ii*sdd+ii*ps, sdd, dD+ii);
-//			}
+			}
 		}
 #endif
 

--- a/blasfeo_hp_pm/d_lapack_lib8.c
+++ b/blasfeo_hp_pm/d_lapack_lib8.c
@@ -1066,13 +1066,9 @@ void blasfeo_hp_dgelqf(int m, int n, struct blasfeo_dmat *sC, int ci, int cj, st
 			{
 			kernel_dlarfb8_rn_8_lib8(n-ii, pD+ii*sdd+ii*ps, pT, pD+jj*sdd+ii*ps);
 			}
-//		if(jj<m)
-//			{
-//			kernel_dlarfb8_rn_8_vs_lib8(n-ii, pD+ii*sdd+ii*ps, pT, pD+jj*sdd+ii*ps, m-jj); // TODO
-//			}
-		for(ll=0; ll<m-jj; ll++)
+		if(jj<m)
 			{
-			kernel_dlarfb8_rn_1_lib8(n-ii, pD+ii*sdd+ii*ps, pT, pD+ll+jj*sdd+ii*ps);
+			kernel_dlarfb8_rn_8_vs_lib8(n-ii, pD+ii*sdd+ii*ps, pT, pD+jj*sdd+ii*ps, m-jj);
 			}
 		}
 	if(ii<imax)
@@ -1192,9 +1188,9 @@ void blasfeo_hp_dgelqf_pd(int m, int n, struct blasfeo_dmat *sC, int ci, int cj,
 			{
 			kernel_dlarfb8_rn_8_lib8(n-ii, pD+ii*sdd+ii*ps, pT, pD+jj*sdd+ii*ps);
 			}
-		for(ll=0; ll<m-jj; ll++)
+		if(jj<m)
 			{
-			kernel_dlarfb8_rn_1_lib8(n-ii, pD+ii*sdd+ii*ps, pT, pD+ll+jj*sdd+ii*ps);
+			kernel_dlarfb8_rn_8_vs_lib8(n-ii, pD+ii*sdd+ii*ps, pT, pD+jj*sdd+ii*ps, m-jj);
 			}
 		}
 	if(ii<imax)

--- a/blasfeo_hp_pm/d_lapack_lib8.c
+++ b/blasfeo_hp_pm/d_lapack_lib8.c
@@ -1012,7 +1012,7 @@ void blasfeo_hp_dgelqf(int m, int n, struct blasfeo_dmat *sC, int ci, int cj, st
 
 	double *dD = sD->dA + di;
 #if defined(TARGET_X64_INTEL_SKYLAKE_X)
-	ALIGNED( double pT[64], 64 ) = {0}; // XXX assuming 8x8 kernel
+	ALIGNED( double pT[64], 64 ) = {0}; // XXX assuming rank-8 update
 //	ALIGNED( double pK[64], 64 ) = {0};
 #else
 	double pT[144] = {0}; // XXX smaller ?
@@ -1051,6 +1051,12 @@ void blasfeo_hp_dgelqf(int m, int n, struct blasfeo_dmat *sC, int ci, int cj, st
 //d_print_mat(8, 8, pT, 8);
 		jj = ii+8;
 #if 1
+		for(; jj<m-23; jj+=24)
+			{
+			kernel_dlarfb8_rn_24_lib8(n-ii, pD+ii*sdd+ii*ps, pT, pD+jj*sdd+ii*ps, sdd);
+			}
+#endif
+#if 1
 		for(; jj<m-15; jj+=16)
 			{
 			kernel_dlarfb8_rn_16_lib8(n-ii, pD+ii*sdd+ii*ps, pT, pD+jj*sdd+ii*ps, sdd);
@@ -1060,6 +1066,10 @@ void blasfeo_hp_dgelqf(int m, int n, struct blasfeo_dmat *sC, int ci, int cj, st
 			{
 			kernel_dlarfb8_rn_8_lib8(n-ii, pD+ii*sdd+ii*ps, pT, pD+jj*sdd+ii*ps);
 			}
+//		if(jj<m)
+//			{
+//			kernel_dlarfb8_rn_8_vs_lib8(n-ii, pD+ii*sdd+ii*ps, pT, pD+jj*sdd+ii*ps, m-jj); // TODO
+//			}
 		for(ll=0; ll<m-jj; ll++)
 			{
 			kernel_dlarfb8_rn_1_lib8(n-ii, pD+ii*sdd+ii*ps, pT, pD+ll+jj*sdd+ii*ps);

--- a/blasfeo_hp_pm/d_lapack_lib8.c
+++ b/blasfeo_hp_pm/d_lapack_lib8.c
@@ -806,16 +806,7 @@ void blasfeo_hp_dgelqf(int m, int n, struct blasfeo_dmat *sC, int ci, int cj, st
 #endif
 		for(; jj<m-7; jj+=8)
 			{
-//			kernel_dlarfb8_rn_8_lib8(n-ii, pD+ii*sdd+ii*ps, pT, pD+jj*sdd+ii*ps);
-			kernel_dlarfb8_rn_1_lib8(n-ii, pD+ii*sdd+ii*ps, pT, pD+jj*sdd+ii*ps+0);
-//		return;
-			kernel_dlarfb8_rn_1_lib8(n-ii, pD+ii*sdd+ii*ps, pT, pD+jj*sdd+ii*ps+1);
-			kernel_dlarfb8_rn_1_lib8(n-ii, pD+ii*sdd+ii*ps, pT, pD+jj*sdd+ii*ps+2);
-			kernel_dlarfb8_rn_1_lib8(n-ii, pD+ii*sdd+ii*ps, pT, pD+jj*sdd+ii*ps+3);
-			kernel_dlarfb8_rn_1_lib8(n-ii, pD+ii*sdd+ii*ps, pT, pD+jj*sdd+ii*ps+4);
-			kernel_dlarfb8_rn_1_lib8(n-ii, pD+ii*sdd+ii*ps, pT, pD+jj*sdd+ii*ps+5);
-			kernel_dlarfb8_rn_1_lib8(n-ii, pD+ii*sdd+ii*ps, pT, pD+jj*sdd+ii*ps+6);
-			kernel_dlarfb8_rn_1_lib8(n-ii, pD+ii*sdd+ii*ps, pT, pD+jj*sdd+ii*ps+7);
+			kernel_dlarfb8_rn_8_lib8(n-ii, pD+ii*sdd+ii*ps, pT, pD+jj*sdd+ii*ps);
 			}
 		for(ll=0; ll<m-jj; ll++)
 			{

--- a/blasfeo_hp_pm/d_lapack_lib8.c
+++ b/blasfeo_hp_pm/d_lapack_lib8.c
@@ -755,10 +755,12 @@ void blasfeo_hp_dgelqf(int m, int n, struct blasfeo_dmat *sC, int ci, int cj, st
 	int sdc = sC->cn;
 	int sdd = sD->cn;
 
+	int cir = ci & (ps-1);
+	int dir = di & (ps-1);
+
 	// go to submatrix
-	double *pC = &(BLASFEO_DMATEL(sC,ci,cj));
-	double *pD = &(BLASFEO_DMATEL(sD,di,dj));
-	int dir = di&(ps-1);
+	double *pC = sC->pA + cj*ps + (ci-cir)*sdc;
+	double *pD = sD->pA + dj*ps + (di-dir)*sdd;
 
 	double *dD = sD->dA + di;
 #if defined(TARGET_X64_INTEL_SKYLAKE_X)
@@ -782,7 +784,7 @@ void blasfeo_hp_dgelqf(int m, int n, struct blasfeo_dmat *sC, int ci, int cj, st
 		{
 		imax0 = (ps-dir)&(ps-1);
 		imax0 = imax<imax0 ? imax : imax0;
-		kernel_dgelqf_vs_lib8(m, n, imax0, di&(ps-1), pD, sdd, dD);
+		kernel_dgelqf_vs_lib8(m, n, imax0, dir, pD, sdd, dD);
 		pD += imax0-ps+ps*sdd+imax0*ps;
 		dD += imax0;
 		m -= imax0;
@@ -875,10 +877,12 @@ void blasfeo_hp_dgelqf_pd(int m, int n, struct blasfeo_dmat *sC, int ci, int cj,
 	int sdc = sC->cn;
 	int sdd = sD->cn;
 
+	int cir = ci & (ps-1);
+	int dir = di & (ps-1);
+
 	// go to submatrix
-	double *pC = &(BLASFEO_DMATEL(sC,ci,cj));
-	double *pD = &(BLASFEO_DMATEL(sD,di,dj));
-	int dir = di&(ps-1);
+	double *pC = sC->pA + cj*ps + (ci-cir)*sdc;
+	double *pD = sD->pA + dj*ps + (di-dir)*sdd;
 
 	double *dD = sD->dA + di;
 #if defined(TARGET_X64_INTEL_SKYLAKE_X)
@@ -902,7 +906,7 @@ void blasfeo_hp_dgelqf_pd(int m, int n, struct blasfeo_dmat *sC, int ci, int cj,
 		{
 		imax0 = (ps-dir)&(ps-1);
 		imax0 = imax<imax0 ? imax : imax0;
-		kernel_dgelqf_pd_vs_lib8(m, n, imax0, di&(ps-1), pD, sdd, dD);
+		kernel_dgelqf_pd_vs_lib8(m, n, imax0, dir, pD, sdd, dD);
 		pD += imax0-ps+ps*sdd+imax0*ps;
 		dD += imax0;
 		m -= imax0;
@@ -968,17 +972,18 @@ void blasfeo_hp_dgelqf_pd_la(int m, int n1, struct blasfeo_dmat *sD, int di, int
 	sD->use_dA = 0;
 	sA->use_dA = 0;
 
-	const int ps = 4;
+	const int ps = 8;
 
 	// extract dimensions
 	int sda = sA->cn;
 	int sdd = sD->cn;
 
+	int air = ai & (ps-1);
+	int dir = di & (ps-1);
+
 	// go to submatrix
-	double *pA = &(BLASFEO_DMATEL(sA, ai, aj)); // TODO ?????????????????
-	double *pD = &(BLASFEO_DMATEL(sD, di, dj)); // TODO ?????????????????
-	int air = ai&(ps-1);
-	int dir = di&(ps-1);
+	double *pA = sA->pA + aj*ps + (ai-air)*sda;
+	double *pD = sD->pA + dj*ps + (di-dir)*sdd;
 
 	double *dD = sD->dA + di;
 #if defined(TARGET_X64_INTEL_SKYLAKE_X)

--- a/blasfeo_wr/d_blas2_lib.c
+++ b/blasfeo_wr/d_blas2_lib.c
@@ -64,7 +64,9 @@
 #define SYMV_L blasfeo_dsymv_l
 #define SYMV_L_MN blasfeo_dsymv_l_mn
 #define TRMV_LNN blasfeo_dtrmv_lnn
+#define TRMV_LNN_MN blasfeo_dtrmv_lnn_mn
 #define TRMV_LTN blasfeo_dtrmv_ltn
+#define TRMV_LTN_MN blasfeo_dtrmv_ltn_mn
 #define TRMV_UNN blasfeo_dtrmv_unn
 #define TRMV_UTN blasfeo_dtrmv_utn
 #define TRSV_LNN blasfeo_dtrsv_lnn

--- a/blasfeo_wr/s_blas2_lib.c
+++ b/blasfeo_wr/s_blas2_lib.c
@@ -64,7 +64,9 @@
 #define SYMV_L blasfeo_ssymv_l
 #define SYMV_L_MN blasfeo_ssymv_l_mn
 #define TRMV_LNN blasfeo_strmv_lnn
+#define TRMV_LNN_MN blasfeo_strmv_lnn_mn
 #define TRMV_LTN blasfeo_strmv_ltn
+#define TRMV_LTN_MN blasfeo_strmv_ltn_mn
 #define TRMV_UNN blasfeo_strmv_unn
 #define TRMV_UTN blasfeo_strmv_utn
 #define TRSV_LNN blasfeo_strsv_lnn

--- a/blasfeo_wr/x_blas2_lib.c
+++ b/blasfeo_wr/x_blas2_lib.c
@@ -149,7 +149,30 @@ void SYMV_L_MN(int m, int n, REAL alpha, struct XMAT *sA, int ai, int aj, struct
 
 
 
-void TRMV_LNN(int m, int n, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int xi, struct XVEC *sz, int zi)
+void TRMV_LNN(int n, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int xi, struct XVEC *sz, int zi)
+	{
+	char cl = 'l';
+	char cn = 'n';
+	char cr = 'r';
+	char ct = 't';
+	char cu = 'u';
+	int i1 = 1;
+	REAL d1 = 1.0;
+	REAL d0 = 0.0;
+	REAL dm1 = -1.0;
+	int lda = sA->m;
+	REAL *pA = sA->pA + ai + aj*lda;
+	REAL *x = sx->pa + xi;
+	REAL *z = sz->pa + zi;
+	if(x!=z)
+		COPY(&n, x, &i1, z, &i1);
+	TRMV(&cl, &cn, &cn, &n, pA, &lda, z, &i1);
+	return;
+	}
+
+
+
+void TRMV_LNN_MN(int m, int n, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int xi, struct XVEC *sz, int zi)
 	{
 	char cl = 'l';
 	char cn = 'n';
@@ -174,7 +197,29 @@ void TRMV_LNN(int m, int n, struct XMAT *sA, int ai, int aj, struct XVEC *sx, in
 
 
 
-void TRMV_LTN(int m, int n, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int xi, struct XVEC *sz, int zi)
+void TRMV_LTN(int n, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int xi, struct XVEC *sz, int zi)
+	{
+	char cl = 'l';
+	char cn = 'n';
+	char cr = 'r';
+	char ct = 't';
+	char cu = 'u';
+	int i1 = 1;
+	REAL d1 = 1.0;
+	REAL dm1 = -1.0;
+	int lda = sA->m;
+	REAL *pA = sA->pA + ai + aj*lda;
+	REAL *x = sx->pa + xi;
+	REAL *z = sz->pa + zi;
+	if(x!=z)
+		COPY(&n, x, &i1, z, &i1);
+	TRMV(&cl, &ct, &cn, &n, pA, &lda, z, &i1);
+	return;
+	}
+
+
+
+void TRMV_LTN_MN(int m, int n, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int xi, struct XVEC *sz, int zi)
 	{
 	char cl = 'l';
 	char cn = 'n';

--- a/blasfeo_wr/x_lapack_lib.c
+++ b/blasfeo_wr/x_lapack_lib.c
@@ -441,12 +441,30 @@ void ORGLQ(int m, int n, int k, struct XMAT *sC, int ci, int cj, struct XMAT *sD
 
 
 // LQ factorization with positive diagonal elements
+// XXX this is a hack that only returns the correct L matrix
+// TODO fix also Q !!!!
 void GELQF_PD(int m, int n, struct XMAT *sC, int ci, int cj, struct XMAT *sD, int di, int dj, void *work)
 	{
-	if(m<=0 | n<=0)
-		return;
-	printf("\nblasfeo_gelqf_pd: feature not implemented yet\n");
-	exit(1);
+//	if(m<=0 | n<=0)
+//		return;
+//	printf("\nblasfeo_gelqf_pd: feature not implemented yet\n");
+//	exit(1);
+	GELQF(m, n, sC, ci, cj, sD, di, dj, work);
+	int ldd = sD->m;
+	REAL *pD = sD->pA+di+dj*ldd;
+	int ii, jj;
+	int imax = m<=n ? m : n;
+	for(ii=0; ii<imax; ii++)
+		{
+		if(pD[ii+ldd*ii]<0.0)
+			{
+			for(jj=ii; jj<m; jj++)
+				{
+				pD[jj+ldd*ii] = - pD[jj+ldd*ii];
+				}
+			}
+		}
+	return;
 	}
 
 

--- a/include/blasfeo_block_size.h
+++ b/include/blasfeo_block_size.h
@@ -51,14 +51,14 @@
 #define LLC_CACHE_SIZE (6*1024*1024) // LLC cache size: 6 MB ; TLB 1536*4 kB = 6 MB
 // double
 #define D_PS 8 // panel size
-#define D_PLD 4 // 2 // GCD of panel length
+#define D_PLD 8 // 4 // GCD of panel length
 #define D_M_KERNEL 24 // max kernel size
 #define D_KC 128 //256 // 192
 #define D_NC 128 //72 //96 //72 // 120 // 512
 #define D_MC 1500 // 6000
 // single
 #define S_PS 16 // panel size
-#define S_PLD 4 // 2 // GCD of panel length
+#define S_PLD 4 // GCD of panel length TODO probably 16 when writing assebly
 #define S_M_KERNEL 32 // max kernel size
 #define S_KC 128 //256
 #define S_NC 128 //144

--- a/include/blasfeo_block_size.h
+++ b/include/blasfeo_block_size.h
@@ -48,14 +48,14 @@
 #define CACHE_LINE_SIZE 64 // data cache size: 64 bytes
 #define L1_CACHE_SIZE (32*1024) // L1 data cache size: 32 kB, 8-way
 #define L2_CACHE_SIZE (1024*1024) // L2 data cache size: 1 MB ; DTLB1 64*4 kB = 256 kB
-#define LLC_CACHE_SIZE (6*1024*1024) // LLC cache size: 6 MB ; TLB 1536*4 kB = 6 MB
+#define LLC_CACHE_SIZE (8*1024*1024) // LLC cache size: 8 MB ; TLB 1536*4 kB = 6 MB
 // double
 #define D_PS 8 // panel size
 #define D_PLD 8 // 4 // GCD of panel length
 #define D_M_KERNEL 24 // max kernel size
 #define D_KC 128 //256 // 192
-#define D_NC 128 //72 //96 //72 // 120 // 512
-#define D_MC 1500 // 6000
+#define D_NC 144 //72 //96 //72 // 120 // 512
+#define D_MC 2400 // 6000
 // single
 #define S_PS 16 // panel size
 #define S_PLD 4 // GCD of panel length TODO probably 16 when writing assebly

--- a/include/blasfeo_block_size.h
+++ b/include/blasfeo_block_size.h
@@ -47,8 +47,8 @@
 // common
 #define CACHE_LINE_SIZE 64 // data cache size: 64 bytes
 #define L1_CACHE_SIZE (32*1024) // L1 data cache size: 32 kB, 8-way
-#define L2_CACHE_SIZE (1024*1024) // L2 data cache size: 1 MB ; DTLB1 64*4 kB = 256 kB
-#define LLC_CACHE_SIZE (8*1024*1024) // LLC cache size: 8 MB ; TLB 1536*4 kB = 6 MB
+#define L2_CACHE_SIZE (256*1024) //(1024*1024) // L2 data cache size: 1 MB ; DTLB1 64*4 kB = 256 kB
+#define LLC_CACHE_SIZE (6*1024*1024) //(8*1024*1024) // LLC cache size: 8 MB ; TLB 1536*4 kB = 6 MB
 // double
 #define D_PS 8 // panel size
 #define D_PLD 8 // 4 // GCD of panel length

--- a/include/blasfeo_block_size.h
+++ b/include/blasfeo_block_size.h
@@ -52,7 +52,7 @@
 // double
 #define D_PS 8 // panel size
 #define D_PLD 4 // 2 // GCD of panel length
-#define D_M_KERNEL 16 // max kernel size
+#define D_M_KERNEL 24 // max kernel size
 #define D_KC 128 //256 // 192
 #define D_NC 128 //72 //96 //72 // 120 // 512
 #define D_MC 1500 // 6000

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -125,7 +125,8 @@ void kernel_dlarft_la_8_lib8(int n1, double *dD, double *pA, double *pT);
 void kernel_dlarfb8_rn_la_8_lib8(int n1, double *pVA, double *pT, double *pD, double *pA);
 void kernel_dlarfb8_rn_la_1_lib8(int n1, double *pVA, double *pT, double *pD, double *pA);
 void kernel_dgelqf_pd_lla_vs_lib8(int m, int n0, int n1, int k, int offD, double *pD, int sdd, double *dD, int offL, double *pL, int sdl, int offA, double *pA, int sda);
-void kernel_dlarft_8_lla_lib8(int n0, int n1, double *dD, double *pL, double *pA, double *pT);
+void kernel_dlarft_lla_8_lib8(int n0, int n1, double *dD, double *pL, double *pA, double *pT);
+void kernel_dlarfb8_rn_lla_1_lib8(int n0, int n1, double *pVL, double *pVA, double *pT, double *pD, double *pL, double *pA);
 
 // panel copy / pack
 // 16

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -126,6 +126,7 @@ void kernel_dlarfb8_rn_la_8_lib8(int n1, double *pVA, double *pT, double *pD, do
 void kernel_dlarfb8_rn_la_1_lib8(int n1, double *pVA, double *pT, double *pD, double *pA);
 void kernel_dgelqf_pd_lla_vs_lib8(int m, int n0, int n1, int k, int offD, double *pD, int sdd, double *dD, int offL, double *pL, int sdl, int offA, double *pA, int sda);
 void kernel_dlarft_lla_8_lib8(int n0, int n1, double *dD, double *pL, double *pA, double *pT);
+void kernel_dlarfb8_rn_lla_8_lib8(int n0, int n1, double *pVL, double *pVA, double *pT, double *pD, double *pL, double *pA);
 void kernel_dlarfb8_rn_lla_1_lib8(int n0, int n1, double *pVL, double *pVA, double *pT, double *pD, double *pL, double *pA);
 
 // panel copy / pack

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -142,6 +142,9 @@ void kernel_dlarfb8_rn_lla_8_lib8(int n0, int n1, double *pVL, double *pVA, doub
 void kernel_dlarfb8_rn_lla_1_lib8(int n0, int n1, double *pVL, double *pVA, double *pT, double *pD, double *pL, double *pA);
 
 // panel copy / pack
+// 24
+void kernel_dpack_nn_24_lib8(int kmax, double *A, int lda, double *C, int sdc);
+void kernel_dpack_nn_24_vs_lib8(int kmax, double *A, int lda, double *C, int sdc, int m1);
 // 16
 void kernel_dpacp_nn_16_lib8(int kmax, int offsetA, double *A, int sda, double *B, int sdb);
 void kernel_dpacp_nn_16_vs_lib8(int kmax, int offsetA, double *A, int sda, double *B, int sdb, int m1);
@@ -1189,6 +1192,9 @@ void kernel_dgemm_nt_8x8_lib88cc(int kmax, double *alpha, double *A, double *B, 
 void kernel_dgemm_nt_8x8_vs_lib88cc(int kmax, double *alpha, double *A, double *B, double *beta, double *C, int ldc, double *D, int ldd, int m1, int n1);
 
 // A, panel-major bs=8; B, C, D column-major
+// 24x8
+void kernel_dgemm_nt_24x8_lib8ccc(int kmax, double *alpha, double *A, int sda, double *B, int ldb, double *beta, double *C, int ldc, double *D, int ldd);
+void kernel_dgemm_nt_24x8_vs_lib8ccc(int kmax, double *alpha, double *A, int sda, double *B, int ldb, double *beta, double *C, int ldc, double *D, int ldd, int m1, int n1);
 // 16x8
 void kernel_dgemm_nt_16x8_lib8ccc(int kmax, double *alpha, double *A, int sda, double *B, int ldb, double *beta, double *C, int ldc, double *D, int ldd);
 void kernel_dgemm_nt_16x8_vs_lib8ccc(int kmax, double *alpha, double *A, int sda, double *B, int ldb, double *beta, double *C, int ldc, double *D, int ldd, int m1, int n1);

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -62,9 +62,13 @@ void blasfeo_align_64_byte(void *ptr, void **ptr_align);
 void kernel_dgemm_nt_24x8_lib8(int k, double *alpha, double *A, int sda, double *B, double *beta, double *C, int sdc, double *D, int sdd); //
 void kernel_dgemm_nt_24x8_vs_lib8(int k, double *alpha, double *A, int sda, double *B, double *beta, double *C, int sdc, double *D, int sdd, int m1, int n1); //
 void kernel_dtrsm_nt_rl_inv_24x8_lib8(int k, double *A, int sda, double *B, double *beta, double *C, int sdc, double *D, int sdd, double *E, double *inv_diag_E); //
+void kernel_dpotrf_nt_l_24x8_lib8(int k, double *A, int sda, double *B, double *C, int sdc, double *D, int sdd, double *inv_diag_D);
+void kernel_dpotrf_nt_l_24x8_vs_lib8(int k, double *A, int sda, double *B, double *C, int sdc, double *D, int sdd, double *inv_diag_D, int m1, int n1);
 void kernel_dtrsm_nt_rl_inv_24x8_vs_lib8(int k, double *A, int sda, double *B, double *beta, double *C, int sdc, double *D, int sdd, double *E, double *inv_diag_E, int m1, int n1); //
 void kernel_dgemm_dtrsm_nt_rl_inv_24x8_lib8(int kp, double *Ap, int sdap, double *Bp, int km_, double *Am, int sdam, double *Bm, double *C, int sdc, double *D, int sdd, double *E, double *inv_diag_E);
 void kernel_dgemm_dtrsm_nt_rl_inv_24x8_vs_lib8(int kp, double *Ap, int sdap, double *Bp, int km_, double *Am, int sdam, double *Bm, double *C, int sdc, double *D, int sdd, double *E, double *inv_diag_E, int m1, int n1);
+void kernel_dsyrk_dpotrf_nt_l_24x8_lib8(int kp, double *Ap, int sdap, double *Bp, int km_, double *Am, int sdam, double *Bm, double *C, int sdc, double *D, int sdd, double *inv_diag_D);
+void kernel_dsyrk_dpotrf_nt_l_24x8_vs_lib8(int kp, double *Ap, int sdap, double *Bp, int km_, double *Am, int sdam, double *Bm, double *C, int sdc, double *D, int sdd, double *inv_diag_D, int m1, int n1);
 // 16x8
 void kernel_dgemm_nt_16x8_lib8(int k, double *alpha, double *A, int sda, double *B, double *beta, double *C, int sdc, double *D, int sdd); //
 void kernel_dgemm_nt_16x8_vs_lib8(int k, double *alpha, double *A, int sda, double *B, double *beta, double *C, int sdc, double *D, int sdd, int m1, int n1); //

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -111,6 +111,7 @@ void kernel_dsyrk_dpotrf_nt_l_8x8_lib8(int kp, double *Ap, double *Bp, int km_, 
 void kernel_dsyrk_dpotrf_nt_l_8x8_vs_lib8(int kp, double *Ap, double *Bp, int km_, double *Am, double *Bm, double *C, double *D, double *inv_diag_D, int m1, int n1);
 void kernel_dgelqf_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd, double *dD);
 void kernel_dgelqf_pd_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd, double *dD);
+void kernel_dlarft_8_lib8(int kmax, double *pD, double *dD, double *pT);
 
 // panel copy / pack
 // 16

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -81,6 +81,7 @@ void kernel_dsyrk_dpotrf_nt_l_16x8_lib8(int kp, double *Ap, int sdap, double *Bp
 void kernel_dsyrk_dpotrf_nt_l_16x8_vs_lib8(int kp, double *Ap, int sdap, double *Bp, int km_, double *Am, int sdam, double *Bm, double *C, int sdc, double *D, int sdd, double *inv_diag_D, int m1, int n1);
 void kernel_dlarfb8_rn_16_lib8(int kmax, double *pV, double *pT, double *pD, int sdd);
 void kernel_dlarfb8_rn_la_16_lib8(int n1, double *pVA, double *pT, double *pD, int sdd, double *pA, int sda);
+void kernel_dlarfb8_rn_lla_16_lib8(int n0, int n1, double *pVL, double *pVA, double *pT, double *pD, int sdd, double *pL, int sdl, double *pA, int sda);
 // 8x16
 void kernel_dgemm_tt_8x16_lib8(int k, double *alpha, int offA, double *A, int sda, double *B, int sdb, double *beta, double *C, double *D); //
 void kernel_dgemm_tt_8x16_vs_lib8(int k, double *alpha, int offA, double *A, int sda, double *B, int sdb, double *beta, double *C, double *D, int m1, int n1); //

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -109,6 +109,7 @@ void kernel_dgemm_dtrsm_nt_rl_inv_8x8_lib8(int kp, double *Ap, double *Bp, int k
 void kernel_dgemm_dtrsm_nt_rl_inv_8x8_vs_lib8(int kp, double *Ap, double *Bp, int km_, double *Am, double *Bm, double *C, double *D, double *E, double *inv_diag_E, int m1, int n1);
 void kernel_dsyrk_dpotrf_nt_l_8x8_lib8(int kp, double *Ap, double *Bp, int km_, double *Am, double *Bm, double *C, double *D, double *inv_diag_D);
 void kernel_dsyrk_dpotrf_nt_l_8x8_vs_lib8(int kp, double *Ap, double *Bp, int km_, double *Am, double *Bm, double *C, double *D, double *inv_diag_D, int m1, int n1);
+void kernel_dgelqf_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd, double *dD);
 
 // panel copy / pack
 // 16

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -112,10 +112,12 @@ void kernel_dsyrk_dpotrf_nt_l_8x8_vs_lib8(int kp, double *Ap, double *Bp, int km
 void kernel_dgelqf_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd, double *dD);
 void kernel_dgelqf_pd_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd, double *dD);
 void kernel_dgelqf_8_lib8(int kmax, double *pD, double *dD);
+void kernel_dgelqf_pd_8_lib8(int kmax, double *pD, double *dD);
 void kernel_dlarft_8_lib8(int kmax, double *pD, double *dD, double *pT);
 void kernel_dlarfb8_rn_8_lib8(int kmax, double *pV, double *pT, double *pD);
 void kernel_dlarfb8_rn_1_lib8(int kmax, double *pV, double *pT, double *pD);
 void kernel_dgelqf_dlarft8_8_lib8(int kmax, double *pD, double *dD, double *pT);
+void kernel_dgelqf_pd_dlarft8_8_lib8(int kmax, double *pD, double *dD, double *pT);
 
 // panel copy / pack
 // 16

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -121,6 +121,7 @@ void kernel_dgelqf_dlarft8_8_lib8(int kmax, double *pD, double *dD, double *pT);
 void kernel_dgelqf_pd_dlarft8_8_lib8(int kmax, double *pD, double *dD, double *pT);
 void kernel_dgelqf_pd_la_vs_lib8(int m, int n1, int k, int offD, double *pD, int sdd, double *dD, int offA, double *pA, int sda);
 void kernel_dlarft_la_8_lib8(int n1, double *dD, double *pA, double *pT);
+void kernel_dlarfb8_rn_la_1_lib8(int n1, double *pVA, double *pT, double *pD, double *pA);
 void kernel_dgelqf_pd_lla_vs_lib8(int m, int n0, int n1, int k, int offD, double *pD, int sdd, double *dD, int offL, double *pL, int sdl, int offA, double *pA, int sda);
 
 // panel copy / pack

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -111,6 +111,7 @@ void kernel_dsyrk_dpotrf_nt_l_8x8_lib8(int kp, double *Ap, double *Bp, int km_, 
 void kernel_dsyrk_dpotrf_nt_l_8x8_vs_lib8(int kp, double *Ap, double *Bp, int km_, double *Am, double *Bm, double *C, double *D, double *inv_diag_D, int m1, int n1);
 void kernel_dgelqf_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd, double *dD);
 void kernel_dgelqf_pd_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd, double *dD);
+void kernel_dgelqf_8_lib8(int kmax, double *pD, double *dD);
 void kernel_dlarft_8_lib8(int kmax, double *pD, double *dD, double *pT);
 void kernel_dlarfb8_rn_8_lib8(int kmax, double *pV, double *pT, double *pD);
 void kernel_dlarfb8_rn_1_lib8(int kmax, double *pV, double *pT, double *pD);

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -119,7 +119,9 @@ void kernel_dlarfb8_rn_8_lib8(int kmax, double *pV, double *pT, double *pD);
 void kernel_dlarfb8_rn_1_lib8(int kmax, double *pV, double *pT, double *pD);
 void kernel_dgelqf_dlarft8_8_lib8(int kmax, double *pD, double *dD, double *pT);
 void kernel_dgelqf_pd_dlarft8_8_lib8(int kmax, double *pD, double *dD, double *pT);
-void kernel_dgelqf_pd_la_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd, double *dD, int offA, double *pA, int sda);
+void kernel_dgelqf_pd_la_vs_lib8(int m, int n1, int k, int offD, double *pD, int sdd, double *dD, int offA, double *pA, int sda);
+void kernel_dlarft_la_8_lib8(int n1, double *dD, double *pA, double *pT);
+void kernel_dgelqf_pd_lla_vs_lib8(int m, int n0, int n1, int k, int offD, double *pD, int sdd, double *dD, int offL, double *pL, int sdl, int offA, double *pA, int sda);
 
 // panel copy / pack
 // 16

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -114,6 +114,7 @@ void kernel_dgelqf_pd_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd
 void kernel_dlarft_8_lib8(int kmax, double *pD, double *dD, double *pT);
 void kernel_dlarfb8_rn_8_lib8(int kmax, double *pV, double *pT, double *pD);
 void kernel_dlarfb8_rn_1_lib8(int kmax, double *pV, double *pT, double *pD);
+void kernel_dgelqf_dlarft8_8_lib8(int kmax, double *pD, double *dD, double *pT);
 
 // panel copy / pack
 // 16

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -58,6 +58,9 @@ void blasfeo_align_64_byte(void *ptr, void **ptr_align);
 // lib8
 //
 
+// 24x8
+void kernel_dgemm_nt_24x8_lib8(int k, double *alpha, double *A, int sda, double *B, double *beta, double *C, int sdc, double *D, int sdd); //
+void kernel_dgemm_nt_24x8_vs_lib8(int k, double *alpha, double *A, int sda, double *B, double *beta, double *C, int sdc, double *D, int sdd, int m1, int n1); //
 // 16x8
 void kernel_dgemm_nt_16x8_lib8(int k, double *alpha, double *A, int sda, double *B, double *beta, double *C, int sdc, double *D, int sdd); //
 void kernel_dgemm_nt_16x8_vs_lib8(int k, double *alpha, double *A, int sda, double *B, double *beta, double *C, int sdc, double *D, int sdd, int m1, int n1); //

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -110,6 +110,7 @@ void kernel_dgemm_dtrsm_nt_rl_inv_8x8_vs_lib8(int kp, double *Ap, double *Bp, in
 void kernel_dsyrk_dpotrf_nt_l_8x8_lib8(int kp, double *Ap, double *Bp, int km_, double *Am, double *Bm, double *C, double *D, double *inv_diag_D);
 void kernel_dsyrk_dpotrf_nt_l_8x8_vs_lib8(int kp, double *Ap, double *Bp, int km_, double *Am, double *Bm, double *C, double *D, double *inv_diag_D, int m1, int n1);
 void kernel_dgelqf_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd, double *dD);
+void kernel_dgelqf_pd_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd, double *dD);
 
 // panel copy / pack
 // 16

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -130,6 +130,7 @@ void kernel_dgelqf_8_lib8(int kmax, double *pD, double *dD);
 void kernel_dgelqf_pd_8_lib8(int kmax, double *pD, double *dD);
 void kernel_dlarft_8_lib8(int kmax, double *pD, double *dD, double *pT);
 void kernel_dlarfb8_rn_8_lib8(int kmax, double *pV, double *pT, double *pD);
+void kernel_dlarfb8_rn_8_vs_lib8(int kmax, double *pV, double *pT, double *pD, int m1);
 void kernel_dlarfb8_rn_1_lib8(int kmax, double *pV, double *pT, double *pD);
 void kernel_dgelqf_dlarft8_8_lib8(int kmax, double *pD, double *dD, double *pT);
 void kernel_dgelqf_pd_dlarft8_8_lib8(int kmax, double *pD, double *dD, double *pT);

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -112,6 +112,7 @@ void kernel_dsyrk_dpotrf_nt_l_8x8_vs_lib8(int kp, double *Ap, double *Bp, int km
 void kernel_dgelqf_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd, double *dD);
 void kernel_dgelqf_pd_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd, double *dD);
 void kernel_dlarft_8_lib8(int kmax, double *pD, double *dD, double *pT);
+void kernel_dlarfb8_rn_8_lib8(int kmax, double *pV, double *pT, double *pD);
 void kernel_dlarfb8_rn_1_lib8(int kmax, double *pV, double *pT, double *pD);
 
 // panel copy / pack

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -141,6 +141,7 @@ void kernel_dlarfb8_rn_la_8_lib8(int n1, double *pVA, double *pT, double *pD, do
 void kernel_dlarfb8_rn_la_8_vs_lib8(int n1, double *pVA, double *pT, double *pD, double *pA, int m1);
 void kernel_dlarfb8_rn_la_1_lib8(int n1, double *pVA, double *pT, double *pD, double *pA);
 void kernel_dgelqf_pd_lla_vs_lib8(int m, int n0, int n1, int k, int offD, double *pD, int sdd, double *dD, int offL, double *pL, int sdl, int offA, double *pA, int sda);
+void kernel_dgelqf_pd_lla_dlarft8_8_lib8(int n0, int n1, double *pD, double *dD, double *pL, double *pA, double *pT);
 void kernel_dlarft_lla_8_lib8(int n0, int n1, double *dD, double *pL, double *pA, double *pT);
 void kernel_dlarfb8_rn_lla_8_lib8(int n0, int n1, double *pVL, double *pVA, double *pT, double *pD, double *pL, double *pA);
 void kernel_dlarfb8_rn_lla_8_vs_lib8(int n0, int n1, double *pVL, double *pVA, double *pT, double *pD, double *pL, double *pA, int m1);

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -119,6 +119,7 @@ void kernel_dlarfb8_rn_8_lib8(int kmax, double *pV, double *pT, double *pD);
 void kernel_dlarfb8_rn_1_lib8(int kmax, double *pV, double *pT, double *pD);
 void kernel_dgelqf_dlarft8_8_lib8(int kmax, double *pD, double *dD, double *pT);
 void kernel_dgelqf_pd_dlarft8_8_lib8(int kmax, double *pD, double *dD, double *pT);
+void kernel_dgelqf_pd_la_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd, double *dD, int offA, double *pA, int sda);
 
 // panel copy / pack
 // 16

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -69,6 +69,7 @@ void kernel_dgemm_dtrsm_nt_rl_inv_24x8_lib8(int kp, double *Ap, int sdap, double
 void kernel_dgemm_dtrsm_nt_rl_inv_24x8_vs_lib8(int kp, double *Ap, int sdap, double *Bp, int km_, double *Am, int sdam, double *Bm, double *C, int sdc, double *D, int sdd, double *E, double *inv_diag_E, int m1, int n1);
 void kernel_dsyrk_dpotrf_nt_l_24x8_lib8(int kp, double *Ap, int sdap, double *Bp, int km_, double *Am, int sdam, double *Bm, double *C, int sdc, double *D, int sdd, double *inv_diag_D);
 void kernel_dsyrk_dpotrf_nt_l_24x8_vs_lib8(int kp, double *Ap, int sdap, double *Bp, int km_, double *Am, int sdam, double *Bm, double *C, int sdc, double *D, int sdd, double *inv_diag_D, int m1, int n1);
+void kernel_dlarfb8_rn_24_lib8(int kmax, double *pV, double *pT, double *pD, int sdd);
 // 16x8
 void kernel_dgemm_nt_16x8_lib8(int k, double *alpha, double *A, int sda, double *B, double *beta, double *C, int sdc, double *D, int sdd); //
 void kernel_dgemm_nt_16x8_vs_lib8(int k, double *alpha, double *A, int sda, double *B, double *beta, double *C, int sdc, double *D, int sdd, int m1, int n1); //

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -112,6 +112,7 @@ void kernel_dsyrk_dpotrf_nt_l_8x8_vs_lib8(int kp, double *Ap, double *Bp, int km
 void kernel_dgelqf_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd, double *dD);
 void kernel_dgelqf_pd_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd, double *dD);
 void kernel_dlarft_8_lib8(int kmax, double *pD, double *dD, double *pT);
+void kernel_dlarfb8_rn_1_lib8(int kmax, double *pV, double *pT, double *pD);
 
 // panel copy / pack
 // 16

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -137,10 +137,12 @@ void kernel_dgelqf_pd_dlarft8_8_lib8(int kmax, double *pD, double *dD, double *p
 void kernel_dgelqf_pd_la_vs_lib8(int m, int n1, int k, int offD, double *pD, int sdd, double *dD, int offA, double *pA, int sda);
 void kernel_dlarft_la_8_lib8(int n1, double *dD, double *pA, double *pT);
 void kernel_dlarfb8_rn_la_8_lib8(int n1, double *pVA, double *pT, double *pD, double *pA);
+void kernel_dlarfb8_rn_la_8_vs_lib8(int n1, double *pVA, double *pT, double *pD, double *pA, int m1);
 void kernel_dlarfb8_rn_la_1_lib8(int n1, double *pVA, double *pT, double *pD, double *pA);
 void kernel_dgelqf_pd_lla_vs_lib8(int m, int n0, int n1, int k, int offD, double *pD, int sdd, double *dD, int offL, double *pL, int sdl, int offA, double *pA, int sda);
 void kernel_dlarft_lla_8_lib8(int n0, int n1, double *dD, double *pL, double *pA, double *pT);
 void kernel_dlarfb8_rn_lla_8_lib8(int n0, int n1, double *pVL, double *pVA, double *pT, double *pD, double *pL, double *pA);
+void kernel_dlarfb8_rn_lla_8_vs_lib8(int n0, int n1, double *pVL, double *pVA, double *pT, double *pD, double *pL, double *pA, int m1);
 void kernel_dlarfb8_rn_lla_1_lib8(int n0, int n1, double *pVL, double *pVA, double *pT, double *pD, double *pL, double *pA);
 
 // panel copy / pack

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -1207,6 +1207,9 @@ void kernel_dgemm_nn_8x8_lib8ccc(int kmax, double *alpha, double *A, double *B, 
 void kernel_dgemm_nn_8x8_vs_lib8ccc(int kmax, double *alpha, double *A, double *B, int ldb, double *beta, double *C, int ldc, double *D, int ldd, int m1, int n1);
 
 // B, panel-major bs=8; A, C, D column-major
+// 8x24
+void kernel_dgemm_nt_8x24_libc8cc(int kmax, double *alpha, double *A, int lda, double *B, int sdb, double *beta, double *C, int ldc, double *D, int ldd);
+void kernel_dgemm_nt_8x24_vs_libc8cc(int kmax, double *alpha, double *A, int lda, double *B, int sdb, double *beta, double *C, int ldc, double *D, int ldd, int m1, int n1);
 // 8x16
 void kernel_dgemm_nt_8x16_libc8cc(int kmax, double *alpha, double *A, int lda, double *B, int sdb, double *beta, double *C, int ldc, double *D, int ldd);
 void kernel_dgemm_nt_8x16_vs_libc8cc(int kmax, double *alpha, double *A, int lda, double *B, int sdb, double *beta, double *C, int ldc, double *D, int ldd, int m1, int n1);

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -135,6 +135,7 @@ void kernel_dlarfb8_rn_1_lib8(int kmax, double *pV, double *pT, double *pD);
 void kernel_dgelqf_dlarft8_8_lib8(int kmax, double *pD, double *dD, double *pT);
 void kernel_dgelqf_pd_dlarft8_8_lib8(int kmax, double *pD, double *dD, double *pT);
 void kernel_dgelqf_pd_la_vs_lib8(int m, int n1, int k, int offD, double *pD, int sdd, double *dD, int offA, double *pA, int sda);
+void kernel_dgelqf_pd_la_dlarft8_8_lib8(int kmax, double *pD, double *dD, double *pA, double *pT);
 void kernel_dlarft_la_8_lib8(int n1, double *dD, double *pA, double *pT);
 void kernel_dlarfb8_rn_la_8_lib8(int n1, double *pVA, double *pT, double *pD, double *pA);
 void kernel_dlarfb8_rn_la_8_vs_lib8(int n1, double *pVA, double *pT, double *pD, double *pA, int m1);

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -125,6 +125,7 @@ void kernel_dlarft_la_8_lib8(int n1, double *dD, double *pA, double *pT);
 void kernel_dlarfb8_rn_la_8_lib8(int n1, double *pVA, double *pT, double *pD, double *pA);
 void kernel_dlarfb8_rn_la_1_lib8(int n1, double *pVA, double *pT, double *pD, double *pA);
 void kernel_dgelqf_pd_lla_vs_lib8(int m, int n0, int n1, int k, int offD, double *pD, int sdd, double *dD, int offL, double *pL, int sdl, int offA, double *pA, int sda);
+void kernel_dlarft_8_lla_lib8(int n0, int n1, double *dD, double *pL, double *pA, double *pT);
 
 // panel copy / pack
 // 16
@@ -151,7 +152,7 @@ void kernel_dpack_tn_8_vs_lib8(int kmax, double *A, int lda, double *C, int m1);
 void kernel_dpack_tt_4_lib8(int kmax, double *A, int lda, double *C, int sdc); // TODO offsetC 
 void kernel_dpack_tt_4_vs_lib8(int kmax, double *A, int lda, double *C, int sdc, int m1); // TODO offsetC 
 
-// levle 2 BLAS
+// level 2 BLAS
 // 16
 void kernel_dgemv_n_16_lib8(int k, double *alpha, double *A, int sda, double *x, double *beta, double *y, double *z);
 // 8

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -121,6 +121,7 @@ void kernel_dgelqf_dlarft8_8_lib8(int kmax, double *pD, double *dD, double *pT);
 void kernel_dgelqf_pd_dlarft8_8_lib8(int kmax, double *pD, double *dD, double *pT);
 void kernel_dgelqf_pd_la_vs_lib8(int m, int n1, int k, int offD, double *pD, int sdd, double *dD, int offA, double *pA, int sda);
 void kernel_dlarft_la_8_lib8(int n1, double *dD, double *pA, double *pT);
+void kernel_dlarfb8_rn_la_8_lib8(int n1, double *pVA, double *pT, double *pD, double *pA);
 void kernel_dlarfb8_rn_la_1_lib8(int n1, double *pVA, double *pT, double *pD, double *pA);
 void kernel_dgelqf_pd_lla_vs_lib8(int m, int n0, int n1, int k, int offD, double *pD, int sdd, double *dD, int offL, double *pL, int sdl, int offA, double *pA, int sda);
 

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -79,6 +79,7 @@ void kernel_dgemm_dtrsm_nt_rl_inv_16x8_lib8(int kp, double *Ap, int sdap, double
 void kernel_dgemm_dtrsm_nt_rl_inv_16x8_vs_lib8(int kp, double *Ap, int sdap, double *Bp, int km_, double *Am, int sdam, double *Bm, double *C, int sdc, double *D, int sdd, double *E, double *inv_diag_E, int m1, int n1);
 void kernel_dsyrk_dpotrf_nt_l_16x8_lib8(int kp, double *Ap, int sdap, double *Bp, int km_, double *Am, int sdam, double *Bm, double *C, int sdc, double *D, int sdd, double *inv_diag_D);
 void kernel_dsyrk_dpotrf_nt_l_16x8_vs_lib8(int kp, double *Ap, int sdap, double *Bp, int km_, double *Am, int sdam, double *Bm, double *C, int sdc, double *D, int sdd, double *inv_diag_D, int m1, int n1);
+void kernel_dlarfb8_rn_16_lib8(int kmax, double *pV, double *pT, double *pD, int sdd);
 // 8x16
 void kernel_dgemm_tt_8x16_lib8(int k, double *alpha, int offA, double *A, int sda, double *B, int sdb, double *beta, double *C, double *D); //
 void kernel_dgemm_tt_8x16_vs_lib8(int k, double *alpha, int offA, double *A, int sda, double *B, int sdb, double *beta, double *C, double *D, int m1, int n1); //

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -1178,6 +1178,9 @@ void kernel_dgemm_nt_8xn_p0_lib44cc(int n, int k, double *alpha, double *A, int 
 
 
 // A, B panel-major bs=8; C, D column-major
+// 24x8
+void kernel_dgemm_nt_24x8_lib88cc(int kmax, double *alpha, double *A, int sda, double *B, double *beta, double *C, int ldc, double *D, int ldd);
+void kernel_dgemm_nt_24x8_vs_lib88cc(int kmax, double *alpha, double *A, int sda, double *B, double *beta, double *C, int ldc, double *D, int ldd, int m1, int n1);
 // 16x8
 void kernel_dgemm_nt_16x8_lib88cc(int kmax, double *alpha, double *A, int sda, double *B, double *beta, double *C, int ldc, double *D, int ldd);
 void kernel_dgemm_nt_16x8_vs_lib88cc(int kmax, double *alpha, double *A, int sda, double *B, double *beta, double *C, int ldc, double *D, int ldd, int m1, int n1);

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -61,6 +61,10 @@ void blasfeo_align_64_byte(void *ptr, void **ptr_align);
 // 24x8
 void kernel_dgemm_nt_24x8_lib8(int k, double *alpha, double *A, int sda, double *B, double *beta, double *C, int sdc, double *D, int sdd); //
 void kernel_dgemm_nt_24x8_vs_lib8(int k, double *alpha, double *A, int sda, double *B, double *beta, double *C, int sdc, double *D, int sdd, int m1, int n1); //
+void kernel_dtrsm_nt_rl_inv_24x8_lib8(int k, double *A, int sda, double *B, double *beta, double *C, int sdc, double *D, int sdd, double *E, double *inv_diag_E); //
+void kernel_dtrsm_nt_rl_inv_24x8_vs_lib8(int k, double *A, int sda, double *B, double *beta, double *C, int sdc, double *D, int sdd, double *E, double *inv_diag_E, int m1, int n1); //
+void kernel_dgemm_dtrsm_nt_rl_inv_24x8_lib8(int kp, double *Ap, int sdap, double *Bp, int km_, double *Am, int sdam, double *Bm, double *C, int sdc, double *D, int sdd, double *E, double *inv_diag_E);
+void kernel_dgemm_dtrsm_nt_rl_inv_24x8_vs_lib8(int kp, double *Ap, int sdap, double *Bp, int km_, double *Am, int sdam, double *Bm, double *C, int sdc, double *D, int sdd, double *E, double *inv_diag_E, int m1, int n1);
 // 16x8
 void kernel_dgemm_nt_16x8_lib8(int k, double *alpha, double *A, int sda, double *B, double *beta, double *C, int sdc, double *D, int sdd); //
 void kernel_dgemm_nt_16x8_vs_lib8(int k, double *alpha, double *A, int sda, double *B, double *beta, double *C, int sdc, double *D, int sdd, int m1, int n1); //

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -80,6 +80,7 @@ void kernel_dgemm_dtrsm_nt_rl_inv_16x8_vs_lib8(int kp, double *Ap, int sdap, dou
 void kernel_dsyrk_dpotrf_nt_l_16x8_lib8(int kp, double *Ap, int sdap, double *Bp, int km_, double *Am, int sdam, double *Bm, double *C, int sdc, double *D, int sdd, double *inv_diag_D);
 void kernel_dsyrk_dpotrf_nt_l_16x8_vs_lib8(int kp, double *Ap, int sdap, double *Bp, int km_, double *Am, int sdam, double *Bm, double *C, int sdc, double *D, int sdd, double *inv_diag_D, int m1, int n1);
 void kernel_dlarfb8_rn_16_lib8(int kmax, double *pV, double *pT, double *pD, int sdd);
+void kernel_dlarfb8_rn_la_16_lib8(int n1, double *pVA, double *pT, double *pD, int sdd, double *pA, int sda);
 // 8x16
 void kernel_dgemm_tt_8x16_lib8(int k, double *alpha, int offA, double *A, int sda, double *B, int sdb, double *beta, double *C, double *D); //
 void kernel_dgemm_tt_8x16_vs_lib8(int k, double *alpha, int offA, double *A, int sda, double *B, int sdb, double *beta, double *C, double *D, int m1, int n1); //

--- a/include/blasfeo_d_kernel.h
+++ b/include/blasfeo_d_kernel.h
@@ -1195,6 +1195,8 @@ void kernel_dgemm_nt_8x8_vs_lib88cc(int kmax, double *alpha, double *A, double *
 // 24x8
 void kernel_dgemm_nt_24x8_lib8ccc(int kmax, double *alpha, double *A, int sda, double *B, int ldb, double *beta, double *C, int ldc, double *D, int ldd);
 void kernel_dgemm_nt_24x8_vs_lib8ccc(int kmax, double *alpha, double *A, int sda, double *B, int ldb, double *beta, double *C, int ldc, double *D, int ldd, int m1, int n1);
+void kernel_dgemm_nn_24x8_lib8ccc(int kmax, double *alpha, double *A, int sda, double *B, int ldb, double *beta, double *C, int ldc, double *D, int ldd);
+void kernel_dgemm_nn_24x8_vs_lib8ccc(int kmax, double *alpha, double *A, int sda, double *B, int ldb, double *beta, double *C, int ldc, double *D, int ldd, int m1, int n1);
 // 16x8
 void kernel_dgemm_nt_16x8_lib8ccc(int kmax, double *alpha, double *A, int sda, double *B, int ldb, double *beta, double *C, int ldc, double *D, int ldd);
 void kernel_dgemm_nt_16x8_vs_lib8ccc(int kmax, double *alpha, double *A, int sda, double *B, int ldb, double *beta, double *C, int ldc, double *D, int ldd, int m1, int n1);
@@ -1210,6 +1212,8 @@ void kernel_dgemm_nn_8x8_vs_lib8ccc(int kmax, double *alpha, double *A, double *
 // 8x24
 void kernel_dgemm_nt_8x24_libc8cc(int kmax, double *alpha, double *A, int lda, double *B, int sdb, double *beta, double *C, int ldc, double *D, int ldd);
 void kernel_dgemm_nt_8x24_vs_libc8cc(int kmax, double *alpha, double *A, int lda, double *B, int sdb, double *beta, double *C, int ldc, double *D, int ldd, int m1, int n1);
+void kernel_dgemm_tt_8x24_libc8cc(int kmax, double *alpha, double *A, int lda, double *B, int sdb, double *beta, double *C, int ldc, double *D, int ldd);
+void kernel_dgemm_tt_8x24_vs_libc8cc(int kmax, double *alpha, double *A, int lda, double *B, int sdb, double *beta, double *C, int ldc, double *D, int ldd, int m1, int n1);
 // 8x16
 void kernel_dgemm_nt_8x16_libc8cc(int kmax, double *alpha, double *A, int lda, double *B, int sdb, double *beta, double *C, int ldc, double *D, int ldd);
 void kernel_dgemm_nt_8x16_vs_libc8cc(int kmax, double *alpha, double *A, int lda, double *B, int sdb, double *beta, double *C, int ldc, double *D, int ldd, int m1, int n1);

--- a/kernel/avx/kernel_dgeqrf_4_lib4.c
+++ b/kernel/avx/kernel_dgeqrf_4_lib4.c
@@ -43,9 +43,9 @@
 #include <smmintrin.h>  // SSE4
 #include <immintrin.h>  // AVX
 
-#include "../../include/blasfeo_common.h"
-#include "../../include/blasfeo_d_aux.h"
-#include "../../include/blasfeo_d_kernel.h"
+#include <include/blasfeo_common.h>
+#include <include/blasfeo_d_aux.h>
+#include <include/blasfeo_d_kernel.h>
 
 
 

--- a/kernel/avx/kernel_dgeqrf_4_lib4.c
+++ b/kernel/avx/kernel_dgeqrf_4_lib4.c
@@ -3649,8 +3649,8 @@ col3:
 		w3 += pD[3+ps*ii] * pD[2+ps*ii];
 		}
 	//
-	pT[1+ps*2] = - dD[2] * (w1*pT[1+ps*1]);
 	pT[0+ps*2] = - dD[2] * (w0*pT[0+ps*0] + w1*pT[0+ps*1]);
+	pT[1+ps*2] = - dD[2] * (w1*pT[1+ps*1]);
 	w3 = - dD[2] * w3;
 	//
 	pD[3+ps*2] += w3;
@@ -3695,9 +3695,9 @@ col4:
 		w2 += pD[2+ps*ii] * pD[3+ps*ii];
 		}
 	//
-	pT[2+ps*3] = - dD[3] * (w2*pT[2+ps*2]);
-	pT[1+ps*3] = - dD[3] * (w1*pT[1+ps*1] + w2*pT[1+ps*2]);
 	pT[0+ps*3] = - dD[3] * (w0*pT[0+ps*0] + w1*pT[0+ps*1] + w2*pT[0+ps*2]);
+	pT[1+ps*3] = - dD[3] * (w1*pT[1+ps*1] + w2*pT[1+ps*2]);
+	pT[2+ps*3] = - dD[3] * (w2*pT[2+ps*2]);
 	return;
 	}
 #endif

--- a/kernel/avx/kernel_dgeqrf_4_lib4.c
+++ b/kernel/avx/kernel_dgeqrf_4_lib4.c
@@ -43,9 +43,9 @@
 #include <smmintrin.h>  // SSE4
 #include <immintrin.h>  // AVX
 
-#include <include/blasfeo_common.h>
-#include <include/blasfeo_d_aux.h>
-#include <include/blasfeo_d_kernel.h>
+#include <blasfeo_common.h>
+#include <blasfeo_d_aux.h>
+#include <blasfeo_d_kernel.h>
 
 
 

--- a/kernel/avx/kernel_dgeqrf_4_lib4.c
+++ b/kernel/avx/kernel_dgeqrf_4_lib4.c
@@ -4253,7 +4253,7 @@ void kernel_dgelqf_pd_la_vs_lib4(int m, int n1, int k, int offD, double *pD, int
 	double *pD0 = pD-offD;
 	double *pA0 = pA-offA;
 	ii = 0;
-#if 0 // rank 2
+#if 0 // TODO rank 2
 	for(; ii<imax-1; ii+=2)
 		{
 		// first row

--- a/kernel/avx/kernel_dgeqrf_4_lib4.c
+++ b/kernel/avx/kernel_dgeqrf_4_lib4.c
@@ -4654,7 +4654,7 @@ void kernel_dgelqf_pd_lla_vs_lib4(int m, int n0, int n1, int k, int offD, double
 	double *pL0 = pL-offL;
 	double *pA0 = pA-offA;
 	ii = 0;
-#if 0 // rank 2
+#if 0 // TODO rank 2
 	for(; ii<imax-1; ii+=2)
 		{
 		// first row

--- a/kernel/avx2/kernel_dgelqf_4_lib4.S
+++ b/kernel/avx2/kernel_dgelqf_4_lib4.S
@@ -10410,8 +10410,8 @@ LC00: // { 100...0 100...0 100...0 100...0 }
 	.align 32
 .LC01:
 #elif defined(OS_MAC)
-LC01:
 	.align 5
+LC01:
 #endif
 	.double	-1.0
 	.double	-1.0
@@ -10422,8 +10422,8 @@ LC01:
 	.align 32
 .LC02:
 #elif defined(OS_MAC)
-LC02:
 	.align 5
+LC02:
 #endif
 	.double	1.0
 	.double	1.0

--- a/kernel/avx2/kernel_dgemm_4x4_lib4.S
+++ b/kernel/avx2/kernel_dgemm_4x4_lib4.S
@@ -10973,7 +10973,7 @@ NAME:
 	vbroadcastsd	88(%r11), %ymm13
 	vfmadd231pd		%ymm3, %ymm13, %ymm12
 	vmovapd			%ymm12, 64(%r12)
-	// 3
+	// 1
 	vmovapd			96(%r12), %ymm12
 	vbroadcastsd	120(%r11), %ymm13
 	vfmadd231pd		%ymm3, %ymm13, %ymm12

--- a/kernel/avx512/Makefile
+++ b/kernel/avx512/Makefile
@@ -72,3 +72,4 @@ clean:
 
 kernel_dgemm_8x8_lib8.o: kernel_dgemm_8x8_lib8.S kernel_dgemm_8x8_lib.S
 kernel_dgemm_16x8_lib8.o: kernel_dgemm_16x8_lib8.S kernel_dgemm_16x8_lib.S
+kernel_dgemm_24x8_lib8.o: kernel_dgemm_24x8_lib8.S kernel_dgemm_24x8_lib.S

--- a/kernel/avx512/Makefile
+++ b/kernel/avx512/Makefile
@@ -44,6 +44,7 @@ KERNEL_OBJS = \
 		kernel_dgemv_16_lib8.o \
 		kernel_dpack_lib8.o \
 		kernel_dgeqrf_8_lib8.o \
+		kernel_dgelqf_lib8.o \
 
 endif
 

--- a/kernel/avx512/Makefile
+++ b/kernel/avx512/Makefile
@@ -38,6 +38,7 @@ include ../../Makefile.rule
 
 ifeq ($(TARGET), X64_INTEL_SKYLAKE_X)
 KERNEL_OBJS = \
+		kernel_dgemm_24x8_lib8.o \
 		kernel_dgemm_16x8_lib8.o \
 		kernel_dgemm_8x8_lib8.o \
 		kernel_dgemv_8_lib8.o \

--- a/kernel/avx512/Makefile
+++ b/kernel/avx512/Makefile
@@ -43,6 +43,7 @@ KERNEL_OBJS = \
 		kernel_dgemv_8_lib8.o \
 		kernel_dgemv_16_lib8.o \
 		kernel_dpack_lib8.o \
+		kernel_dgeqrf_8_lib8.o \
 
 endif
 

--- a/kernel/avx512/kernel_dgelqf_lib8.S
+++ b/kernel/avx512/kernel_dgelqf_lib8.S
@@ -5236,15 +5236,14 @@ NAME:
 
 	// first column
 
-//	movq	ARG2, %r11 // D
+	movq	ARG1, %r10 // n
 	movq	ARG4, %r11 // A
-	movq	ARG3, %r12 // dD
-	movq	ARG5, %r13 // T
 
 	vxorpd			%xmm25, %xmm25, %xmm25
-	movq	ARG1, %r10 // n
 //	subl	$ 1, %r10d
 //	addq	$ 64, %r11
+	cmpl	$ 0, %r10d
+	jle		101f
 100:
 	vmovsd			0(%r11), %xmm24
 	vfmadd231sd		%xmm24, %xmm24, %xmm25
@@ -5252,6 +5251,10 @@ NAME:
 	addq	$ 64, %r11
 	cmpl	$ 0, %r10d
 	jg		100b
+101:
+
+	movq	ARG3, %r12 // dD
+	movq	ARG5, %r13 // T
 
 	vxorpd			%xmm24, %xmm24, %xmm24
 	vucomisd		%xmm24, %xmm25
@@ -5275,8 +5278,8 @@ NAME:
 	vxorpd			%xmm31, %xmm24, %xmm27
 	vmovsd			%xmm27, 0+64*0(%r13) // pT[0+ps*0]
 
-//	vmovapd			0*64(%r11), %zmm0
-	vxorpd			%zmm0, %zmm0, %zmm0
+	vmovapd			0*64(%r11), %zmm0
+//	vxorpd			%zmm0, %zmm0, %zmm0
 	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
 //	vbroadcastsd	0+1*64(%r11), %zmm17
 //	vmulpd			%zmm25, %zmm17, %zmm17
@@ -5365,7 +5368,7 @@ NAME:
 //	vmovapd			%zmm23, 7*64(%r11)
 
 	movq	ARG1, %r10 // n
-	movq	ARG4, %r11
+	movq	ARG4, %r11 // A
 
 	movq	$ 0, %r14 // XXX chech for reg overwrite
 
@@ -5407,8 +5410,10 @@ NAME:
 	vxorpd			%xmm31, %xmm24, %xmm27
 	vmovsd			%xmm27, 8+64*1(%r13) // pT[1+ps*1]
 
-//	vmovapd			1*64(%r11), %zmm0
-	vxorpd			%zmm0, %zmm0, %zmm0
+	movl	$ 0xfe, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			1*64(%r11), %zmm0 {%k1}{z}
+//	vxorpd			%zmm0, %zmm0, %zmm0
 	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
 ////	vbroadcastsd	8+1*64(%r11), %zmm17
 ////	vmulpd			%zmm25, %zmm17, %zmm17
@@ -5552,8 +5557,10 @@ NAME:
 	vxorpd			%xmm31, %xmm24, %xmm27
 	vmovsd			%xmm27, 16+64*2(%r13) // pT[1+ps*1]
 
-//	vmovapd			2*64(%r11), %zmm0
-	vxorpd			%zmm0, %zmm0, %zmm0
+	movl	$ 0xfc, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			2*64(%r11), %zmm0 {%k1}{z}
+//	vxorpd			%zmm0, %zmm0, %zmm0
 	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
 ////	vbroadcastsd	16+1*64(%r11), %zmm17
 ////	vmulpd			%zmm25, %zmm17, %zmm17
@@ -5704,8 +5711,10 @@ NAME:
 	vxorpd			%xmm31, %xmm24, %xmm27
 	vmovsd			%xmm27, 24+64*3(%r13) // pT[1+ps*1]
 
-//	vmovapd			3*64(%r11), %zmm0
-	vxorpd			%zmm0, %zmm0, %zmm0
+	movl	$ 0xf8, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			3*64(%r11), %zmm0 {%k1}{z}
+//	vxorpd			%zmm0, %zmm0, %zmm0
 	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
 ////	vbroadcastsd	24+1*64(%r11), %zmm17
 ////	vmulpd			%zmm25, %zmm17, %zmm17
@@ -5867,8 +5876,10 @@ NAME:
 	vxorpd			%xmm31, %xmm24, %xmm27
 	vmovsd			%xmm27, 32+64*4(%r13) // pT[1+ps*1]
 
-//	vmovapd			4*64(%r11), %zmm0
-	vxorpd			%zmm0, %zmm0, %zmm0
+	movl	$ 0xf0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			4*64(%r11), %zmm0 {%k1}{z}
+//	vxorpd			%zmm0, %zmm0, %zmm0
 	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
 ////	vbroadcastsd	32+1*64(%r11), %zmm17
 ////	vmulpd			%zmm25, %zmm17, %zmm17
@@ -6045,8 +6056,10 @@ NAME:
 	vxorpd			%xmm31, %xmm24, %xmm27
 	vmovsd			%xmm27, 40+64*5(%r13) // pT[1+ps*1]
 
-//	vmovapd			5*64(%r11), %zmm0
-	vxorpd			%zmm0, %zmm0, %zmm0
+	movl	$ 0xe0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			5*64(%r11), %zmm0 {%k1}{z}
+//	vxorpd			%zmm0, %zmm0, %zmm0
 	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
 ////	vbroadcastsd	40+1*64(%r11), %zmm17
 ////	vmulpd			%zmm25, %zmm17, %zmm17
@@ -6235,8 +6248,10 @@ NAME:
 	vxorpd			%xmm31, %xmm24, %xmm27
 	vmovsd			%xmm27, 48+64*6(%r13) // pT[1+ps*1]
 
-//	vmovapd			6*64(%r11), %zmm0
-	vxorpd			%zmm0, %zmm0, %zmm0
+	movl	$ 0xc0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			6*64(%r11), %zmm0 {%k1}{z}
+//	vxorpd			%zmm0, %zmm0, %zmm0
 	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
 ////	vbroadcastsd	48+1*64(%r11), %zmm17
 ////	vmulpd			%zmm25, %zmm17, %zmm17
@@ -6437,8 +6452,10 @@ NAME:
 	vxorpd			%xmm31, %xmm24, %xmm27
 	vmovsd			%xmm27, 56+64*7(%r13) // pT[1+ps*1]
 
-//	vmovapd			7*64(%r11), %zmm0
-	vxorpd			%zmm0, %zmm0, %zmm0
+	movl	$ 0x80, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			7*64(%r11), %zmm0 {%k1}{z}
+//	vxorpd			%zmm0, %zmm0, %zmm0
 	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
 ////	vbroadcastsd	56+1*64(%r11), %zmm17
 ////	vmulpd			%zmm25, %zmm17, %zmm17
@@ -6564,6 +6581,1859 @@ NAME:
 	ret
 
 	FUN_END(kernel_dgelqf_pd_la_dlarft8_8_lib8)
+
+
+
+
+
+//                                          1       2       3           4           5           6           7
+// void kernel_dgelqf_pd_lla_dlarft8_8_lib8(int n0, int n1, double *pD, double *dD, double *pL, double *pA, double *pT)
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dgelqf_pd_lla_dlarft8_8_lib8)
+	
+	PROLOGUE
+
+	// zero T
+
+	movq	ARG7, %r10 // T
+
+	vxorpd			%zmm24, %zmm24, %zmm24
+	vmovapd			%zmm24, 0*64(%r10)
+	vmovapd			%zmm24, 1*64(%r10)
+	vmovapd			%zmm24, 2*64(%r10)
+	vmovapd			%zmm24, 3*64(%r10)
+	vmovapd			%zmm24, 4*64(%r10)
+	vmovapd			%zmm24, 5*64(%r10)
+	vmovapd			%zmm24, 6*64(%r10)
+	vmovapd			%zmm24, 7*64(%r10)
+
+	// first column
+
+	movq	ARG5, %r11 // L
+
+	vxorpd			%xmm25, %xmm25, %xmm25
+	vmovsd			0(%r11), %xmm24
+	vfmadd231sd		%xmm24, %xmm24, %xmm25
+
+	movq	ARG2, %r10 // n
+	movq	ARG6, %r11 // A
+
+//	subl	$ 1, %r10d
+//	addq	$ 64, %r11
+	cmpl	$ 0, %r10d
+	jle		101f
+100:
+	vmovsd			0(%r11), %xmm24
+	vfmadd231sd		%xmm24, %xmm24, %xmm25
+	subl	$ 1, %r10d
+	addq	$ 64, %r11
+	cmpl	$ 0, %r10d
+	jg		100b
+101:
+
+	movq	ARG4, %r12 // dD
+	movq	ARG7, %r13 // T
+
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		101f
+	vmovsd			%xmm24, 0(%r12)
+	jmp		102f
+
+101:
+	movq	ARG3, %r11 // D
+
+	leaq	0+64*0(%r11), %r14 // XXX chech for reg overwrite
+	leaq	0(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vxorpd			%xmm31, %xmm24, %xmm27
+	vmovsd			%xmm27, 0+64*0(%r13) // pT[0+ps*0]
+
+	// D
+
+	vmovapd			0*64(%r11), %zmm0 // TODO k1 for next cols
+
+	// L
+	movq	ARG1, %r10 // n0
+	movq	ARG5, %r11 // L
+
+	movq	$ 0, %r14 // XXX chech for reg overwrite
+
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+	// final triangle
+	vbroadcastsd	0*64(%r11, %r14), %zmm16
+	vmulpd			%zmm25, %zmm16, %zmm16
+//	vbroadcastsd	1*64(%r11, %r14), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+//	vbroadcastsd	2*64(%r11, %r14), %zmm18
+//	vmulpd			%zmm25, %zmm18, %zmm18
+//	vbroadcastsd	3*64(%r11, %r14), %zmm19
+//	vmulpd			%zmm25, %zmm19, %zmm19
+//	vbroadcastsd	4*64(%r11, %r14), %zmm20
+//	vmulpd			%zmm25, %zmm20, %zmm20
+//	vbroadcastsd	5*64(%r11, %r14), %zmm21
+//	vmulpd			%zmm25, %zmm21, %zmm21
+//	vbroadcastsd	6*64(%r11, %r14), %zmm22
+//	vmulpd			%zmm25, %zmm22, %zmm22
+//	vbroadcastsd	7*64(%r11, %r14), %zmm23
+//	vmulpd			%zmm25, %zmm23, %zmm23
+	vfmadd231pd		0*64(%r11), %zmm16, %zmm0 // TODO k1 for next cols
+	vmovsd			%xmm16, 0*64(%r11, %r14)
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm1
+//	vmovsd			%xmm17, 1*64(%r11, %r14)
+//	vfmadd231pd		2*64(%r11), %zmm18, %zmm0
+//	vmovsd			%xmm18, 2*64(%r11, %r14)
+//	vfmadd231pd		3*64(%r11), %zmm19, %zmm1
+//	vmovsd			%xmm19, 3*64(%r11, %r14)
+//	vfmadd231pd		4*64(%r11), %zmm20, %zmm0
+//	vmovsd			%xmm20, 4*64(%r11, %r14)
+//	vfmadd231pd		5*64(%r11), %zmm21, %zmm1
+//	vmovsd			%xmm21, 5*64(%r11, %r14)
+//	vfmadd231pd		6*64(%r11), %zmm22, %zmm0
+//	vmovsd			%xmm22, 6*64(%r11, %r14)
+//	vfmadd231pd		7*64(%r11), %zmm23, %zmm1
+//	vmovsd			%xmm23, 7*64(%r11, %r14)
+
+	// A
+	movq	ARG2, %r10 // n1
+	movq	ARG6, %r11 // A
+
+	movq	$ 0, %r14 // XXX chech for reg overwrite
+
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0xfe, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vbroadcastsd	0(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0 {%k1}{z}
+
+	// D
+	movq	ARG3, %r11 // D
+	vmovapd			0*64(%r11), %zmm16
+	vaddpd			%zmm0, %zmm16, %zmm16
+	vmovapd			%zmm16, 0*64(%r11)
+
+	// L
+	movq	ARG1, %r10 // n0
+	movq	ARG5, %r11 // L
+
+	movq	$ 0, %r14 // XXX chech for reg overwrite
+
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+	// final triangle
+	vmovapd			0*64(%r11), %zmm16
+	movl	$ 0xfe, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			1*64(%r11), %zmm17 {%k1}{z}
+//	vmovapd			2*64(%r11), %zmm18
+//	vmovapd			3*64(%r11), %zmm19
+//	vmovapd			4*64(%r11), %zmm20
+//	vmovapd			5*64(%r11), %zmm21
+//	vmovapd			6*64(%r11), %zmm22
+//	vmovapd			7*64(%r11), %zmm23
+	vbroadcastsd	0*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm16
+//	vbroadcastsd	1*64(%r11, %r14), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm17
+//	vbroadcastsd	2*64(%r11, %r14), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm18
+//	vbroadcastsd	3*64(%r11, %r14), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm19
+//	vbroadcastsd	4*64(%r11, %r14), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm20
+//	vbroadcastsd	5*64(%r11, %r14), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm21
+//	vbroadcastsd	6*64(%r11, %r14), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm22
+//	vbroadcastsd	7*64(%r11, %r14), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vfmadd231pd		%zmm16, %zmm16, %zmm25
+	vmovapd			%zmm16, 0*64(%r11)
+	vfmadd231pd		%zmm17, %zmm17, %zmm25
+//	vmovapd			%zmm17, 1*64(%r11)
+//	vfmadd231pd		%zmm18, %zmm18, %zmm25
+//	vmovapd			%zmm18, 2*64(%r11)
+//	vfmadd231pd		%zmm19, %zmm19, %zmm25
+//	vmovapd			%zmm19, 3*64(%r11)
+//	vfmadd231pd		%zmm20, %zmm20, %zmm25
+//	vmovapd			%zmm20, 4*64(%r11)
+//	vfmadd231pd		%zmm21, %zmm21, %zmm25
+//	vmovapd			%zmm21, 5*64(%r11)
+//	vfmadd231pd		%zmm22, %zmm22, %zmm25
+//	vmovapd			%zmm22, 6*64(%r11)
+//	vfmadd231pd		%zmm23, %zmm23, %zmm25
+//	vmovapd			%zmm23, 7*64(%r11)
+
+	// A
+	movq	ARG2, %r10 // n1
+	movq	ARG6, %r11 // A
+
+	movq	$ 0, %r14 // XXX chech for reg overwrite
+
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// second column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 8(%r12)
+	jmp		102f
+
+101:
+	movq	ARG3, %r11 // D
+
+	leaq	8+64*1(%r11), %r14 // XXX chech for reg overwrite
+	leaq	8(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vxorpd			%xmm31, %xmm24, %xmm27
+	vmovsd			%xmm27, 8+64*1(%r13) // pT[1+ps*1]
+
+	// D
+	movq	ARG3, %r11 // D
+
+	movl	$ 0xfe, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			1*64(%r11), %zmm0 {%k1}{z}
+
+	// L
+	movq	ARG1, %r10 // n0
+	movq	ARG5, %r11 // L
+
+	movq	$ 8, %r14 // XXX chech for reg overwrite
+
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+	// final triangle
+	vbroadcastsd	0*64(%r11, %r14), %zmm16
+	vmulpd			%zmm25, %zmm16, %zmm16
+	vbroadcastsd	1*64(%r11, %r14), %zmm17
+	vmulpd			%zmm25, %zmm17, %zmm17
+//	vbroadcastsd	2*64(%r11, %r14), %zmm18
+//	vmulpd			%zmm25, %zmm18, %zmm18
+//	vbroadcastsd	3*64(%r11, %r14), %zmm19
+//	vmulpd			%zmm25, %zmm19, %zmm19
+//	vbroadcastsd	4*64(%r11, %r14), %zmm20
+//	vmulpd			%zmm25, %zmm20, %zmm20
+//	vbroadcastsd	5*64(%r11, %r14), %zmm21
+//	vmulpd			%zmm25, %zmm21, %zmm21
+//	vbroadcastsd	6*64(%r11, %r14), %zmm22
+//	vmulpd			%zmm25, %zmm22, %zmm22
+//	vbroadcastsd	7*64(%r11, %r14), %zmm23
+//	vmulpd			%zmm25, %zmm23, %zmm23
+	vfmadd231pd		0*64(%r11), %zmm16, %zmm0 // TODO k1 for next cols
+	vmovsd			%xmm16, 0*64(%r11, %r14)
+	movl	$ 0xfe, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		1*64(%r11), %zmm17, %zmm0 {%k1}
+	vmovsd			%xmm17, 1*64(%r11, %r14)
+//	vfmadd231pd		2*64(%r11), %zmm18, %zmm0
+//	vmovsd			%xmm18, 2*64(%r11, %r14)
+//	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+//	vmovsd			%xmm19, 3*64(%r11, %r14)
+//	vfmadd231pd		4*64(%r11), %zmm20, %zmm0
+//	vmovsd			%xmm20, 4*64(%r11, %r14)
+//	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+//	vmovsd			%xmm21, 5*64(%r11, %r14)
+//	vfmadd231pd		6*64(%r11), %zmm22, %zmm0
+//	vmovsd			%xmm22, 6*64(%r11, %r14)
+//	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+//	vmovsd			%xmm23, 7*64(%r11, %r14)
+
+	// A
+	movq	ARG2, %r10 // n
+	movq	ARG6, %r11
+
+	movq	$ 8, %r14 // XXX chech for reg overwrite
+
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC00+16(%rip), %zmm27 // 1.0
+#else
+	vbroadcastsd	LC00+16(%rip), %zmm27 // 1.0
+#endif
+	movl	$ 0x01, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			0+64*0(%r13), %zmm27 {%k1}
+	vmulpd			%zmm27, %zmm0, %zmm0
+	vbroadcastsd	8+64*1(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0
+	vmovapd			%zmm0, 1*64(%r13) {%k1}
+
+	movl	$ 0xfc, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm0, %zmm0 {%k1}{z}
+
+	// D
+	movq	ARG3, %r11 // D
+	vmovapd			1*64(%r11), %zmm17
+	vaddpd			%zmm0, %zmm17, %zmm17
+	vmovapd			%zmm17, 1*64(%r11)
+
+	// L
+	movq	ARG1, %r10 // n
+	movq	ARG5, %r11
+
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+
+	movq	$ 8, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+	// final triangle
+	vmovapd			0*64(%r11), %zmm16
+	movl	$ 0xfe, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			1*64(%r11), %zmm17 {%k1}{z}
+	movl	$ 0xfc, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			2*64(%r11), %zmm18 {%k1}{z}
+//	vmovapd			3*64(%r11), %zmm19
+//	vmovapd			4*64(%r11), %zmm20
+//	vmovapd			5*64(%r11), %zmm21
+//	vmovapd			6*64(%r11), %zmm22
+//	vmovapd			7*64(%r11), %zmm23
+	vbroadcastsd	0*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm16
+	vbroadcastsd	1*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm17
+//	vbroadcastsd	2*64(%r11, %r14), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm18
+//	vbroadcastsd	3*64(%r11, %r14), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm19
+//	vbroadcastsd	4*64(%r11, %r14), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm20
+//	vbroadcastsd	5*64(%r11, %r14), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm21
+//	vbroadcastsd	6*64(%r11, %r14), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm22
+//	vbroadcastsd	7*64(%r11, %r14), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vfmadd231pd		%zmm16, %zmm16, %zmm25
+	vmovapd			%zmm16, 0*64(%r11)
+	vfmadd231pd		%zmm17, %zmm17, %zmm25
+	movl	$ 0xfe, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm17, 1*64(%r11) {%k1}
+	vfmadd231pd		%zmm18, %zmm18, %zmm25
+//	vmovapd			%zmm18, 2*64(%r11)
+//	vfmadd231pd		%zmm19, %zmm19, %zmm25
+//	vmovapd			%zmm19, 3*64(%r11)
+//	vfmadd231pd		%zmm20, %zmm20, %zmm25
+//	vmovapd			%zmm20, 4*64(%r11)
+//	vfmadd231pd		%zmm21, %zmm21, %zmm25
+//	vmovapd			%zmm21, 5*64(%r11)
+//	vfmadd231pd		%zmm22, %zmm22, %zmm25
+//	vmovapd			%zmm22, 6*64(%r11)
+//	vfmadd231pd		%zmm23, %zmm23, %zmm25
+//	vmovapd			%zmm23, 7*64(%r11)
+
+	// A
+	movq	ARG2, %r10 // n
+	movq	ARG6, %r11
+
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+
+	movq	$ 8, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// third column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 16(%r12)
+	jmp		102f
+
+101:
+	movq	ARG3, %r11 // D
+
+	leaq	16+64*2(%r11), %r14 // XXX chech for reg overwrite
+	leaq	16(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vxorpd			%xmm31, %xmm24, %xmm27
+	vmovsd			%xmm27, 16+64*2(%r13) // pT[1+ps*1]
+
+	// D
+	movq	ARG3, %r11 // D
+
+	movl	$ 0xfc, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			2*64(%r11), %zmm0 {%k1}{z}
+
+	// L
+	movq	ARG1, %r10 // n0
+	movq	ARG5, %r11 // L
+
+	movq	$ 16, %r14 // XXX chech for reg overwrite
+
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+	// final triangle
+	vbroadcastsd	0*64(%r11, %r14), %zmm16
+	vmulpd			%zmm25, %zmm16, %zmm16
+	vbroadcastsd	1*64(%r11, %r14), %zmm17
+	vmulpd			%zmm25, %zmm17, %zmm17
+	vbroadcastsd	2*64(%r11, %r14), %zmm18
+	vmulpd			%zmm25, %zmm18, %zmm18
+//	vbroadcastsd	3*64(%r11, %r14), %zmm19
+//	vmulpd			%zmm25, %zmm19, %zmm19
+//	vbroadcastsd	4*64(%r11, %r14), %zmm20
+//	vmulpd			%zmm25, %zmm20, %zmm20
+//	vbroadcastsd	5*64(%r11, %r14), %zmm21
+//	vmulpd			%zmm25, %zmm21, %zmm21
+//	vbroadcastsd	6*64(%r11, %r14), %zmm22
+//	vmulpd			%zmm25, %zmm22, %zmm22
+//	vbroadcastsd	7*64(%r11, %r14), %zmm23
+//	vmulpd			%zmm25, %zmm23, %zmm23
+	vfmadd231pd		0*64(%r11), %zmm16, %zmm0 // TODO k1 for next cols
+	vmovsd			%xmm16, 0*64(%r11, %r14)
+	movl	$ 0xfe, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		1*64(%r11), %zmm17, %zmm0 {%k1}
+	vmovsd			%xmm17, 1*64(%r11, %r14)
+	movl	$ 0xfc, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		2*64(%r11), %zmm18, %zmm0 {%k1}
+	vmovsd			%xmm18, 2*64(%r11, %r14)
+//	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+//	vmovsd			%xmm19, 3*64(%r11, %r14)
+//	vfmadd231pd		4*64(%r11), %zmm20, %zmm0
+//	vmovsd			%xmm20, 4*64(%r11, %r14)
+//	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+//	vmovsd			%xmm21, 5*64(%r11, %r14)
+//	vfmadd231pd		6*64(%r11), %zmm22, %zmm0
+//	vmovsd			%xmm22, 6*64(%r11, %r14)
+//	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+//	vmovsd			%xmm23, 7*64(%r11, %r14)
+
+	// A
+	movq	ARG2, %r10 // n
+	movq	ARG6, %r11
+
+	movq	$ 16, %r14 // XXX chech for reg overwrite
+
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0x01, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			0*64(%r13), %zmm24
+	vmulpd			%zmm24, %zmm0, %zmm1 {%k1}{z}
+	vmovapd			1*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x03, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	vmovapd			%zmm1, %zmm0 {%k1}
+	vbroadcastsd	16+2*64(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0
+	vmovapd			%zmm0, 2*64(%r13) {%k1}
+
+	movl	$ 0xf8, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm0, %zmm0 {%k1}{z}
+
+	// D
+	movq	ARG3, %r11 // D
+	vmovapd			2*64(%r11), %zmm18
+	vaddpd			%zmm0, %zmm18, %zmm18
+	vmovapd			%zmm18, 2*64(%r11)
+
+	// L
+	movq	ARG1, %r10 // n
+	movq	ARG5, %r11
+
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+
+	movq	$ 16, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+	// final triangle
+	vmovapd			0*64(%r11), %zmm16
+	movl	$ 0xfe, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			1*64(%r11), %zmm17 {%k1}{z}
+	movl	$ 0xfc, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			2*64(%r11), %zmm18 {%k1}{z}
+	movl	$ 0xf8, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			3*64(%r11), %zmm19 {%k1}{z}
+//	vmovapd			4*64(%r11), %zmm20
+//	vmovapd			5*64(%r11), %zmm21
+//	vmovapd			6*64(%r11), %zmm22
+//	vmovapd			7*64(%r11), %zmm23
+	vbroadcastsd	0*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm16
+	vbroadcastsd	1*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm17
+	vbroadcastsd	2*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm18
+//	vbroadcastsd	3*64(%r11, %r14), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm19
+//	vbroadcastsd	4*64(%r11, %r14), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm20
+//	vbroadcastsd	5*64(%r11, %r14), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm21
+//	vbroadcastsd	6*64(%r11, %r14), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm22
+//	vbroadcastsd	7*64(%r11, %r14), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vfmadd231pd		%zmm16, %zmm16, %zmm25
+	vmovapd			%zmm16, 0*64(%r11)
+	vfmadd231pd		%zmm17, %zmm17, %zmm25
+	movl	$ 0xfe, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm17, 1*64(%r11) {%k1}
+	vfmadd231pd		%zmm18, %zmm18, %zmm25
+	movl	$ 0xfc, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm18, 2*64(%r11) {%k1}
+	vfmadd231pd		%zmm19, %zmm19, %zmm25
+//	vmovapd			%zmm19, 3*64(%r11)
+//	vfmadd231pd		%zmm20, %zmm20, %zmm25
+//	vmovapd			%zmm20, 4*64(%r11)
+//	vfmadd231pd		%zmm21, %zmm21, %zmm25
+//	vmovapd			%zmm21, 5*64(%r11)
+//	vfmadd231pd		%zmm22, %zmm22, %zmm25
+//	vmovapd			%zmm22, 6*64(%r11)
+//	vfmadd231pd		%zmm23, %zmm23, %zmm25
+//	vmovapd			%zmm23, 7*64(%r11)
+
+	// A
+	movq	ARG2, %r10 // n
+	movq	ARG6, %r11
+
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+
+	movq	$ 16, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// fourth column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 24(%r12)
+	jmp		102f
+
+101:
+	movq	ARG3, %r11 // D
+
+	leaq	24+64*3(%r11), %r14 // XXX chech for reg overwrite
+	leaq	24(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vxorpd			%xmm31, %xmm24, %xmm27
+	vmovsd			%xmm27, 24+64*3(%r13) // pT[1+ps*1]
+
+	// D
+	movl	$ 0xf8, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			3*64(%r11), %zmm0 {%k1}{z}
+
+	// L
+	movq	ARG1, %r10 // n0
+	movq	ARG5, %r11 // L
+
+	movq	$ 24, %r14 // XXX chech for reg overwrite
+
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+	// final triangle
+	vbroadcastsd	0*64(%r11, %r14), %zmm16
+	vmulpd			%zmm25, %zmm16, %zmm16
+	vbroadcastsd	1*64(%r11, %r14), %zmm17
+	vmulpd			%zmm25, %zmm17, %zmm17
+	vbroadcastsd	2*64(%r11, %r14), %zmm18
+	vmulpd			%zmm25, %zmm18, %zmm18
+	vbroadcastsd	3*64(%r11, %r14), %zmm19
+	vmulpd			%zmm25, %zmm19, %zmm19
+//	vbroadcastsd	4*64(%r11, %r14), %zmm20
+//	vmulpd			%zmm25, %zmm20, %zmm20
+//	vbroadcastsd	5*64(%r11, %r14), %zmm21
+//	vmulpd			%zmm25, %zmm21, %zmm21
+//	vbroadcastsd	6*64(%r11, %r14), %zmm22
+//	vmulpd			%zmm25, %zmm22, %zmm22
+//	vbroadcastsd	7*64(%r11, %r14), %zmm23
+//	vmulpd			%zmm25, %zmm23, %zmm23
+	vfmadd231pd		0*64(%r11), %zmm16, %zmm0
+	vmovsd			%xmm16, 0*64(%r11, %r14)
+	movl	$ 0xfe, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		1*64(%r11), %zmm17, %zmm0 {%k1}
+	vmovsd			%xmm17, 1*64(%r11, %r14)
+	movl	$ 0xfc, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		2*64(%r11), %zmm18, %zmm0 {%k1}
+	vmovsd			%xmm18, 2*64(%r11, %r14)
+	movl	$ 0xf8, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		3*64(%r11), %zmm19, %zmm0 {%k1}
+	vmovsd			%xmm19, 3*64(%r11, %r14)
+//	vfmadd231pd		4*64(%r11), %zmm20, %zmm0
+//	vmovsd			%xmm20, 4*64(%r11, %r14)
+//	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+//	vmovsd			%xmm21, 5*64(%r11, %r14)
+//	vfmadd231pd		6*64(%r11), %zmm22, %zmm0
+//	vmovsd			%xmm22, 6*64(%r11, %r14)
+//	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+//	vmovsd			%xmm23, 7*64(%r11, %r14)
+
+	// A
+	movq	ARG2, %r10 // n
+	movq	ARG6, %r11
+
+	movq	$ 24, %r14 // XXX chech for reg overwrite
+
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0x01, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			0*64(%r13), %zmm24
+	vmulpd			%zmm24, %zmm0, %zmm1 {%k1}{z}
+	vmovapd			1*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x03, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	vmovapd			2*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x07, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	vmovapd			%zmm1, %zmm0 {%k1}
+	vbroadcastsd	24+3*64(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0
+	vmovapd			%zmm0, 3*64(%r13) {%k1}
+
+	movl	$ 0xf0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm0, %zmm0 {%k1}{z}
+
+	// D
+	movq	ARG3, %r11 // D
+	vmovapd			3*64(%r11), %zmm19
+	vaddpd			%zmm0, %zmm19, %zmm19
+	vmovapd			%zmm19, 3*64(%r11)
+
+	// L
+	movq	ARG1, %r10 // n
+	movq	ARG5, %r11
+
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+
+	movq	$ 24, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+	// final triangle
+	vmovapd			0*64(%r11), %zmm16
+	movl	$ 0xfe, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			1*64(%r11), %zmm17 {%k1}{z}
+	movl	$ 0xfc, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			2*64(%r11), %zmm18 {%k1}{z}
+	movl	$ 0xf8, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			3*64(%r11), %zmm19 {%k1}{z}
+	movl	$ 0xf0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			4*64(%r11), %zmm20 {%k1}{z}
+//	vmovapd			5*64(%r11), %zmm21
+//	vmovapd			6*64(%r11), %zmm22
+//	vmovapd			7*64(%r11), %zmm23
+	vbroadcastsd	0*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm16
+	vbroadcastsd	1*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm17
+	vbroadcastsd	2*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm18
+	vbroadcastsd	3*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm19
+//	vbroadcastsd	4*64(%r11, %r14), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm20
+//	vbroadcastsd	5*64(%r11, %r14), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm21
+//	vbroadcastsd	6*64(%r11, %r14), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm22
+//	vbroadcastsd	7*64(%r11, %r14), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vfmadd231pd		%zmm16, %zmm16, %zmm25
+	vmovapd			%zmm16, 0*64(%r11)
+	vfmadd231pd		%zmm17, %zmm17, %zmm25
+	movl	$ 0xfe, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm17, 1*64(%r11) {%k1}
+	vfmadd231pd		%zmm18, %zmm18, %zmm25
+	movl	$ 0xfc, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm18, 2*64(%r11) {%k1}
+	vfmadd231pd		%zmm19, %zmm19, %zmm25
+	movl	$ 0xf8, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm19, 3*64(%r11) {%k1}
+	vfmadd231pd		%zmm20, %zmm20, %zmm25
+//	vmovapd			%zmm20, 4*64(%r11)
+//	vfmadd231pd		%zmm21, %zmm21, %zmm25
+//	vmovapd			%zmm21, 5*64(%r11)
+//	vfmadd231pd		%zmm22, %zmm22, %zmm25
+//	vmovapd			%zmm22, 6*64(%r11)
+//	vfmadd231pd		%zmm23, %zmm23, %zmm25
+//	vmovapd			%zmm23, 7*64(%r11)
+
+	// A
+	movq	ARG2, %r10 // n
+	movq	ARG6, %r11
+
+	movq	$ 24, %r14 // XXX chech for reg overwrite
+
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// fifth column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 32(%r12)
+	jmp		102f
+
+101:
+	movq	ARG3, %r11 // D
+
+	leaq	32+64*4(%r11), %r14 // XXX chech for reg overwrite
+	leaq	32(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vxorpd			%xmm31, %xmm24, %xmm27
+	vmovsd			%xmm27, 32+64*4(%r13) // pT[1+ps*1]
+
+	// D
+	movl	$ 0xf0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			4*64(%r11), %zmm0 {%k1}{z}
+
+	// L
+	movq	ARG1, %r10 // n0
+	movq	ARG5, %r11 // L
+
+	movq	$ 32, %r14 // XXX chech for reg overwrite
+
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+	// final triangle
+	vbroadcastsd	0*64(%r11, %r14), %zmm16
+	vmulpd			%zmm25, %zmm16, %zmm16
+	vbroadcastsd	1*64(%r11, %r14), %zmm17
+	vmulpd			%zmm25, %zmm17, %zmm17
+	vbroadcastsd	2*64(%r11, %r14), %zmm18
+	vmulpd			%zmm25, %zmm18, %zmm18
+	vbroadcastsd	3*64(%r11, %r14), %zmm19
+	vmulpd			%zmm25, %zmm19, %zmm19
+	vbroadcastsd	4*64(%r11, %r14), %zmm20
+	vmulpd			%zmm25, %zmm20, %zmm20
+//	vbroadcastsd	5*64(%r11, %r14), %zmm21
+//	vmulpd			%zmm25, %zmm21, %zmm21
+//	vbroadcastsd	6*64(%r11, %r14), %zmm22
+//	vmulpd			%zmm25, %zmm22, %zmm22
+//	vbroadcastsd	7*64(%r11, %r14), %zmm23
+//	vmulpd			%zmm25, %zmm23, %zmm23
+	vfmadd231pd		0*64(%r11), %zmm16, %zmm0
+	vmovsd			%xmm16, 0*64(%r11, %r14)
+	movl	$ 0xfe, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		1*64(%r11), %zmm17, %zmm0 {%k1}
+	vmovsd			%xmm17, 1*64(%r11, %r14)
+	movl	$ 0xfc, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		2*64(%r11), %zmm18, %zmm0 {%k1}
+	vmovsd			%xmm18, 2*64(%r11, %r14)
+	movl	$ 0xf8, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		3*64(%r11), %zmm19, %zmm0 {%k1}
+	vmovsd			%xmm19, 3*64(%r11, %r14)
+	movl	$ 0xf0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		4*64(%r11), %zmm20, %zmm0 {%k1}
+	vmovsd			%xmm20, 4*64(%r11, %r14)
+//	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+//	vmovsd			%xmm21, 5*64(%r11, %r14)
+//	vfmadd231pd		6*64(%r11), %zmm22, %zmm0
+//	vmovsd			%xmm22, 6*64(%r11, %r14)
+//	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+//	vmovsd			%xmm23, 7*64(%r11, %r14)
+
+	// A
+	movq	ARG2, %r10 // n
+	movq	ARG6, %r11
+
+	movq	$ 32, %r14 // XXX chech for reg overwrite
+
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0x01, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			0*64(%r13), %zmm24
+	vmulpd			%zmm24, %zmm0, %zmm1 {%k1}{z}
+	//
+	vmovapd			1*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x03, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			2*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x07, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			3*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x0f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			%zmm1, %zmm0 {%k1}
+	vbroadcastsd	32+4*64(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0
+	vmovapd			%zmm0, 4*64(%r13) {%k1}
+
+	movl	$ 0xe0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm0, %zmm0 {%k1}{z}
+
+	// D
+	movq	ARG3, %r11 // D
+	vmovapd			4*64(%r11), %zmm20
+	vaddpd			%zmm0, %zmm20, %zmm20
+	vmovapd			%zmm20, 4*64(%r11)
+
+	// L
+	movq	ARG1, %r10 // n
+	movq	ARG5, %r11
+
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+
+	movq	$ 32, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+	// final triangle
+	vmovapd			0*64(%r11), %zmm16
+	movl	$ 0xfe, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			1*64(%r11), %zmm17 {%k1}{z}
+	movl	$ 0xfc, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			2*64(%r11), %zmm18 {%k1}{z}
+	movl	$ 0xf8, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			3*64(%r11), %zmm19 {%k1}{z}
+	movl	$ 0xf0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			4*64(%r11), %zmm20 {%k1}{z}
+	movl	$ 0xe0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			5*64(%r11), %zmm21 {%k1}{z}
+//	vmovapd			6*64(%r11), %zmm22
+//	vmovapd			7*64(%r11), %zmm23
+	vbroadcastsd	0*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm16
+	vbroadcastsd	1*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm17
+	vbroadcastsd	2*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm18
+	vbroadcastsd	3*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm19
+	vbroadcastsd	4*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm20
+//	vbroadcastsd	5*64(%r11, %r14), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm21
+//	vbroadcastsd	6*64(%r11, %r14), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm22
+//	vbroadcastsd	7*64(%r11, %r14), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vfmadd231pd		%zmm16, %zmm16, %zmm25
+	vmovapd			%zmm16, 0*64(%r11)
+	vfmadd231pd		%zmm17, %zmm17, %zmm25
+	movl	$ 0xfe, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm17, 1*64(%r11) {%k1}
+	vfmadd231pd		%zmm18, %zmm18, %zmm25
+	movl	$ 0xfc, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm18, 2*64(%r11) {%k1}
+	vfmadd231pd		%zmm19, %zmm19, %zmm25
+	movl	$ 0xf8, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm19, 3*64(%r11) {%k1}
+	vfmadd231pd		%zmm20, %zmm20, %zmm25
+	movl	$ 0xf0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm20, 4*64(%r11) {%k1}
+	vfmadd231pd		%zmm21, %zmm21, %zmm25
+//	vmovapd			%zmm21, 5*64(%r11)
+//	vfmadd231pd		%zmm22, %zmm22, %zmm25
+//	vmovapd			%zmm22, 6*64(%r11)
+//	vfmadd231pd		%zmm23, %zmm23, %zmm25
+//	vmovapd			%zmm23, 7*64(%r11)
+
+	// A
+	movq	ARG2, %r10 // n
+	movq	ARG6, %r11
+
+	movq	$ 32, %r14 // XXX chech for reg overwrite
+
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// sixth column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 40(%r12)
+	jmp		102f
+
+101:
+	movq	ARG3, %r11 // D
+
+	leaq	40+64*5(%r11), %r14 // XXX chech for reg overwrite
+	leaq	40(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vxorpd			%xmm31, %xmm24, %xmm27
+	vmovsd			%xmm27, 40+64*5(%r13) // pT[1+ps*1]
+
+	// D
+	movl	$ 0xc0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			5*64(%r11), %zmm0 {%k1}{z}
+
+	// L
+	movq	ARG1, %r10 // n0
+	movq	ARG5, %r11 // L
+
+	movq	$ 40, %r14 // XXX chech for reg overwrite
+
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+	// final triangle
+	vbroadcastsd	0*64(%r11, %r14), %zmm16
+	vmulpd			%zmm25, %zmm16, %zmm16
+	vbroadcastsd	1*64(%r11, %r14), %zmm17
+	vmulpd			%zmm25, %zmm17, %zmm17
+	vbroadcastsd	2*64(%r11, %r14), %zmm18
+	vmulpd			%zmm25, %zmm18, %zmm18
+	vbroadcastsd	3*64(%r11, %r14), %zmm19
+	vmulpd			%zmm25, %zmm19, %zmm19
+	vbroadcastsd	4*64(%r11, %r14), %zmm20
+	vmulpd			%zmm25, %zmm20, %zmm20
+	vbroadcastsd	5*64(%r11, %r14), %zmm21
+	vmulpd			%zmm25, %zmm21, %zmm21
+//	vbroadcastsd	6*64(%r11, %r14), %zmm22
+//	vmulpd			%zmm25, %zmm22, %zmm22
+//	vbroadcastsd	7*64(%r11, %r14), %zmm23
+//	vmulpd			%zmm25, %zmm23, %zmm23
+	vfmadd231pd		0*64(%r11), %zmm16, %zmm0
+	vmovsd			%xmm16, 0*64(%r11, %r14)
+	movl	$ 0xfe, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		1*64(%r11), %zmm17, %zmm0 {%k1}
+	vmovsd			%xmm17, 1*64(%r11, %r14)
+	movl	$ 0xfc, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		2*64(%r11), %zmm18, %zmm0 {%k1}
+	vmovsd			%xmm18, 2*64(%r11, %r14)
+	movl	$ 0xf8, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		3*64(%r11), %zmm19, %zmm0 {%k1}
+	vmovsd			%xmm19, 3*64(%r11, %r14)
+	movl	$ 0xf0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		4*64(%r11), %zmm20, %zmm0 {%k1}
+	vmovsd			%xmm20, 4*64(%r11, %r14)
+	movl	$ 0xe0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		5*64(%r11), %zmm21, %zmm0 {%k1}
+	vmovsd			%xmm21, 5*64(%r11, %r14)
+//	vfmadd231pd		6*64(%r11), %zmm22, %zmm0
+//	vmovsd			%xmm22, 6*64(%r11, %r14)
+//	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+//	vmovsd			%xmm23, 7*64(%r11, %r14)
+
+	// A
+	movq	ARG2, %r10 // n
+	movq	ARG6, %r11
+
+	movq	$ 40, %r14 // XXX chech for reg overwrite
+
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0x01, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			0*64(%r13), %zmm24
+	vmulpd			%zmm24, %zmm0, %zmm1 {%k1}{z}
+	//
+	vmovapd			1*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x03, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			2*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x07, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			3*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x0f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			4*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x1f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			%zmm1, %zmm0 {%k1}
+	vbroadcastsd	40+5*64(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0
+	vmovapd			%zmm0, 5*64(%r13) {%k1}
+
+	movl	$ 0xc0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm0, %zmm0 {%k1}{z}
+
+	// D
+	movq	ARG3, %r11 // D
+	vmovapd			5*64(%r11), %zmm21
+	vaddpd			%zmm0, %zmm21, %zmm21
+	vmovapd			%zmm21, 5*64(%r11)
+
+	// L
+	movq	ARG1, %r10 // n
+	movq	ARG5, %r11
+
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+
+	movq	$ 40, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+	// final triangle
+	vmovapd			0*64(%r11), %zmm16
+	movl	$ 0xfe, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			1*64(%r11), %zmm17 {%k1}{z}
+	movl	$ 0xfc, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			2*64(%r11), %zmm18 {%k1}{z}
+	movl	$ 0xf8, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			3*64(%r11), %zmm19 {%k1}{z}
+	movl	$ 0xf0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			4*64(%r11), %zmm20 {%k1}{z}
+	movl	$ 0xe0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			5*64(%r11), %zmm21 {%k1}{z}
+	movl	$ 0xc0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			6*64(%r11), %zmm22 {%k1}{z}
+//	vmovapd			7*64(%r11), %zmm23
+	vbroadcastsd	0*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm16
+	vbroadcastsd	1*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm17
+	vbroadcastsd	2*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm18
+	vbroadcastsd	3*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm19
+	vbroadcastsd	4*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm20
+	vbroadcastsd	5*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm21
+//	vbroadcastsd	6*64(%r11, %r14), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm22
+//	vbroadcastsd	7*64(%r11, %r14), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vfmadd231pd		%zmm16, %zmm16, %zmm25
+	vmovapd			%zmm16, 0*64(%r11)
+	vfmadd231pd		%zmm17, %zmm17, %zmm25
+	movl	$ 0xfe, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm17, 1*64(%r11) {%k1}
+	vfmadd231pd		%zmm18, %zmm18, %zmm25
+	movl	$ 0xfc, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm18, 2*64(%r11) {%k1}
+	vfmadd231pd		%zmm19, %zmm19, %zmm25
+	movl	$ 0xf8, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm19, 3*64(%r11) {%k1}
+	vfmadd231pd		%zmm20, %zmm20, %zmm25
+	movl	$ 0xf0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm20, 4*64(%r11) {%k1}
+	vfmadd231pd		%zmm21, %zmm21, %zmm25
+	movl	$ 0xe0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm21, 5*64(%r11) {%k1}
+	vfmadd231pd		%zmm22, %zmm22, %zmm25
+//	vmovapd			%zmm22, 6*64(%r11)
+//	vfmadd231pd		%zmm23, %zmm23, %zmm25
+//	vmovapd			%zmm23, 7*64(%r11)
+
+	// A
+	movq	ARG2, %r10 // n
+	movq	ARG6, %r11
+
+	movq	$ 40, %r14 // XXX chech for reg overwrite
+
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// seventh column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 48(%r12)
+	jmp		102f
+
+101:
+	movq	ARG3, %r11 // D
+
+	leaq	48+64*6(%r11), %r14 // XXX chech for reg overwrite
+	leaq	48(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vxorpd			%xmm31, %xmm24, %xmm27
+	vmovsd			%xmm27, 48+64*6(%r13) // pT[1+ps*1]
+
+	// D
+	movl	$ 0xc0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			6*64(%r11), %zmm0 {%k1}{z}
+
+	// L
+	movq	ARG1, %r10 // n0
+	movq	ARG5, %r11 // L
+
+	movq	$ 48, %r14 // XXX chech for reg overwrite
+
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+	// final triangle
+	vbroadcastsd	0*64(%r11, %r14), %zmm16
+	vmulpd			%zmm25, %zmm16, %zmm16
+	vbroadcastsd	1*64(%r11, %r14), %zmm17
+	vmulpd			%zmm25, %zmm17, %zmm17
+	vbroadcastsd	2*64(%r11, %r14), %zmm18
+	vmulpd			%zmm25, %zmm18, %zmm18
+	vbroadcastsd	3*64(%r11, %r14), %zmm19
+	vmulpd			%zmm25, %zmm19, %zmm19
+	vbroadcastsd	4*64(%r11, %r14), %zmm20
+	vmulpd			%zmm25, %zmm20, %zmm20
+	vbroadcastsd	5*64(%r11, %r14), %zmm21
+	vmulpd			%zmm25, %zmm21, %zmm21
+	vbroadcastsd	6*64(%r11, %r14), %zmm22
+	vmulpd			%zmm25, %zmm22, %zmm22
+//	vbroadcastsd	7*64(%r11, %r14), %zmm23
+//	vmulpd			%zmm25, %zmm23, %zmm23
+	vfmadd231pd		0*64(%r11), %zmm16, %zmm0
+	vmovsd			%xmm16, 0*64(%r11, %r14)
+	movl	$ 0xfe, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		1*64(%r11), %zmm17, %zmm0 {%k1}
+	vmovsd			%xmm17, 1*64(%r11, %r14)
+	movl	$ 0xfc, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		2*64(%r11), %zmm18, %zmm0 {%k1}
+	vmovsd			%xmm18, 2*64(%r11, %r14)
+	movl	$ 0xf8, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		3*64(%r11), %zmm19, %zmm0 {%k1}
+	vmovsd			%xmm19, 3*64(%r11, %r14)
+	movl	$ 0xf0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		4*64(%r11), %zmm20, %zmm0 {%k1}
+	vmovsd			%xmm20, 4*64(%r11, %r14)
+	movl	$ 0xe0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		5*64(%r11), %zmm21, %zmm0 {%k1}
+	vmovsd			%xmm21, 5*64(%r11, %r14)
+	movl	$ 0xc0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		6*64(%r11), %zmm22, %zmm0 {%k1}
+	vmovsd			%xmm22, 6*64(%r11, %r14)
+//	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+//	vmovsd			%xmm23, 7*64(%r11, %r14)
+
+	// A
+	movq	ARG2, %r10 // n
+	movq	ARG6, %r11
+
+	movq	$ 48, %r14 // XXX chech for reg overwrite
+
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0x01, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			0*64(%r13), %zmm24
+	vmulpd			%zmm24, %zmm0, %zmm1 {%k1}{z}
+	//
+	vmovapd			1*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x03, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			2*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x07, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			3*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x0f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			4*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x1f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			5*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x3f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			%zmm1, %zmm0 {%k1}
+	vbroadcastsd	48+6*64(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0
+	vmovapd			%zmm0, 6*64(%r13) {%k1}
+
+	movl	$ 0x80, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm0, %zmm0 {%k1}{z}
+
+	// D
+	movq	ARG3, %r11 // D
+	vmovapd			6*64(%r11), %zmm22
+	vaddpd			%zmm0, %zmm22, %zmm22
+	vmovapd			%zmm22, 6*64(%r11)
+
+	// L
+	movq	ARG1, %r10 // n
+	movq	ARG5, %r11
+
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+
+	movq	$ 48, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+	// final triangle
+	vmovapd			0*64(%r11), %zmm16
+	movl	$ 0xfe, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			1*64(%r11), %zmm17 {%k1}{z}
+	movl	$ 0xfc, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			2*64(%r11), %zmm18 {%k1}{z}
+	movl	$ 0xf8, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			3*64(%r11), %zmm19 {%k1}{z}
+	movl	$ 0xf0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			4*64(%r11), %zmm20 {%k1}{z}
+	movl	$ 0xe0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			5*64(%r11), %zmm21 {%k1}{z}
+	movl	$ 0xc0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			6*64(%r11), %zmm22 {%k1}{z}
+	movl	$ 0x80, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			7*64(%r11), %zmm23 {%k1}{z}
+	vbroadcastsd	0*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm16
+	vbroadcastsd	1*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm17
+	vbroadcastsd	2*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm18
+	vbroadcastsd	3*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm19
+	vbroadcastsd	4*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm20
+	vbroadcastsd	5*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm21
+	vbroadcastsd	6*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm22
+//	vbroadcastsd	7*64(%r11, %r14), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vfmadd231pd		%zmm16, %zmm16, %zmm25
+	vmovapd			%zmm16, 0*64(%r11)
+	vfmadd231pd		%zmm17, %zmm17, %zmm25
+	movl	$ 0xfe, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm17, 1*64(%r11) {%k1}
+	vfmadd231pd		%zmm18, %zmm18, %zmm25
+	movl	$ 0xfc, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm18, 2*64(%r11) {%k1}
+	vfmadd231pd		%zmm19, %zmm19, %zmm25
+	movl	$ 0xf8, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm19, 3*64(%r11) {%k1}
+	vfmadd231pd		%zmm20, %zmm20, %zmm25
+	movl	$ 0xf0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm20, 4*64(%r11) {%k1}
+	vfmadd231pd		%zmm21, %zmm21, %zmm25
+	movl	$ 0xe0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm21, 5*64(%r11) {%k1}
+	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	movl	$ 0xc0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm22, 6*64(%r11) {%k1}
+	vfmadd231pd		%zmm23, %zmm23, %zmm25
+//	vmovapd			%zmm23, 7*64(%r11)
+
+	// A
+	movq	ARG2, %r10 // n
+	movq	ARG6, %r11
+
+	movq	$ 48, %r14 // XXX chech for reg overwrite
+
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// eigth column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 56(%r12)
+	jmp		102f
+
+101:
+	movq	ARG3, %r11 // D
+
+	leaq	56+64*7(%r11), %r14 // XXX chech for reg overwrite
+	leaq	56(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vxorpd			%xmm31, %xmm24, %xmm27
+	vmovsd			%xmm27, 56+64*7(%r13) // pT[1+ps*1]
+
+	// D
+	movl	$ 0x80, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			7*64(%r11), %zmm0 {%k1}{z}
+
+	// L
+	movq	ARG1, %r10 // n0
+	movq	ARG5, %r11 // L
+
+	movq	$ 56, %r14 // XXX chech for reg overwrite
+
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+	// final triangle
+	vbroadcastsd	0*64(%r11, %r14), %zmm16
+	vmulpd			%zmm25, %zmm16, %zmm16
+	vbroadcastsd	1*64(%r11, %r14), %zmm17
+	vmulpd			%zmm25, %zmm17, %zmm17
+	vbroadcastsd	2*64(%r11, %r14), %zmm18
+	vmulpd			%zmm25, %zmm18, %zmm18
+	vbroadcastsd	3*64(%r11, %r14), %zmm19
+	vmulpd			%zmm25, %zmm19, %zmm19
+	vbroadcastsd	4*64(%r11, %r14), %zmm20
+	vmulpd			%zmm25, %zmm20, %zmm20
+	vbroadcastsd	5*64(%r11, %r14), %zmm21
+	vmulpd			%zmm25, %zmm21, %zmm21
+	vbroadcastsd	6*64(%r11, %r14), %zmm22
+	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	7*64(%r11, %r14), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+	vfmadd231pd		0*64(%r11), %zmm16, %zmm0
+	vmovsd			%xmm16, 0*64(%r11, %r14)
+	movl	$ 0xfe, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		1*64(%r11), %zmm17, %zmm0 {%k1}
+	vmovsd			%xmm17, 1*64(%r11, %r14)
+	movl	$ 0xfc, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		2*64(%r11), %zmm18, %zmm0 {%k1}
+	vmovsd			%xmm18, 2*64(%r11, %r14)
+	movl	$ 0xf8, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		3*64(%r11), %zmm19, %zmm0 {%k1}
+	vmovsd			%xmm19, 3*64(%r11, %r14)
+	movl	$ 0xf0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		4*64(%r11), %zmm20, %zmm0 {%k1}
+	vmovsd			%xmm20, 4*64(%r11, %r14)
+	movl	$ 0xe0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		5*64(%r11), %zmm21, %zmm0 {%k1}
+	vmovsd			%xmm21, 5*64(%r11, %r14)
+	movl	$ 0xc0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		6*64(%r11), %zmm22, %zmm0 {%k1}
+	vmovsd			%xmm22, 6*64(%r11, %r14)
+	movl	$ 0x80, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm0 {%k1}
+	vmovsd			%xmm23, 7*64(%r11, %r14)
+
+	// A
+	movq	ARG2, %r10 // n
+	movq	ARG6, %r11
+
+	movq	$ 56, %r14 // XXX chech for reg overwrite
+
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0x01, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			0*64(%r13), %zmm24
+	vmulpd			%zmm24, %zmm0, %zmm1 {%k1}{z}
+	//
+	vmovapd			1*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x03, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			2*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x07, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			3*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x0f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			4*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x1f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			5*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x3f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			6*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x7f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			%zmm1, %zmm0 {%k1}
+	vbroadcastsd	56+7*64(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0
+	vmovapd			%zmm0, 7*64(%r13) {%k1}
+
+102:
+
+1000:
+	EPILOGUE
+	
+	ret
+
+	FUN_END(kernel_dgelqf_pd_lla_dlarft8_8_lib8)
 
 
 

--- a/kernel/avx512/kernel_dgelqf_lib8.S
+++ b/kernel/avx512/kernel_dgelqf_lib8.S
@@ -1,0 +1,1908 @@
+/**************************************************************************************************
+*                                                                                                 *
+* This file is part of BLASFEO.                                                                   *
+*                                                                                                 *
+* BLASFEO -- BLAS For Embedded Optimization.                                                      *
+* Copyright (C) 2021 by Gianluca Frison.                                                          *
+* Developed at IMTEK (University of Freiburg) under the supervision of Moritz Diehl.              *
+* All rights reserved.                                                                            *
+*                                                                                                 *
+* The 2-Clause BSD License                                                                        *
+*                                                                                                 *
+* Redistribution and use in source and binary forms, with or without                              *
+* modification, are permitted provided that the following conditions are met:                     *
+*                                                                                                 *
+* 1. Redistributions of source code must retain the above copyright notice, this                  *
+*    list of conditions and the following disclaimer.                                             *
+* 2. Redistributions in binary form must reproduce the above copyright notice,                    *
+*    this list of conditions and the following disclaimer in the documentation                    *
+*    and/or other materials provided with the distribution.                                       *
+*                                                                                                 *
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND                 *
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED                   *
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE                          *
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR                 *
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES                  *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;                    *
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND                     *
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT                      *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS                   *
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                                    *
+*                                                                                                 *
+* Author: Gianluca Frison, gianluca.frison (at) imtek.uni-freiburg.de                             *
+*                                                                                                 *
+**************************************************************************************************/
+
+#if defined(OS_LINUX) | defined(OS_MAC)
+
+//#define STACKSIZE 96
+#define STACKSIZE 64
+#define ARG1  %rdi
+#define ARG2  %rsi
+#define ARG3  %rdx
+#define ARG4  %rcx
+#define ARG5  %r8
+#define ARG6  %r9
+#define ARG7  STACKSIZE +  8(%rsp)
+#define ARG8  STACKSIZE + 16(%rsp)
+#define ARG9  STACKSIZE + 24(%rsp)
+#define ARG10 STACKSIZE + 32(%rsp)
+#define ARG11 STACKSIZE + 40(%rsp)
+#define ARG12 STACKSIZE + 48(%rsp)
+#define ARG13 STACKSIZE + 56(%rsp)
+#define ARG14 STACKSIZE + 64(%rsp)
+#define ARG15 STACKSIZE + 72(%rsp)
+#define ARG16 STACKSIZE + 80(%rsp)
+#define ARG17 STACKSIZE + 88(%rsp)
+#define ARG18 STACKSIZE + 96(%rsp)
+#define ARG19 STACKSIZE + 104(%rsp)
+#define PROLOGUE \
+	subq	$STACKSIZE, %rsp; \
+	movq	%rbx,   (%rsp); \
+	movq	%rbp,  8(%rsp); \
+	movq	%r12, 16(%rsp); \
+	movq	%r13, 24(%rsp); \
+	movq	%r14, 32(%rsp); \
+	movq	%r15, 40(%rsp); \
+	vzeroupper;
+#define EPILOGUE \
+	vzeroupper; \
+	movq	  (%rsp), %rbx; \
+	movq	 8(%rsp), %rbp; \
+	movq	16(%rsp), %r12; \
+	movq	24(%rsp), %r13; \
+	movq	32(%rsp), %r14; \
+	movq	40(%rsp), %r15; \
+	addq	$STACKSIZE, %rsp;
+
+#if defined(OS_LINUX)
+
+#define GLOB_FUN_START(NAME) \
+	.globl NAME; \
+	.type NAME, @function; \
+NAME:
+#define FUN_START(NAME) \
+	.type NAME, @function; \
+NAME:
+#define FUN_END(NAME) \
+	.size	NAME, .-NAME
+#define CALL(NAME) \
+	call NAME
+
+#else // defined(OS_MAC)
+
+#define GLOB_FUN_START(NAME) \
+	.globl _ ## NAME; \
+_ ## NAME:
+#define FUN_START(NAME) \
+_ ## NAME:
+#define FUN_END(NAME)
+#define CALL(NAME) \
+	callq _ ## NAME
+
+#endif
+
+#elif defined(OS_WINDOWS)
+
+#define STACKSIZE 256
+#define ARG1  %rcx
+#define ARG2  %rdx
+#define ARG3  %r8
+#define ARG4  %r9
+#define ARG5  STACKSIZE + 40(%rsp)
+#define ARG6  STACKSIZE + 48(%rsp)
+#define ARG7  STACKSIZE + 56(%rsp)
+#define ARG8  STACKSIZE + 64(%rsp)
+#define ARG9  STACKSIZE + 72(%rsp)
+#define ARG10 STACKSIZE + 80(%rsp)
+#define ARG11 STACKSIZE + 88(%rsp)
+#define ARG12 STACKSIZE + 96(%rsp)
+#define ARG13 STACKSIZE + 104(%rsp)
+#define ARG14 STACKSIZE + 112(%rsp)
+#define ARG15 STACKSIZE + 120(%rsp)
+#define ARG16 STACKSIZE + 128(%rsp)
+#define ARG17 STACKSIZE + 136(%rsp)
+#define ARG18 STACKSIZE + 144(%rsp)
+#define ARG19 STACKSIZE + 152(%rsp)
+#define PROLOGUE \
+	subq	$STACKSIZE, %rsp; \
+	movq	%rbx,   (%rsp); \
+	movq	%rbp,  8(%rsp); \
+	movq	%r12, 16(%rsp); \
+	movq	%r13, 24(%rsp); \
+	movq	%r14, 32(%rsp); \
+	movq	%r15, 40(%rsp); \
+	movq	%rdi, 48(%rsp); \
+	movq	%rsi, 56(%rsp); \
+	vmovups	%xmm6, 64(%rsp); \
+	vmovups	%xmm7, 80(%rsp); \
+	vmovups	%xmm8, 96(%rsp); \
+	vmovups	%xmm9, 112(%rsp); \
+	vmovups	%xmm10, 128(%rsp); \
+	vmovups	%xmm11, 144(%rsp); \
+	vmovups	%xmm12, 160(%rsp); \
+	vmovups	%xmm13, 176(%rsp); \
+	vmovups	%xmm14, 192(%rsp); \
+	vmovups	%xmm15, 208(%rsp); \
+	vzeroupper;
+#define EPILOGUE \
+	vzeroupper; \
+	movq	  (%rsp), %rbx; \
+	movq	 8(%rsp), %rbp; \
+	movq	16(%rsp), %r12; \
+	movq	24(%rsp), %r13; \
+	movq	32(%rsp), %r14; \
+	movq	40(%rsp), %r15; \
+	movq	48(%rsp), %rdi; \
+	movq	56(%rsp), %rsi; \
+	vmovups	64(%rsp), %xmm6; \
+	vmovups	80(%rsp), %xmm7; \
+	vmovups	96(%rsp), %xmm8; \
+	vmovups	112(%rsp), %xmm9; \
+	vmovups	128(%rsp), %xmm10; \
+	vmovups	144(%rsp), %xmm11; \
+	vmovups	160(%rsp), %xmm12; \
+	vmovups	176(%rsp), %xmm13; \
+	vmovups	192(%rsp), %xmm14; \
+	vmovups	208(%rsp), %xmm15; \
+	addq	$STACKSIZE, %rsp;
+
+#define GLOB_FUN_START(NAME) \
+	.globl NAME; \
+	.def NAME; .scl 2; .type 32; .endef; \
+NAME:
+#define FUN_START(NAME) \
+	.def NAME; .scl 2; .type 32; .endef; \
+NAME:
+#define FUN_END(NAME)
+#define CALL(NAME) \
+	call NAME
+
+#else
+
+#error wrong OS
+
+#endif
+
+
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	.text
+#elif defined(OS_MAC)
+	.section	__TEXT,__text,regular,pure_instructions
+#endif
+
+
+
+
+
+
+#if MACRO_LEVEL>=1
+	.macro INNER_KERNEL_1_DGELQF_DLARFT8_8_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_1_dgelqf_dlarft8_8_lib8)
+#endif
+
+	cmpl	$ 7, %r10d
+	jle		109f
+103:
+	vbroadcastsd	0*64(%r11, %r14), %zmm16
+	vmulpd			%zmm25, %zmm16, %zmm16
+	vbroadcastsd	1*64(%r11, %r14), %zmm17
+	vmulpd			%zmm25, %zmm17, %zmm17
+	vbroadcastsd	2*64(%r11, %r14), %zmm18
+	vmulpd			%zmm25, %zmm18, %zmm18
+	vbroadcastsd	3*64(%r11, %r14), %zmm19
+	vmulpd			%zmm25, %zmm19, %zmm19
+	vbroadcastsd	4*64(%r11, %r14), %zmm20
+	vmulpd			%zmm25, %zmm20, %zmm20
+	vbroadcastsd	5*64(%r11, %r14), %zmm21
+	vmulpd			%zmm25, %zmm21, %zmm21
+	vbroadcastsd	6*64(%r11, %r14), %zmm22
+	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	7*64(%r11, %r14), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+	vfmadd231pd		0*64(%r11), %zmm16, %zmm0
+	vmovsd			%xmm16, 0*64(%r11, %r14)
+	vfmadd231pd		1*64(%r11), %zmm17, %zmm1
+	vmovsd			%xmm17, 1*64(%r11, %r14)
+	vfmadd231pd		2*64(%r11), %zmm18, %zmm0
+	vmovsd			%xmm18, 2*64(%r11, %r14)
+	vfmadd231pd		3*64(%r11), %zmm19, %zmm1
+	vmovsd			%xmm19, 3*64(%r11, %r14)
+	vfmadd231pd		4*64(%r11), %zmm20, %zmm0
+	vmovsd			%xmm20, 4*64(%r11, %r14)
+	vfmadd231pd		5*64(%r11), %zmm21, %zmm1
+	vmovsd			%xmm21, 5*64(%r11, %r14)
+	vfmadd231pd		6*64(%r11), %zmm22, %zmm0
+	vmovsd			%xmm22, 6*64(%r11, %r14)
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm1
+	vmovsd			%xmm23, 7*64(%r11, %r14)
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+	cmpl	$ 7, %r10d
+	jg		103b
+109:
+	vaddpd			%zmm1, %zmm0, %zmm0 // reduce acc
+	cmpl	$ 0, %r10d
+	jle		104f
+105:
+	vbroadcastsd	0(%r11, %r14), %zmm16
+	vmulpd			%zmm25, %zmm16, %zmm16
+	vfmadd231pd		0(%r11), %zmm16, %zmm0
+	vmovsd			%xmm16, 0(%r11, %r14)
+	subl	$ 1, %r10d
+	addq	$ 64, %r11
+	cmpl	$ 0, %r10d
+	jg		105b
+104:
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_1_dgelqf_dlarft8_8_lib8)
+#endif
+
+
+
+
+
+#if MACRO_LEVEL>=1
+	.macro INNER_KERNEL_2_DGELQF_DLARFT8_8_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_2_dgelqf_dlarft8_8_lib8)
+#endif
+
+	cmpl	$ 7, %r10d
+	jle		110f
+106:
+	vmovapd			0*64(%r11), %zmm16
+	vmovapd			1*64(%r11), %zmm17
+	vmovapd			2*64(%r11), %zmm18
+	vmovapd			3*64(%r11), %zmm19
+	vmovapd			4*64(%r11), %zmm20
+	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+	vmovapd			7*64(%r11), %zmm23
+	vbroadcastsd	0*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm16
+	vbroadcastsd	1*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm17
+	vbroadcastsd	2*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm18
+	vbroadcastsd	3*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm19
+	vbroadcastsd	4*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm20
+	vbroadcastsd	5*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm21
+	vbroadcastsd	6*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vbroadcastsd	7*64(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vfmadd231pd		%zmm16, %zmm16, %zmm25
+	vmovapd			%zmm16, 0*64(%r11)
+	vfmadd231pd		%zmm17, %zmm17, %zmm26
+	vmovapd			%zmm17, 1*64(%r11)
+	vfmadd231pd		%zmm18, %zmm18, %zmm25
+	vmovapd			%zmm18, 2*64(%r11)
+	vfmadd231pd		%zmm19, %zmm19, %zmm26
+	vmovapd			%zmm19, 3*64(%r11)
+	vfmadd231pd		%zmm20, %zmm20, %zmm25
+	vmovapd			%zmm20, 4*64(%r11)
+	vfmadd231pd		%zmm21, %zmm21, %zmm26
+	vmovapd			%zmm21, 5*64(%r11)
+	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm23, 7*64(%r11)
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+	cmpl	$ 7, %r10d
+	jg		106b
+110:
+	vaddpd			%zmm26, %zmm25, %zmm25 // reduce acc
+	cmpl	$ 0, %r10d
+	jle		107f
+108:
+	vmovapd			0(%r11), %zmm16
+	vbroadcastsd	0(%r11, %r14), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm16
+	vfmadd231pd		%zmm16, %zmm16, %zmm25
+	vmovapd			%zmm16, 0(%r11)
+	subl	$ 1, %r10d
+	addq	$ 64, %r11
+	cmpl	$ 0, %r10d
+	jg		108b
+107:
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_2_dgelqf_dlarft8_8_lib8)
+#endif
+
+
+
+
+
+//                                  1      2           3           4
+// void kernel_dgelqf_dlarft8_8_lib8(int n, double *pD, double *dD, double *pT, double *beta)
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dgelqf_dlarft8_8_lib8)
+	
+	PROLOGUE
+
+	// zero T
+
+	movq	ARG4, %r10 // T
+
+	vxorpd			%zmm24, %zmm24, %zmm24
+	vmovapd			%zmm24, 0*64(%r10)
+	vmovapd			%zmm24, 1*64(%r10)
+	vmovapd			%zmm24, 2*64(%r10)
+	vmovapd			%zmm24, 3*64(%r10)
+	vmovapd			%zmm24, 4*64(%r10)
+	vmovapd			%zmm24, 5*64(%r10)
+	vmovapd			%zmm24, 6*64(%r10)
+	vmovapd			%zmm24, 7*64(%r10)
+
+	// first column
+
+	movq	ARG2, %r11 // D
+	movq	ARG3, %r12 // dD
+	movq	ARG4, %r13 // T
+
+	vxorpd			%xmm25, %xmm25, %xmm25
+	movq	ARG1, %r10 // n
+	subl	$ 1, %r10d
+	addq	$ 64, %r11
+100:
+	vmovsd			0(%r11), %xmm24
+	vfmadd231sd		%xmm24, %xmm24, %xmm25
+	subl	$ 1, %r10d
+	addq	$ 64, %r11
+	cmpl	$ 0, %r10d
+	jg		100b
+
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		101f
+	vmovsd			%xmm24, 0(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+	vmovsd			0+64*0(%r11), %xmm24 // alpha
+	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
+	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovsd			.LC00(%rip), %xmm26 // mask
+#else
+	vmovsd			LC00(%rip), %xmm26 // mask
+#endif
+	vandpd			%xmm26, %xmm24, %xmm27
+	vxorpd			%xmm26, %xmm27, %xmm27
+	vxorpd			%xmm27, %xmm25, %xmm25 // beta
+	vmovsd			%xmm25, 0+64*0(%r11) // pD[0+ps*0]
+	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
+#else
+	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
+#endif
+	vmovsd			%xmm24, %xmm27, %xmm27
+	vmovddup		%xmm24, %xmm24
+	vmovsd			%xmm25, %xmm24, %xmm24
+	vdivpd			%xmm24, %xmm27, %xmm24
+	vmovsd			%xmm24, 0(%r12) // dD[0]
+	vxorpd			%xmm26, %xmm24, %xmm27
+	vmovsd			%xmm27, 0+64*0(%r13) // pT[0+ps*0]
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
+
+	vmovapd			0*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+	vbroadcastsd	0+1*64(%r11), %zmm17
+	vmulpd			%zmm25, %zmm17, %zmm17
+	vbroadcastsd	0+2*64(%r11), %zmm18
+	vmulpd			%zmm25, %zmm18, %zmm18
+	vbroadcastsd	0+3*64(%r11), %zmm19
+	vmulpd			%zmm25, %zmm19, %zmm19
+	vbroadcastsd	0+4*64(%r11), %zmm20
+	vmulpd			%zmm25, %zmm20, %zmm20
+	vbroadcastsd	0+5*64(%r11), %zmm21
+	vmulpd			%zmm25, %zmm21, %zmm21
+	vbroadcastsd	0+6*64(%r11), %zmm22
+	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	0+7*64(%r11), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+	vmovsd			%xmm17, 0+1*64(%r11)
+	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+	vmovsd			%xmm18, 0+2*64(%r11)
+	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+	vmovsd			%xmm19, 0+3*64(%r11)
+	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+	vmovsd			%xmm20, 0+4*64(%r11)
+	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+	vmovsd			%xmm21, 0+5*64(%r11)
+	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+	vmovsd			%xmm22, 0+6*64(%r11)
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+	vmovsd			%xmm23, 0+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 0, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_DLARFT8_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_dlarft8_8_lib8)
+#endif
+
+	movl	$ 0xfe, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vbroadcastsd	0(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+	vmovapd			0*64(%r11), %zmm16
+	vmovapd			1*64(%r11), %zmm17
+	vmovapd			2*64(%r11), %zmm18
+	vmovapd			3*64(%r11), %zmm19
+	vmovapd			4*64(%r11), %zmm20
+	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+	vmovapd			7*64(%r11), %zmm23
+	vaddpd			%zmm0, %zmm16, %zmm16
+	vbroadcastsd	0+1*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm17
+	vbroadcastsd	0+2*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm18
+	vbroadcastsd	0+3*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm19
+	vbroadcastsd	0+4*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm20
+	vbroadcastsd	0+5*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm21
+	vbroadcastsd	0+6*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vbroadcastsd	0+7*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+	vmovapd			%zmm16, 0*64(%r11)
+	vmovapd			%zmm17, 1*64(%r11)
+	vfmadd231pd		%zmm18, %zmm18, %zmm25
+	vmovapd			%zmm18, 2*64(%r11)
+	vfmadd231pd		%zmm19, %zmm19, %zmm26
+	vmovapd			%zmm19, 3*64(%r11)
+	vfmadd231pd		%zmm20, %zmm20, %zmm25
+	vmovapd			%zmm20, 4*64(%r11)
+	vfmadd231pd		%zmm21, %zmm21, %zmm26
+	vmovapd			%zmm21, 5*64(%r11)
+	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm23, 7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 0, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_DLARFT8_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_dlarft8_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// second column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 8(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+	vmovsd			8+64*1(%r11), %xmm24 // alpha
+	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
+	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovsd			.LC00(%rip), %xmm26 // mask
+#else
+	vmovsd			LC00(%rip), %xmm26 // mask
+#endif
+	vandpd			%xmm26, %xmm24, %xmm27
+	vxorpd			%xmm26, %xmm27, %xmm27
+	vxorpd			%xmm27, %xmm25, %xmm25 // beta
+	vmovsd			%xmm25, 8+64*1(%r11) // pD[1+ps*1]
+	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
+#else
+	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
+#endif
+	vmovsd			%xmm24, %xmm27, %xmm27
+	vmovddup		%xmm24, %xmm24
+	vmovsd			%xmm25, %xmm24, %xmm24
+	vdivpd			%xmm24, %xmm27, %xmm24
+	vmovsd			%xmm24, 8(%r12) // dD[1]
+	vxorpd			%xmm26, %xmm24, %xmm27
+	vmovsd			%xmm27, 8+64*1(%r13) // pT[1+ps*1]
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
+
+	vmovapd			1*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+//	vbroadcastsd	8+1*64(%r11), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+	vbroadcastsd	8+2*64(%r11), %zmm18
+	vmulpd			%zmm25, %zmm18, %zmm18
+	vbroadcastsd	8+3*64(%r11), %zmm19
+	vmulpd			%zmm25, %zmm19, %zmm19
+	vbroadcastsd	8+4*64(%r11), %zmm20
+	vmulpd			%zmm25, %zmm20, %zmm20
+	vbroadcastsd	8+5*64(%r11), %zmm21
+	vmulpd			%zmm25, %zmm21, %zmm21
+	vbroadcastsd	8+6*64(%r11), %zmm22
+	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	8+7*64(%r11), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+//	vmovsd			%xmm17, 8+1*64(%r11)
+	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+	vmovsd			%xmm18, 8+2*64(%r11)
+	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+	vmovsd			%xmm19, 8+3*64(%r11)
+	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+	vmovsd			%xmm20, 8+4*64(%r11)
+	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+	vmovsd			%xmm21, 8+5*64(%r11)
+	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+	vmovsd			%xmm22, 8+6*64(%r11)
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+	vmovsd			%xmm23, 8+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 8, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_DLARFT8_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_dlarft8_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC00+16(%rip), %zmm27 // 1.0
+#else
+	vbroadcastsd	LC00+16(%rip), %zmm27 // 1.0
+#endif
+	movl	$ 0x01, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			0+64*0(%r13), %zmm27 {%k1}
+	vmulpd			%zmm27, %zmm0, %zmm0
+	vbroadcastsd	8+64*1(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0
+	vmovapd			%zmm0, 1*64(%r13) {%k1}
+
+	movl	$ 0xfc, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+//	vmovapd			0*64(%r11), %zmm16
+	vmovapd			1*64(%r11), %zmm17
+	vmovapd			2*64(%r11), %zmm18
+	vmovapd			3*64(%r11), %zmm19
+	vmovapd			4*64(%r11), %zmm20
+	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+	vmovapd			7*64(%r11), %zmm23
+//	vaddpd			%zmm0, %zmm16, %zmm16
+//	vbroadcastsd	8+1*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm17
+	vaddpd			%zmm0, %zmm17, %zmm17
+	vbroadcastsd	8+2*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm18
+	vbroadcastsd	8+3*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm19
+	vbroadcastsd	8+4*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm20
+	vbroadcastsd	8+5*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm21
+	vbroadcastsd	8+6*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vbroadcastsd	8+7*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+//	vmovapd			%zmm16, 0*64(%r11)
+	vmovapd			%zmm17, 1*64(%r11)
+//	vfmadd231pd		%zmm18, %zmm18, %zmm25
+	vmovapd			%zmm18, 2*64(%r11)
+	vfmadd231pd		%zmm19, %zmm19, %zmm26
+	vmovapd			%zmm19, 3*64(%r11)
+	vfmadd231pd		%zmm20, %zmm20, %zmm25
+	vmovapd			%zmm20, 4*64(%r11)
+	vfmadd231pd		%zmm21, %zmm21, %zmm26
+	vmovapd			%zmm21, 5*64(%r11)
+	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm23, 7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 8, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_DLARFT8_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_dlarft8_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// third column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 16(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+	vmovsd			16+64*2(%r11), %xmm24 // alpha
+	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
+	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovsd			.LC00(%rip), %xmm26 // mask
+#else
+	vmovsd			LC00(%rip), %xmm26 // mask
+#endif
+	vandpd			%xmm26, %xmm24, %xmm27
+	vxorpd			%xmm26, %xmm27, %xmm27
+	vxorpd			%xmm27, %xmm25, %xmm25 // beta
+	vmovsd			%xmm25, 16+64*2(%r11) // pD[1+ps*1]
+	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
+#else
+	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
+#endif
+	vmovsd			%xmm24, %xmm27, %xmm27
+	vmovddup		%xmm24, %xmm24
+	vmovsd			%xmm25, %xmm24, %xmm24
+	vdivpd			%xmm24, %xmm27, %xmm24
+	vmovsd			%xmm24, 16(%r12) // dD[1]
+	vxorpd			%xmm26, %xmm24, %xmm27
+	vmovsd			%xmm27, 16+64*2(%r13) // pT[1+ps*1]
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
+
+	vmovapd			2*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+//	vbroadcastsd	16+1*64(%r11), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+//	vbroadcastsd	16+2*64(%r11), %zmm18
+//	vmulpd			%zmm25, %zmm18, %zmm18
+	vbroadcastsd	16+3*64(%r11), %zmm19
+	vmulpd			%zmm25, %zmm19, %zmm19
+	vbroadcastsd	16+4*64(%r11), %zmm20
+	vmulpd			%zmm25, %zmm20, %zmm20
+	vbroadcastsd	16+5*64(%r11), %zmm21
+	vmulpd			%zmm25, %zmm21, %zmm21
+	vbroadcastsd	16+6*64(%r11), %zmm22
+	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	16+7*64(%r11), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+//	vmovsd			%xmm17, 16+1*64(%r11)
+//	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+//	vmovsd			%xmm18, 16+2*64(%r11)
+	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+	vmovsd			%xmm19, 16+3*64(%r11)
+	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+	vmovsd			%xmm20, 16+4*64(%r11)
+	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+	vmovsd			%xmm21, 16+5*64(%r11)
+	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+	vmovsd			%xmm22, 16+6*64(%r11)
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+	vmovsd			%xmm23, 16+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 16, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_DLARFT8_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_dlarft8_8_lib8)
+#endif
+
+	movl	$ 0x01, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			0*64(%r13), %zmm24
+	vmulpd			%zmm24, %zmm0, %zmm1 {%k1}{z}
+	vmovapd			1*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x03, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	vmovapd			%zmm1, %zmm0 {%k1}
+	vbroadcastsd	16+2*64(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0
+	vmovapd			%zmm0, 2*64(%r13) {%k1}
+
+	movl	$ 0xf8, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+//	vmovapd			0*64(%r11), %zmm16
+//	vmovapd			1*64(%r11), %zmm17
+	vmovapd			2*64(%r11), %zmm18
+	vmovapd			3*64(%r11), %zmm19
+	vmovapd			4*64(%r11), %zmm20
+	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+	vmovapd			7*64(%r11), %zmm23
+//	vaddpd			%zmm0, %zmm16, %zmm16
+//	vbroadcastsd	16+1*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm17
+//	vaddpd			%zmm0, %zmm17, %zmm17
+//	vbroadcastsd	16+2*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm18
+	vaddpd			%zmm0, %zmm18, %zmm18
+	vbroadcastsd	16+3*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm19
+	vbroadcastsd	16+4*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm20
+	vbroadcastsd	16+5*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm21
+	vbroadcastsd	16+6*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vbroadcastsd	16+7*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+//	vmovapd			%zmm16, 0*64(%r11)
+//	vmovapd			%zmm17, 1*64(%r11)
+//	vfmadd231pd		%zmm18, %zmm18, %zmm25
+	vmovapd			%zmm18, 2*64(%r11)
+//	vfmadd231pd		%zmm19, %zmm19, %zmm26
+	vmovapd			%zmm19, 3*64(%r11)
+	vfmadd231pd		%zmm20, %zmm20, %zmm25
+	vmovapd			%zmm20, 4*64(%r11)
+	vfmadd231pd		%zmm21, %zmm21, %zmm26
+	vmovapd			%zmm21, 5*64(%r11)
+	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm23, 7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 16, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_DLARFT8_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_dlarft8_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// fourth column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 24(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+	vmovsd			24+64*3(%r11), %xmm24 // alpha
+	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
+	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovsd			.LC00(%rip), %xmm26 // mask
+#else
+	vmovsd			LC00(%rip), %xmm26 // mask
+#endif
+	vandpd			%xmm26, %xmm24, %xmm27
+	vxorpd			%xmm26, %xmm27, %xmm27
+	vxorpd			%xmm27, %xmm25, %xmm25 // beta
+	vmovsd			%xmm25, 24+64*3(%r11) // pD[1+ps*1]
+	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
+#else
+	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
+#endif
+	vmovsd			%xmm24, %xmm27, %xmm27
+	vmovddup		%xmm24, %xmm24
+	vmovsd			%xmm25, %xmm24, %xmm24
+	vdivpd			%xmm24, %xmm27, %xmm24
+	vmovsd			%xmm24, 24(%r12) // dD[1]
+	vxorpd			%xmm26, %xmm24, %xmm27
+	vmovsd			%xmm27, 24+64*3(%r13) // pT[1+ps*1]
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
+
+	vmovapd			3*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+//	vbroadcastsd	24+1*64(%r11), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+//	vbroadcastsd	24+2*64(%r11), %zmm18
+//	vmulpd			%zmm25, %zmm18, %zmm18
+//	vbroadcastsd	24+3*64(%r11), %zmm19
+//	vmulpd			%zmm25, %zmm19, %zmm19
+	vbroadcastsd	24+4*64(%r11), %zmm20
+	vmulpd			%zmm25, %zmm20, %zmm20
+	vbroadcastsd	24+5*64(%r11), %zmm21
+	vmulpd			%zmm25, %zmm21, %zmm21
+	vbroadcastsd	24+6*64(%r11), %zmm22
+	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	24+7*64(%r11), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+//	vmovsd			%xmm17, 24+1*64(%r11)
+//	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+//	vmovsd			%xmm18, 24+2*64(%r11)
+//	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+//	vmovsd			%xmm19, 24+3*64(%r11)
+	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+	vmovsd			%xmm20, 24+4*64(%r11)
+	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+	vmovsd			%xmm21, 24+5*64(%r11)
+	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+	vmovsd			%xmm22, 24+6*64(%r11)
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+	vmovsd			%xmm23, 24+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 24, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_DLARFT8_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_dlarft8_8_lib8)
+#endif
+
+	movl	$ 0x01, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			0*64(%r13), %zmm24
+	vmulpd			%zmm24, %zmm0, %zmm1 {%k1}{z}
+	vmovapd			1*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x03, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	vmovapd			2*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x07, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	vmovapd			%zmm1, %zmm0 {%k1}
+	vbroadcastsd	24+3*64(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0
+	vmovapd			%zmm0, 3*64(%r13) {%k1}
+
+	movl	$ 0xf0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+//	vmovapd			0*64(%r11), %zmm16
+//	vmovapd			1*64(%r11), %zmm17
+//	vmovapd			2*64(%r11), %zmm18
+	vmovapd			3*64(%r11), %zmm19
+	vmovapd			4*64(%r11), %zmm20
+	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+	vmovapd			7*64(%r11), %zmm23
+//	vaddpd			%zmm0, %zmm16, %zmm16
+//	vbroadcastsd	24+1*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm17
+//	vaddpd			%zmm0, %zmm17, %zmm17
+//	vbroadcastsd	24+2*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm18
+//	vaddpd			%zmm0, %zmm18, %zmm18
+//	vbroadcastsd	24+3*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm19
+	vaddpd			%zmm0, %zmm19, %zmm19
+	vbroadcastsd	24+4*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm20
+	vbroadcastsd	24+5*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm21
+	vbroadcastsd	24+6*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vbroadcastsd	24+7*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+//	vmovapd			%zmm16, 0*64(%r11)
+//	vmovapd			%zmm17, 1*64(%r11)
+//	vfmadd231pd		%zmm18, %zmm18, %zmm25
+//	vmovapd			%zmm18, 2*64(%r11)
+//	vfmadd231pd		%zmm19, %zmm19, %zmm26
+	vmovapd			%zmm19, 3*64(%r11)
+//	vfmadd231pd		%zmm20, %zmm20, %zmm25
+	vmovapd			%zmm20, 4*64(%r11)
+	vfmadd231pd		%zmm21, %zmm21, %zmm26
+	vmovapd			%zmm21, 5*64(%r11)
+	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm23, 7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 24, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_DLARFT8_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_dlarft8_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// fifth column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 32(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+	vmovsd			32+64*4(%r11), %xmm24 // alpha
+	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
+	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovsd			.LC00(%rip), %xmm26 // mask
+#else
+	vmovsd			LC00(%rip), %xmm26 // mask
+#endif
+	vandpd			%xmm26, %xmm24, %xmm27
+	vxorpd			%xmm26, %xmm27, %xmm27
+	vxorpd			%xmm27, %xmm25, %xmm25 // beta
+	vmovsd			%xmm25, 32+64*4(%r11) // pD[1+ps*1]
+	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
+#else
+	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
+#endif
+	vmovsd			%xmm24, %xmm27, %xmm27
+	vmovddup		%xmm24, %xmm24
+	vmovsd			%xmm25, %xmm24, %xmm24
+	vdivpd			%xmm24, %xmm27, %xmm24
+	vmovsd			%xmm24, 32(%r12) // dD[1]
+	vxorpd			%xmm26, %xmm24, %xmm27
+	vmovsd			%xmm27, 32+64*4(%r13) // pT[1+ps*1]
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
+
+	vmovapd			4*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+//	vbroadcastsd	32+1*64(%r11), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+//	vbroadcastsd	32+2*64(%r11), %zmm18
+//	vmulpd			%zmm25, %zmm18, %zmm18
+//	vbroadcastsd	32+3*64(%r11), %zmm19
+//	vmulpd			%zmm25, %zmm19, %zmm19
+//	vbroadcastsd	32+4*64(%r11), %zmm20
+//	vmulpd			%zmm25, %zmm20, %zmm20
+	vbroadcastsd	32+5*64(%r11), %zmm21
+	vmulpd			%zmm25, %zmm21, %zmm21
+	vbroadcastsd	32+6*64(%r11), %zmm22
+	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	32+7*64(%r11), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+//	vmovsd			%xmm17, 32+1*64(%r11)
+//	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+//	vmovsd			%xmm18, 32+2*64(%r11)
+//	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+//	vmovsd			%xmm19, 32+3*64(%r11)
+//	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+//	vmovsd			%xmm20, 32+4*64(%r11)
+	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+	vmovsd			%xmm21, 32+5*64(%r11)
+	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+	vmovsd			%xmm22, 32+6*64(%r11)
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+	vmovsd			%xmm23, 32+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 32, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_DLARFT8_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_dlarft8_8_lib8)
+#endif
+
+	movl	$ 0x01, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			0*64(%r13), %zmm24
+	vmulpd			%zmm24, %zmm0, %zmm1 {%k1}{z}
+	//
+	vmovapd			1*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x03, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			2*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x07, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			3*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x0f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			%zmm1, %zmm0 {%k1}
+	vbroadcastsd	32+4*64(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0
+	vmovapd			%zmm0, 4*64(%r13) {%k1}
+
+	movl	$ 0xe0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+//	vmovapd			0*64(%r11), %zmm16
+//	vmovapd			1*64(%r11), %zmm17
+//	vmovapd			2*64(%r11), %zmm18
+//	vmovapd			3*64(%r11), %zmm19
+	vmovapd			4*64(%r11), %zmm20
+	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+	vmovapd			7*64(%r11), %zmm23
+//	vaddpd			%zmm0, %zmm16, %zmm16
+//	vbroadcastsd	32+1*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm17
+//	vaddpd			%zmm0, %zmm17, %zmm17
+//	vbroadcastsd	32+2*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm18
+//	vaddpd			%zmm0, %zmm18, %zmm18
+//	vbroadcastsd	32+3*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm19
+//	vaddpd			%zmm0, %zmm19, %zmm19
+//	vbroadcastsd	32+4*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm20
+	vaddpd			%zmm0, %zmm20, %zmm20
+	vbroadcastsd	32+5*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm21
+	vbroadcastsd	32+6*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vbroadcastsd	32+7*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+//	vmovapd			%zmm16, 0*64(%r11)
+//	vmovapd			%zmm17, 1*64(%r11)
+//	vfmadd231pd		%zmm18, %zmm18, %zmm25
+//	vmovapd			%zmm18, 2*64(%r11)
+//	vfmadd231pd		%zmm19, %zmm19, %zmm26
+//	vmovapd			%zmm19, 3*64(%r11)
+//	vfmadd231pd		%zmm20, %zmm20, %zmm25
+	vmovapd			%zmm20, 4*64(%r11)
+//	vfmadd231pd		%zmm21, %zmm21, %zmm26
+	vmovapd			%zmm21, 5*64(%r11)
+	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm23, 7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 32, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_DLARFT8_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_dlarft8_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// sixth column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 40(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+	vmovsd			40+64*5(%r11), %xmm24 // alpha
+	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
+	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovsd			.LC00(%rip), %xmm26 // mask
+#else
+	vmovsd			LC00(%rip), %xmm26 // mask
+#endif
+	vandpd			%xmm26, %xmm24, %xmm27
+	vxorpd			%xmm26, %xmm27, %xmm27
+	vxorpd			%xmm27, %xmm25, %xmm25 // beta
+	vmovsd			%xmm25, 40+64*5(%r11) // pD[1+ps*1]
+	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
+#else
+	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
+#endif
+	vmovsd			%xmm24, %xmm27, %xmm27
+	vmovddup		%xmm24, %xmm24
+	vmovsd			%xmm25, %xmm24, %xmm24
+	vdivpd			%xmm24, %xmm27, %xmm24
+	vmovsd			%xmm24, 40(%r12) // dD[1]
+	vxorpd			%xmm26, %xmm24, %xmm27
+	vmovsd			%xmm27, 40+64*5(%r13) // pT[1+ps*1]
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
+
+	vmovapd			5*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+//	vbroadcastsd	40+1*64(%r11), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+//	vbroadcastsd	40+2*64(%r11), %zmm18
+//	vmulpd			%zmm25, %zmm18, %zmm18
+//	vbroadcastsd	40+3*64(%r11), %zmm19
+//	vmulpd			%zmm25, %zmm19, %zmm19
+//	vbroadcastsd	40+4*64(%r11), %zmm20
+//	vmulpd			%zmm25, %zmm20, %zmm20
+//	vbroadcastsd	40+5*64(%r11), %zmm21
+//	vmulpd			%zmm25, %zmm21, %zmm21
+	vbroadcastsd	40+6*64(%r11), %zmm22
+	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	40+7*64(%r11), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+//	vmovsd			%xmm17, 40+1*64(%r11)
+//	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+//	vmovsd			%xmm18, 40+2*64(%r11)
+//	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+//	vmovsd			%xmm19, 40+3*64(%r11)
+//	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+//	vmovsd			%xmm20, 40+4*64(%r11)
+//	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+//	vmovsd			%xmm21, 40+5*64(%r11)
+	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+	vmovsd			%xmm22, 40+6*64(%r11)
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+	vmovsd			%xmm23, 40+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 40, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_DLARFT8_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_dlarft8_8_lib8)
+#endif
+
+	movl	$ 0x01, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			0*64(%r13), %zmm24
+	vmulpd			%zmm24, %zmm0, %zmm1 {%k1}{z}
+	//
+	vmovapd			1*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x03, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			2*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x07, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			3*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x0f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			4*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x1f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			%zmm1, %zmm0 {%k1}
+	vbroadcastsd	40+5*64(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0
+	vmovapd			%zmm0, 5*64(%r13) {%k1}
+
+	movl	$ 0xc0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+//	vmovapd			0*64(%r11), %zmm16
+//	vmovapd			1*64(%r11), %zmm17
+//	vmovapd			2*64(%r11), %zmm18
+//	vmovapd			3*64(%r11), %zmm19
+//	vmovapd			4*64(%r11), %zmm20
+	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+	vmovapd			7*64(%r11), %zmm23
+//	vaddpd			%zmm0, %zmm16, %zmm16
+//	vbroadcastsd	40+1*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm17
+//	vaddpd			%zmm0, %zmm17, %zmm17
+//	vbroadcastsd	40+2*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm18
+//	vaddpd			%zmm0, %zmm18, %zmm18
+//	vbroadcastsd	40+3*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm19
+//	vaddpd			%zmm0, %zmm19, %zmm19
+//	vbroadcastsd	40+4*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm20
+//	vaddpd			%zmm0, %zmm20, %zmm20
+//	vbroadcastsd	40+5*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm21
+	vaddpd			%zmm0, %zmm21, %zmm21
+	vbroadcastsd	40+6*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vbroadcastsd	40+7*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+//	vmovapd			%zmm16, 0*64(%r11)
+//	vmovapd			%zmm17, 1*64(%r11)
+//	vfmadd231pd		%zmm18, %zmm18, %zmm25
+//	vmovapd			%zmm18, 2*64(%r11)
+//	vfmadd231pd		%zmm19, %zmm19, %zmm26
+//	vmovapd			%zmm19, 3*64(%r11)
+//	vfmadd231pd		%zmm20, %zmm20, %zmm25
+//	vmovapd			%zmm20, 4*64(%r11)
+//	vfmadd231pd		%zmm21, %zmm21, %zmm26
+	vmovapd			%zmm21, 5*64(%r11)
+//	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm23, 7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 40, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_DLARFT8_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_dlarft8_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// seventh column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 48(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+	vmovsd			48+64*6(%r11), %xmm24 // alpha
+	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
+	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovsd			.LC00(%rip), %xmm26 // mask
+#else
+	vmovsd			LC00(%rip), %xmm26 // mask
+#endif
+	vandpd			%xmm26, %xmm24, %xmm27
+	vxorpd			%xmm26, %xmm27, %xmm27
+	vxorpd			%xmm27, %xmm25, %xmm25 // beta
+	vmovsd			%xmm25, 48+64*6(%r11) // pD[1+ps*1]
+	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
+#else
+	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
+#endif
+	vmovsd			%xmm24, %xmm27, %xmm27
+	vmovddup		%xmm24, %xmm24
+	vmovsd			%xmm25, %xmm24, %xmm24
+	vdivpd			%xmm24, %xmm27, %xmm24
+	vmovsd			%xmm24, 48(%r12) // dD[1]
+	vxorpd			%xmm26, %xmm24, %xmm27
+	vmovsd			%xmm27, 48+64*6(%r13) // pT[1+ps*1]
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
+
+	vmovapd			6*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+//	vbroadcastsd	48+1*64(%r11), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+//	vbroadcastsd	48+2*64(%r11), %zmm18
+//	vmulpd			%zmm25, %zmm18, %zmm18
+//	vbroadcastsd	48+3*64(%r11), %zmm19
+//	vmulpd			%zmm25, %zmm19, %zmm19
+//	vbroadcastsd	48+4*64(%r11), %zmm20
+//	vmulpd			%zmm25, %zmm20, %zmm20
+//	vbroadcastsd	48+5*64(%r11), %zmm21
+//	vmulpd			%zmm25, %zmm21, %zmm21
+//	vbroadcastsd	48+6*64(%r11), %zmm22
+//	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	48+7*64(%r11), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+//	vmovsd			%xmm17, 48+1*64(%r11)
+//	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+//	vmovsd			%xmm18, 48+2*64(%r11)
+//	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+//	vmovsd			%xmm19, 48+3*64(%r11)
+//	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+//	vmovsd			%xmm20, 48+4*64(%r11)
+//	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+//	vmovsd			%xmm21, 48+5*64(%r11)
+//	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+//	vmovsd			%xmm22, 48+6*64(%r11)
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+	vmovsd			%xmm23, 48+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 48, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_DLARFT8_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_dlarft8_8_lib8)
+#endif
+
+	movl	$ 0x01, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			0*64(%r13), %zmm24
+	vmulpd			%zmm24, %zmm0, %zmm1 {%k1}{z}
+	//
+	vmovapd			1*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x03, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			2*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x07, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			3*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x0f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			4*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x1f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			5*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x3f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			%zmm1, %zmm0 {%k1}
+	vbroadcastsd	48+6*64(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0
+	vmovapd			%zmm0, 6*64(%r13) {%k1}
+
+	movl	$ 0x80, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+//	vmovapd			0*64(%r11), %zmm16
+//	vmovapd			1*64(%r11), %zmm17
+//	vmovapd			2*64(%r11), %zmm18
+//	vmovapd			3*64(%r11), %zmm19
+//	vmovapd			4*64(%r11), %zmm20
+//	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+	vmovapd			7*64(%r11), %zmm23
+//	vaddpd			%zmm0, %zmm16, %zmm16
+//	vbroadcastsd	48+1*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm17
+//	vaddpd			%zmm0, %zmm17, %zmm17
+//	vbroadcastsd	48+2*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm18
+//	vaddpd			%zmm0, %zmm18, %zmm18
+//	vbroadcastsd	48+3*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm19
+//	vaddpd			%zmm0, %zmm19, %zmm19
+//	vbroadcastsd	48+4*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm20
+//	vaddpd			%zmm0, %zmm20, %zmm20
+//	vbroadcastsd	48+5*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm21
+//	vaddpd			%zmm0, %zmm21, %zmm21
+//	vbroadcastsd	48+6*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vaddpd			%zmm0, %zmm22, %zmm22
+	vbroadcastsd	48+7*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+//	vmovapd			%zmm16, 0*64(%r11)
+//	vmovapd			%zmm17, 1*64(%r11)
+//	vfmadd231pd		%zmm18, %zmm18, %zmm25
+//	vmovapd			%zmm18, 2*64(%r11)
+//	vfmadd231pd		%zmm19, %zmm19, %zmm26
+//	vmovapd			%zmm19, 3*64(%r11)
+//	vfmadd231pd		%zmm20, %zmm20, %zmm25
+//	vmovapd			%zmm20, 4*64(%r11)
+//	vfmadd231pd		%zmm21, %zmm21, %zmm26
+//	vmovapd			%zmm21, 5*64(%r11)
+//	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+//	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm23, 7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 48, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_DLARFT8_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_dlarft8_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// eigth column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 56(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+	vmovsd			56+64*7(%r11), %xmm24 // alpha
+	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
+	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovsd			.LC00(%rip), %xmm26 // mask
+#else
+	vmovsd			LC00(%rip), %xmm26 // mask
+#endif
+	vandpd			%xmm26, %xmm24, %xmm27
+	vxorpd			%xmm26, %xmm27, %xmm27
+	vxorpd			%xmm27, %xmm25, %xmm25 // beta
+	vmovsd			%xmm25, 56+64*7(%r11) // pD[1+ps*1]
+	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
+#else
+	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
+#endif
+	vmovsd			%xmm24, %xmm27, %xmm27
+	vmovddup		%xmm24, %xmm24
+	vmovsd			%xmm25, %xmm24, %xmm24
+	vdivpd			%xmm24, %xmm27, %xmm24
+	vmovsd			%xmm24, 56(%r12) // dD[1]
+	vxorpd			%xmm26, %xmm24, %xmm27
+	vmovsd			%xmm27, 56+64*7(%r13) // pT[1+ps*1]
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
+
+	vmovapd			7*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+//	vbroadcastsd	56+1*64(%r11), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+//	vbroadcastsd	56+2*64(%r11), %zmm18
+//	vmulpd			%zmm25, %zmm18, %zmm18
+//	vbroadcastsd	56+3*64(%r11), %zmm19
+//	vmulpd			%zmm25, %zmm19, %zmm19
+//	vbroadcastsd	56+4*64(%r11), %zmm20
+//	vmulpd			%zmm25, %zmm20, %zmm20
+//	vbroadcastsd	56+5*64(%r11), %zmm21
+//	vmulpd			%zmm25, %zmm21, %zmm21
+//	vbroadcastsd	56+6*64(%r11), %zmm22
+//	vmulpd			%zmm25, %zmm22, %zmm22
+//	vbroadcastsd	56+7*64(%r11), %zmm23
+//	vmulpd			%zmm25, %zmm23, %zmm23
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+//	vmovsd			%xmm17, 56+1*64(%r11)
+//	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+//	vmovsd			%xmm18, 56+2*64(%r11)
+//	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+//	vmovsd			%xmm19, 56+3*64(%r11)
+//	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+//	vmovsd			%xmm20, 56+4*64(%r11)
+//	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+//	vmovsd			%xmm21, 56+5*64(%r11)
+//	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+//	vmovsd			%xmm22, 56+6*64(%r11)
+//	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+//	vmovsd			%xmm23, 56+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 56, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_DLARFT8_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_dlarft8_8_lib8)
+#endif
+
+	movl	$ 0x01, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			0*64(%r13), %zmm24
+	vmulpd			%zmm24, %zmm0, %zmm1 {%k1}{z}
+	//
+	vmovapd			1*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x03, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			2*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x07, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			3*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x0f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			4*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x1f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			5*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x3f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			6*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x7f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			%zmm1, %zmm0 {%k1}
+	vbroadcastsd	56+7*64(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0
+	vmovapd			%zmm0, 7*64(%r13) {%k1}
+
+102:
+
+	EPILOGUE
+	
+	ret
+
+	FUN_END(kernel_dgelqf_dlarft8_8_lib8)
+
+
+
+
+
+// read-only data
+#if defined(OS_LINUX)
+	.section	.rodata.cst32,"aM",@progbits,32
+#elif defined(OS_MAC)
+	.section	__TEXT,__const
+#elif defined(OS_WINDOWS)
+	.section .rdata,"dr"
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	.align 64
+.LC00: // { 100...0 -1.0 1.0 }
+#elif defined(OS_MAC)
+LC00: // { 100...0 100...0 100...0 100...0 }
+	.align 6
+#endif
+	.long	0x00000000
+	.long	0x80000000
+	.double	-1.0
+	.double	1.0
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	.align 64
+.LC05:
+#elif defined(OS_MAC)
+	.align 6
+LC05:
+#endif
+	.quad 0x0
+	.quad 0x1
+	.quad 0x2
+	.quad 0x3
+	.quad 0x4
+	.quad 0x5
+	.quad 0x6
+	.quad 0x7
+
+
+
+
+
+#if defined(OS_LINUX)
+	.section	.note.GNU-stack,"",@progbits
+#elif defined(OS_MAC)
+	.subsections_via_symbols
+#endif
+

--- a/kernel/avx512/kernel_dgelqf_lib8.S
+++ b/kernel/avx512/kernel_dgelqf_lib8.S
@@ -352,6 +352,49 @@ NAME:
 
 
 
+#if MACRO_LEVEL>=1
+	.macro INNER_EDGE_DGELQF_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_edge_dgelqf_lib8)
+#endif
+
+	vmovsd			0(%r14), %xmm24 // alpha
+	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
+	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC00(%rip), %zmm31 // mask
+#else
+	vbroadcastsd	LC00(%rip), %zmm31 // mask
+#endif
+	vandpd			%xmm31, %xmm24, %xmm27
+	vxorpd			%xmm31, %xmm27, %xmm27
+	vxorpd			%xmm27, %xmm25, %xmm25 // beta
+	vmovsd			%xmm25, 0(%r14) // pD[0+ps*0]
+	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
+#else
+	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
+#endif
+	vmovsd			%xmm24, %xmm27, %xmm27
+	vmovddup		%xmm24, %xmm24
+	vmovsd			%xmm25, %xmm24, %xmm24
+	vdivpd			%xmm24, %xmm27, %xmm24
+	vmovsd			%xmm24, 0(%r15) // dD[0]
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_edge_dgelqf_lib8)
+#endif
+
+
+
+
+
 //                           1      2           3
 // void kernel_dgelqf_8_lib8(int n, double *pD, double *dD)
 
@@ -385,29 +428,15 @@ NAME:
 
 101:
 	movq	ARG2, %r11 // D
-	vmovsd			0+64*0(%r11), %xmm24 // alpha
-	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
-	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC00(%rip), %zmm31 // mask
+
+	leaq	0+64*0(%r11), %r14 // XXX chech for reg overwrite
+	leaq	0(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_LIB8
 #else
-	vbroadcastsd	LC00(%rip), %zmm31 // mask
+	CALL(inner_edge_dgelqf_lib8)
 #endif
-	vandpd			%xmm31, %xmm24, %xmm27
-	vxorpd			%xmm31, %xmm27, %xmm27
-	vxorpd			%xmm27, %xmm25, %xmm25 // beta
-	vmovsd			%xmm25, 0+64*0(%r11) // pD[0+ps*0]
-	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
-#else
-	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
-#endif
-	vmovsd			%xmm24, %xmm27, %xmm27
-	vmovddup		%xmm24, %xmm24
-	vmovsd			%xmm25, %xmm24, %xmm24
-	vdivpd			%xmm24, %xmm27, %xmm24
-	vmovsd			%xmm24, 0(%r12) // dD[0]
 
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
 	vbroadcastsd	.LC05+1*8(%rip), %zmm27
@@ -535,29 +564,14 @@ NAME:
 
 101:
 	movq	ARG2, %r11 // D
-	vmovsd			8+64*1(%r11), %xmm24 // alpha
-	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
-	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC00(%rip), %zmm31 // mask
+	leaq	8+64*1(%r11), %r14 // XXX chech for reg overwrite
+	leaq	8(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_LIB8
 #else
-	vbroadcastsd	LC00(%rip), %zmm31 // mask
+	CALL(inner_edge_dgelqf_lib8)
 #endif
-	vandpd			%xmm31, %xmm24, %xmm27
-	vxorpd			%xmm31, %xmm27, %xmm27
-	vxorpd			%xmm27, %xmm25, %xmm25 // beta
-	vmovsd			%xmm25, 8+64*1(%r11) // pD[1+ps*1]
-	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
-#else
-	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
-#endif
-	vmovsd			%xmm24, %xmm27, %xmm27
-	vmovddup		%xmm24, %xmm24
-	vmovsd			%xmm25, %xmm24, %xmm24
-	vdivpd			%xmm24, %xmm27, %xmm24
-	vmovsd			%xmm24, 8(%r12) // dD[1]
 
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
 	vbroadcastsd	.LC05+1*8(%rip), %zmm27
@@ -686,29 +700,14 @@ NAME:
 
 101:
 	movq	ARG2, %r11 // D
-	vmovsd			16+64*2(%r11), %xmm24 // alpha
-	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
-	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC00(%rip), %zmm31 // mask
+	leaq	16+64*2(%r11), %r14 // XXX chech for reg overwrite
+	leaq	16(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_LIB8
 #else
-	vbroadcastsd	LC00(%rip), %zmm31 // mask
+	CALL(inner_edge_dgelqf_lib8)
 #endif
-	vandpd			%xmm31, %xmm24, %xmm27
-	vxorpd			%xmm31, %xmm27, %xmm27
-	vxorpd			%xmm27, %xmm25, %xmm25 // beta
-	vmovsd			%xmm25, 16+64*2(%r11) // pD[1+ps*1]
-	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
-#else
-	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
-#endif
-	vmovsd			%xmm24, %xmm27, %xmm27
-	vmovddup		%xmm24, %xmm24
-	vmovsd			%xmm25, %xmm24, %xmm24
-	vdivpd			%xmm24, %xmm27, %xmm24
-	vmovsd			%xmm24, 16(%r12) // dD[1]
 
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
 	vbroadcastsd	.LC05+1*8(%rip), %zmm27
@@ -838,29 +837,15 @@ NAME:
 
 101:
 	movq	ARG2, %r11 // D
-	vmovsd			24+64*3(%r11), %xmm24 // alpha
-	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
-	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC00(%rip), %zmm31 // mask
+
+	leaq	24+64*3(%r11), %r14 // XXX chech for reg overwrite
+	leaq	24(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_LIB8
 #else
-	vbroadcastsd	LC00(%rip), %zmm31 // mask
+	CALL(inner_edge_dgelqf_lib8)
 #endif
-	vandpd			%xmm31, %xmm24, %xmm27
-	vxorpd			%xmm31, %xmm27, %xmm27
-	vxorpd			%xmm27, %xmm25, %xmm25 // beta
-	vmovsd			%xmm25, 24+64*3(%r11) // pD[1+ps*1]
-	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
-#else
-	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
-#endif
-	vmovsd			%xmm24, %xmm27, %xmm27
-	vmovddup		%xmm24, %xmm24
-	vmovsd			%xmm25, %xmm24, %xmm24
-	vdivpd			%xmm24, %xmm27, %xmm24
-	vmovsd			%xmm24, 24(%r12) // dD[1]
 
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
 	vbroadcastsd	.LC05+1*8(%rip), %zmm27
@@ -991,29 +976,15 @@ NAME:
 
 101:
 	movq	ARG2, %r11 // D
-	vmovsd			32+64*4(%r11), %xmm24 // alpha
-	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
-	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC00(%rip), %zmm31 // mask
+
+	leaq	32+64*4(%r11), %r14 // XXX chech for reg overwrite
+	leaq	32(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_LIB8
 #else
-	vbroadcastsd	LC00(%rip), %zmm31 // mask
+	CALL(inner_edge_dgelqf_lib8)
 #endif
-	vandpd			%xmm31, %xmm24, %xmm27
-	vxorpd			%xmm31, %xmm27, %xmm27
-	vxorpd			%xmm27, %xmm25, %xmm25 // beta
-	vmovsd			%xmm25, 32+64*4(%r11) // pD[1+ps*1]
-	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
-#else
-	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
-#endif
-	vmovsd			%xmm24, %xmm27, %xmm27
-	vmovddup		%xmm24, %xmm24
-	vmovsd			%xmm25, %xmm24, %xmm24
-	vdivpd			%xmm24, %xmm27, %xmm24
-	vmovsd			%xmm24, 32(%r12) // dD[1]
 
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
 	vbroadcastsd	.LC05+1*8(%rip), %zmm27
@@ -1145,29 +1116,15 @@ NAME:
 
 101:
 	movq	ARG2, %r11 // D
-	vmovsd			40+64*5(%r11), %xmm24 // alpha
-	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
-	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC00(%rip), %zmm31 // mask
+
+	leaq	40+64*5(%r11), %r14 // XXX chech for reg overwrite
+	leaq	40(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_LIB8
 #else
-	vbroadcastsd	LC00(%rip), %zmm31 // mask
+	CALL(inner_edge_dgelqf_lib8)
 #endif
-	vandpd			%xmm31, %xmm24, %xmm27
-	vxorpd			%xmm31, %xmm27, %xmm27
-	vxorpd			%xmm27, %xmm25, %xmm25 // beta
-	vmovsd			%xmm25, 40+64*5(%r11) // pD[1+ps*1]
-	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
-#else
-	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
-#endif
-	vmovsd			%xmm24, %xmm27, %xmm27
-	vmovddup		%xmm24, %xmm24
-	vmovsd			%xmm25, %xmm24, %xmm24
-	vdivpd			%xmm24, %xmm27, %xmm24
-	vmovsd			%xmm24, 40(%r12) // dD[1]
 
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
 	vbroadcastsd	.LC05+1*8(%rip), %zmm27
@@ -1300,29 +1257,15 @@ NAME:
 
 101:
 	movq	ARG2, %r11 // D
-	vmovsd			48+64*6(%r11), %xmm24 // alpha
-	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
-	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC00(%rip), %zmm31 // mask
+
+	leaq	48+64*6(%r11), %r14 // XXX chech for reg overwrite
+	leaq	48(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_LIB8
 #else
-	vbroadcastsd	LC00(%rip), %zmm31 // mask
+	CALL(inner_edge_dgelqf_lib8)
 #endif
-	vandpd			%xmm31, %xmm24, %xmm27
-	vxorpd			%xmm31, %xmm27, %xmm27
-	vxorpd			%xmm27, %xmm25, %xmm25 // beta
-	vmovsd			%xmm25, 48+64*6(%r11) // pD[1+ps*1]
-	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
-#else
-	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
-#endif
-	vmovsd			%xmm24, %xmm27, %xmm27
-	vmovddup		%xmm24, %xmm24
-	vmovsd			%xmm25, %xmm24, %xmm24
-	vdivpd			%xmm24, %xmm27, %xmm24
-	vmovsd			%xmm24, 48(%r12) // dD[1]
 
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
 	vbroadcastsd	.LC05+1*8(%rip), %zmm27
@@ -1456,29 +1399,15 @@ NAME:
 
 101:
 	movq	ARG2, %r11 // D
-	vmovsd			56+64*7(%r11), %xmm24 // alpha
-	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
-	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC00(%rip), %zmm31 // mask
+
+	leaq	56+64*7(%r11), %r14 // XXX chech for reg overwrite
+	leaq	56(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_LIB8
 #else
-	vbroadcastsd	LC00(%rip), %zmm31 // mask
+	CALL(inner_edge_dgelqf_lib8)
 #endif
-	vandpd			%xmm31, %xmm24, %xmm27
-	vxorpd			%xmm31, %xmm27, %xmm27
-	vxorpd			%xmm27, %xmm25, %xmm25 // beta
-	vmovsd			%xmm25, 56+64*7(%r11) // pD[1+ps*1]
-	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
-#else
-	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
-#endif
-	vmovsd			%xmm24, %xmm27, %xmm27
-	vmovddup		%xmm24, %xmm24
-	vmovsd			%xmm25, %xmm24, %xmm24
-	vdivpd			%xmm24, %xmm27, %xmm24
-	vmovsd			%xmm24, 56(%r12) // dD[1]
 
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
 	vbroadcastsd	.LC05+1*8(%rip), %zmm27
@@ -1590,30 +1519,17 @@ NAME:
 
 101:
 	movq	ARG2, %r11 // D
-	vmovsd			0+64*0(%r11), %xmm24 // alpha
-	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
-	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vmovsd			.LC00(%rip), %xmm26 // mask
+
+	leaq	0+64*0(%r11), %r14 // XXX chech for reg overwrite
+	leaq	0(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_LIB8
 #else
-	vmovsd			LC00(%rip), %xmm26 // mask
+	CALL(inner_edge_dgelqf_lib8)
 #endif
-	vandpd			%xmm26, %xmm24, %xmm27
-	vxorpd			%xmm26, %xmm27, %xmm27
-	vxorpd			%xmm27, %xmm25, %xmm25 // beta
-	vmovsd			%xmm25, 0+64*0(%r11) // pD[0+ps*0]
-	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
-#else
-	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
-#endif
-	vmovsd			%xmm24, %xmm27, %xmm27
-	vmovddup		%xmm24, %xmm24
-	vmovsd			%xmm25, %xmm24, %xmm24
-	vdivpd			%xmm24, %xmm27, %xmm24
-	vmovsd			%xmm24, 0(%r12) // dD[0]
-	vxorpd			%xmm26, %xmm24, %xmm27
+
+	vxorpd			%xmm31, %xmm24, %xmm27
 	vmovsd			%xmm27, 0+64*0(%r13) // pT[0+ps*0]
 
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -1741,30 +1657,17 @@ NAME:
 
 101:
 	movq	ARG2, %r11 // D
-	vmovsd			8+64*1(%r11), %xmm24 // alpha
-	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
-	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vmovsd			.LC00(%rip), %xmm26 // mask
+
+	leaq	8+64*1(%r11), %r14 // XXX chech for reg overwrite
+	leaq	8(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_LIB8
 #else
-	vmovsd			LC00(%rip), %xmm26 // mask
+	CALL(inner_edge_dgelqf_lib8)
 #endif
-	vandpd			%xmm26, %xmm24, %xmm27
-	vxorpd			%xmm26, %xmm27, %xmm27
-	vxorpd			%xmm27, %xmm25, %xmm25 // beta
-	vmovsd			%xmm25, 8+64*1(%r11) // pD[1+ps*1]
-	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
-#else
-	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
-#endif
-	vmovsd			%xmm24, %xmm27, %xmm27
-	vmovddup		%xmm24, %xmm24
-	vmovsd			%xmm25, %xmm24, %xmm24
-	vdivpd			%xmm24, %xmm27, %xmm24
-	vmovsd			%xmm24, 8(%r12) // dD[1]
-	vxorpd			%xmm26, %xmm24, %xmm27
+
+	vxorpd			%xmm31, %xmm24, %xmm27
 	vmovsd			%xmm27, 8+64*1(%r13) // pT[1+ps*1]
 
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -1905,30 +1808,17 @@ NAME:
 
 101:
 	movq	ARG2, %r11 // D
-	vmovsd			16+64*2(%r11), %xmm24 // alpha
-	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
-	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vmovsd			.LC00(%rip), %xmm26 // mask
+
+	leaq	16+64*2(%r11), %r14 // XXX chech for reg overwrite
+	leaq	16(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_LIB8
 #else
-	vmovsd			LC00(%rip), %xmm26 // mask
+	CALL(inner_edge_dgelqf_lib8)
 #endif
-	vandpd			%xmm26, %xmm24, %xmm27
-	vxorpd			%xmm26, %xmm27, %xmm27
-	vxorpd			%xmm27, %xmm25, %xmm25 // beta
-	vmovsd			%xmm25, 16+64*2(%r11) // pD[1+ps*1]
-	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
-#else
-	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
-#endif
-	vmovsd			%xmm24, %xmm27, %xmm27
-	vmovddup		%xmm24, %xmm24
-	vmovsd			%xmm25, %xmm24, %xmm24
-	vdivpd			%xmm24, %xmm27, %xmm24
-	vmovsd			%xmm24, 16(%r12) // dD[1]
-	vxorpd			%xmm26, %xmm24, %xmm27
+
+	vxorpd			%xmm31, %xmm24, %xmm27
 	vmovsd			%xmm27, 16+64*2(%r13) // pT[1+ps*1]
 
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -2076,30 +1966,17 @@ NAME:
 
 101:
 	movq	ARG2, %r11 // D
-	vmovsd			24+64*3(%r11), %xmm24 // alpha
-	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
-	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vmovsd			.LC00(%rip), %xmm26 // mask
+
+	leaq	24+64*3(%r11), %r14 // XXX chech for reg overwrite
+	leaq	24(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_LIB8
 #else
-	vmovsd			LC00(%rip), %xmm26 // mask
+	CALL(inner_edge_dgelqf_lib8)
 #endif
-	vandpd			%xmm26, %xmm24, %xmm27
-	vxorpd			%xmm26, %xmm27, %xmm27
-	vxorpd			%xmm27, %xmm25, %xmm25 // beta
-	vmovsd			%xmm25, 24+64*3(%r11) // pD[1+ps*1]
-	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
-#else
-	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
-#endif
-	vmovsd			%xmm24, %xmm27, %xmm27
-	vmovddup		%xmm24, %xmm24
-	vmovsd			%xmm25, %xmm24, %xmm24
-	vdivpd			%xmm24, %xmm27, %xmm24
-	vmovsd			%xmm24, 24(%r12) // dD[1]
-	vxorpd			%xmm26, %xmm24, %xmm27
+
+	vxorpd			%xmm31, %xmm24, %xmm27
 	vmovsd			%xmm27, 24+64*3(%r13) // pT[1+ps*1]
 
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -2258,30 +2135,17 @@ NAME:
 
 101:
 	movq	ARG2, %r11 // D
-	vmovsd			32+64*4(%r11), %xmm24 // alpha
-	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
-	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vmovsd			.LC00(%rip), %xmm26 // mask
+
+	leaq	32+64*4(%r11), %r14 // XXX chech for reg overwrite
+	leaq	32(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_LIB8
 #else
-	vmovsd			LC00(%rip), %xmm26 // mask
+	CALL(inner_edge_dgelqf_lib8)
 #endif
-	vandpd			%xmm26, %xmm24, %xmm27
-	vxorpd			%xmm26, %xmm27, %xmm27
-	vxorpd			%xmm27, %xmm25, %xmm25 // beta
-	vmovsd			%xmm25, 32+64*4(%r11) // pD[1+ps*1]
-	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
-#else
-	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
-#endif
-	vmovsd			%xmm24, %xmm27, %xmm27
-	vmovddup		%xmm24, %xmm24
-	vmovsd			%xmm25, %xmm24, %xmm24
-	vdivpd			%xmm24, %xmm27, %xmm24
-	vmovsd			%xmm24, 32(%r12) // dD[1]
-	vxorpd			%xmm26, %xmm24, %xmm27
+
+	vxorpd			%xmm31, %xmm24, %xmm27
 	vmovsd			%xmm27, 32+64*4(%r13) // pT[1+ps*1]
 
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -2455,30 +2319,17 @@ NAME:
 
 101:
 	movq	ARG2, %r11 // D
-	vmovsd			40+64*5(%r11), %xmm24 // alpha
-	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
-	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vmovsd			.LC00(%rip), %xmm26 // mask
+
+	leaq	40+64*5(%r11), %r14 // XXX chech for reg overwrite
+	leaq	40(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_LIB8
 #else
-	vmovsd			LC00(%rip), %xmm26 // mask
+	CALL(inner_edge_dgelqf_lib8)
 #endif
-	vandpd			%xmm26, %xmm24, %xmm27
-	vxorpd			%xmm26, %xmm27, %xmm27
-	vxorpd			%xmm27, %xmm25, %xmm25 // beta
-	vmovsd			%xmm25, 40+64*5(%r11) // pD[1+ps*1]
-	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
-#else
-	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
-#endif
-	vmovsd			%xmm24, %xmm27, %xmm27
-	vmovddup		%xmm24, %xmm24
-	vmovsd			%xmm25, %xmm24, %xmm24
-	vdivpd			%xmm24, %xmm27, %xmm24
-	vmovsd			%xmm24, 40(%r12) // dD[1]
-	vxorpd			%xmm26, %xmm24, %xmm27
+
+	vxorpd			%xmm31, %xmm24, %xmm27
 	vmovsd			%xmm27, 40+64*5(%r13) // pT[1+ps*1]
 
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -2664,30 +2515,17 @@ NAME:
 
 101:
 	movq	ARG2, %r11 // D
-	vmovsd			48+64*6(%r11), %xmm24 // alpha
-	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
-	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vmovsd			.LC00(%rip), %xmm26 // mask
+
+	leaq	48+64*6(%r11), %r14 // XXX chech for reg overwrite
+	leaq	48(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_LIB8
 #else
-	vmovsd			LC00(%rip), %xmm26 // mask
+	CALL(inner_edge_dgelqf_lib8)
 #endif
-	vandpd			%xmm26, %xmm24, %xmm27
-	vxorpd			%xmm26, %xmm27, %xmm27
-	vxorpd			%xmm27, %xmm25, %xmm25 // beta
-	vmovsd			%xmm25, 48+64*6(%r11) // pD[1+ps*1]
-	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
-#else
-	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
-#endif
-	vmovsd			%xmm24, %xmm27, %xmm27
-	vmovddup		%xmm24, %xmm24
-	vmovsd			%xmm25, %xmm24, %xmm24
-	vdivpd			%xmm24, %xmm27, %xmm24
-	vmovsd			%xmm24, 48(%r12) // dD[1]
-	vxorpd			%xmm26, %xmm24, %xmm27
+
+	vxorpd			%xmm31, %xmm24, %xmm27
 	vmovsd			%xmm27, 48+64*6(%r13) // pT[1+ps*1]
 
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -2885,30 +2723,17 @@ NAME:
 
 101:
 	movq	ARG2, %r11 // D
-	vmovsd			56+64*7(%r11), %xmm24 // alpha
-	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
-	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vmovsd			.LC00(%rip), %xmm26 // mask
+
+	leaq	56+64*7(%r11), %r14 // XXX chech for reg overwrite
+	leaq	56(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_LIB8
 #else
-	vmovsd			LC00(%rip), %xmm26 // mask
+	CALL(inner_edge_dgelqf_lib8)
 #endif
-	vandpd			%xmm26, %xmm24, %xmm27
-	vxorpd			%xmm26, %xmm27, %xmm27
-	vxorpd			%xmm27, %xmm25, %xmm25 // beta
-	vmovsd			%xmm25, 56+64*7(%r11) // pD[1+ps*1]
-	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
-#else
-	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
-#endif
-	vmovsd			%xmm24, %xmm27, %xmm27
-	vmovddup		%xmm24, %xmm24
-	vmovsd			%xmm25, %xmm24, %xmm24
-	vdivpd			%xmm24, %xmm27, %xmm24
-	vmovsd			%xmm24, 56(%r12) // dD[1]
-	vxorpd			%xmm26, %xmm24, %xmm27
+
+	vxorpd			%xmm31, %xmm24, %xmm27
 	vmovsd			%xmm27, 56+64*7(%r13) // pT[1+ps*1]
 
 #if defined(OS_LINUX) | defined(OS_WINDOWS)

--- a/kernel/avx512/kernel_dgelqf_lib8.S
+++ b/kernel/avx512/kernel_dgelqf_lib8.S
@@ -454,17 +454,17 @@ NAME:
 	vmulsd			%xmm24, %xmm24, %xmm27 // tmp*tmp
 	vaddsd			%xmm27, %xmm25, %xmm25 // sigma+tmp*tmp
 	vaddsd			%xmm27, %xmm27, %xmm27 // 2*tmp*tmp
-	vdivsd			%xmm25, %xmm27, %xmm26
-	vmovsd			%xmm26, 0(%r15) // dD[0]
-
+	vmovlhps		%xmm24, %xmm25, %xmm25
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vmovsd			.LC00+16(%rip), %xmm27
+	vmovsd			.LC00+16(%rip), %xmm26
 #else
-	vmovsd			LC00+16(%rip), %xmm27
+	vmovsd			LC00+16(%rip), %xmm26
 #endif
-	vdivsd			%xmm24, %xmm27, %xmm24 // tmp
+	vmovlhps		%xmm26, %xmm27, %xmm27
+	vdivpd			%xmm25, %xmm27, %xmm26
+	vmovhlps		%xmm26, %xmm24, %xmm24 // tmp
+	vmovsd			%xmm26, 0(%r15) // dD[0]
 	vbroadcastsd	%xmm24, %zmm25
-	
 	vmovapd			%xmm26, %xmm24
 
 #if MACRO_LEVEL>=1

--- a/kernel/avx512/kernel_dgelqf_lib8.S
+++ b/kernel/avx512/kernel_dgelqf_lib8.S
@@ -5201,11 +5201,1369 @@ NAME:
 
 102:
 
+1000:
 	EPILOGUE
 	
 	ret
 
 	FUN_END(kernel_dgelqf_pd_dlarft8_8_lib8)
+
+
+
+
+
+//                                         1      2           3           4           5
+// void kernel_dgelqf_pd_la_dlarft8_8_lib8(int n, double *pD, double *dD, double *pA, double *pT)
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dgelqf_pd_la_dlarft8_8_lib8)
+	
+	PROLOGUE
+
+	// zero T
+
+	movq	ARG5, %r10 // T
+
+	vxorpd			%zmm24, %zmm24, %zmm24
+	vmovapd			%zmm24, 0*64(%r10)
+	vmovapd			%zmm24, 1*64(%r10)
+	vmovapd			%zmm24, 2*64(%r10)
+	vmovapd			%zmm24, 3*64(%r10)
+	vmovapd			%zmm24, 4*64(%r10)
+	vmovapd			%zmm24, 5*64(%r10)
+	vmovapd			%zmm24, 6*64(%r10)
+	vmovapd			%zmm24, 7*64(%r10)
+
+	// first column
+
+//	movq	ARG2, %r11 // D
+	movq	ARG4, %r11 // A
+	movq	ARG3, %r12 // dD
+	movq	ARG5, %r13 // T
+
+	vxorpd			%xmm25, %xmm25, %xmm25
+	movq	ARG1, %r10 // n
+//	subl	$ 1, %r10d
+//	addq	$ 64, %r11
+100:
+	vmovsd			0(%r11), %xmm24
+	vfmadd231sd		%xmm24, %xmm24, %xmm25
+	subl	$ 1, %r10d
+	addq	$ 64, %r11
+	cmpl	$ 0, %r10d
+	jg		100b
+
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		101f
+	vmovsd			%xmm24, 0(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+
+	leaq	0+64*0(%r11), %r14 // XXX chech for reg overwrite
+	leaq	0(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vxorpd			%xmm31, %xmm24, %xmm27
+	vmovsd			%xmm27, 0+64*0(%r13) // pT[0+ps*0]
+
+//	vmovapd			0*64(%r11), %zmm0
+	vxorpd			%zmm0, %zmm0, %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+//	vbroadcastsd	0+1*64(%r11), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+//	vbroadcastsd	0+2*64(%r11), %zmm18
+//	vmulpd			%zmm25, %zmm18, %zmm18
+//	vbroadcastsd	0+3*64(%r11), %zmm19
+//	vmulpd			%zmm25, %zmm19, %zmm19
+//	vbroadcastsd	0+4*64(%r11), %zmm20
+//	vmulpd			%zmm25, %zmm20, %zmm20
+//	vbroadcastsd	0+5*64(%r11), %zmm21
+//	vmulpd			%zmm25, %zmm21, %zmm21
+//	vbroadcastsd	0+6*64(%r11), %zmm22
+//	vmulpd			%zmm25, %zmm22, %zmm22
+//	vbroadcastsd	0+7*64(%r11), %zmm23
+//	vmulpd			%zmm25, %zmm23, %zmm23
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+//	vmovsd			%xmm17, 0+1*64(%r11)
+//	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+//	vmovsd			%xmm18, 0+2*64(%r11)
+//	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+//	vmovsd			%xmm19, 0+3*64(%r11)
+//	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+//	vmovsd			%xmm20, 0+4*64(%r11)
+//	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+//	vmovsd			%xmm21, 0+5*64(%r11)
+//	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+//	vmovsd			%xmm22, 0+6*64(%r11)
+//	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+//	vmovsd			%xmm23, 0+7*64(%r11)
+
+	movq	ARG1, %r10 // n
+	movq	ARG4, %r11
+
+	movq	$ 0, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0xfe, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vbroadcastsd	0(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+	vmovapd			0*64(%r11), %zmm16
+//	vmovapd			1*64(%r11), %zmm17
+//	vmovapd			2*64(%r11), %zmm18
+//	vmovapd			3*64(%r11), %zmm19
+//	vmovapd			4*64(%r11), %zmm20
+//	vmovapd			5*64(%r11), %zmm21
+//	vmovapd			6*64(%r11), %zmm22
+//	vmovapd			7*64(%r11), %zmm23
+	vaddpd			%zmm0, %zmm16, %zmm16
+//	vbroadcastsd	0+1*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm17
+//	vbroadcastsd	0+2*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm18
+//	vbroadcastsd	0+3*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm19
+//	vbroadcastsd	0+4*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm20
+//	vbroadcastsd	0+5*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm21
+//	vbroadcastsd	0+6*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm22
+//	vbroadcastsd	0+7*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+	vmovapd			%zmm16, 0*64(%r11)
+//	vmovapd			%zmm17, 1*64(%r11)
+//	vfmadd231pd		%zmm18, %zmm18, %zmm25
+//	vmovapd			%zmm18, 2*64(%r11)
+//	vfmadd231pd		%zmm19, %zmm19, %zmm26
+//	vmovapd			%zmm19, 3*64(%r11)
+//	vfmadd231pd		%zmm20, %zmm20, %zmm25
+//	vmovapd			%zmm20, 4*64(%r11)
+//	vfmadd231pd		%zmm21, %zmm21, %zmm26
+//	vmovapd			%zmm21, 5*64(%r11)
+//	vfmadd231pd		%zmm22, %zmm22, %zmm25
+//	vmovapd			%zmm22, 6*64(%r11)
+//	vfmadd231pd		%zmm23, %zmm23, %zmm26
+//	vmovapd			%zmm23, 7*64(%r11)
+
+	movq	ARG1, %r10 // n
+	movq	ARG4, %r11
+
+	movq	$ 0, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// second column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 8(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+
+	leaq	8+64*1(%r11), %r14 // XXX chech for reg overwrite
+	leaq	8(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vxorpd			%xmm31, %xmm24, %xmm27
+	vmovsd			%xmm27, 8+64*1(%r13) // pT[1+ps*1]
+
+//	vmovapd			1*64(%r11), %zmm0
+	vxorpd			%zmm0, %zmm0, %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+////	vbroadcastsd	8+1*64(%r11), %zmm17
+////	vmulpd			%zmm25, %zmm17, %zmm17
+//	vbroadcastsd	8+2*64(%r11), %zmm18
+//	vmulpd			%zmm25, %zmm18, %zmm18
+//	vbroadcastsd	8+3*64(%r11), %zmm19
+//	vmulpd			%zmm25, %zmm19, %zmm19
+//	vbroadcastsd	8+4*64(%r11), %zmm20
+//	vmulpd			%zmm25, %zmm20, %zmm20
+//	vbroadcastsd	8+5*64(%r11), %zmm21
+//	vmulpd			%zmm25, %zmm21, %zmm21
+//	vbroadcastsd	8+6*64(%r11), %zmm22
+//	vmulpd			%zmm25, %zmm22, %zmm22
+//	vbroadcastsd	8+7*64(%r11), %zmm23
+//	vmulpd			%zmm25, %zmm23, %zmm23
+////	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+////	vmovsd			%xmm17, 8+1*64(%r11)
+//	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+//	vmovsd			%xmm18, 8+2*64(%r11)
+//	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+//	vmovsd			%xmm19, 8+3*64(%r11)
+//	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+//	vmovsd			%xmm20, 8+4*64(%r11)
+//	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+//	vmovsd			%xmm21, 8+5*64(%r11)
+//	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+//	vmovsd			%xmm22, 8+6*64(%r11)
+//	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+//	vmovsd			%xmm23, 8+7*64(%r11)
+
+	movq	ARG1, %r10 // n
+	movq	ARG4, %r11
+
+	movq	$ 8, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC00+16(%rip), %zmm27 // 1.0
+#else
+	vbroadcastsd	LC00+16(%rip), %zmm27 // 1.0
+#endif
+	movl	$ 0x01, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			0+64*0(%r13), %zmm27 {%k1}
+	vmulpd			%zmm27, %zmm0, %zmm0
+	vbroadcastsd	8+64*1(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0
+	vmovapd			%zmm0, 1*64(%r13) {%k1}
+
+	movl	$ 0xfc, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+////	vmovapd			0*64(%r11), %zmm16
+	vmovapd			1*64(%r11), %zmm17
+//	vmovapd			2*64(%r11), %zmm18
+//	vmovapd			3*64(%r11), %zmm19
+//	vmovapd			4*64(%r11), %zmm20
+//	vmovapd			5*64(%r11), %zmm21
+//	vmovapd			6*64(%r11), %zmm22
+//	vmovapd			7*64(%r11), %zmm23
+////	vaddpd			%zmm0, %zmm16, %zmm16
+////	vbroadcastsd	8+1*64(%r11), %zmm24
+////	vfmadd231pd		%zmm0, %zmm24, %zmm17
+	vaddpd			%zmm0, %zmm17, %zmm17
+//	vbroadcastsd	8+2*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm18
+//	vbroadcastsd	8+3*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm19
+//	vbroadcastsd	8+4*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm20
+//	vbroadcastsd	8+5*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm21
+//	vbroadcastsd	8+6*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm22
+//	vbroadcastsd	8+7*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+////	vmovapd			%zmm16, 0*64(%r11)
+	vmovapd			%zmm17, 1*64(%r11)
+////	vfmadd231pd		%zmm18, %zmm18, %zmm25
+//	vmovapd			%zmm18, 2*64(%r11)
+//	vfmadd231pd		%zmm19, %zmm19, %zmm26
+//	vmovapd			%zmm19, 3*64(%r11)
+//	vfmadd231pd		%zmm20, %zmm20, %zmm25
+//	vmovapd			%zmm20, 4*64(%r11)
+//	vfmadd231pd		%zmm21, %zmm21, %zmm26
+//	vmovapd			%zmm21, 5*64(%r11)
+//	vfmadd231pd		%zmm22, %zmm22, %zmm25
+//	vmovapd			%zmm22, 6*64(%r11)
+//	vfmadd231pd		%zmm23, %zmm23, %zmm26
+//	vmovapd			%zmm23, 7*64(%r11)
+
+	movq	ARG1, %r10 // n
+	movq	ARG4, %r11
+
+	movq	$ 8, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// third column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 16(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+
+	leaq	16+64*2(%r11), %r14 // XXX chech for reg overwrite
+	leaq	16(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vxorpd			%xmm31, %xmm24, %xmm27
+	vmovsd			%xmm27, 16+64*2(%r13) // pT[1+ps*1]
+
+//	vmovapd			2*64(%r11), %zmm0
+	vxorpd			%zmm0, %zmm0, %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+////	vbroadcastsd	16+1*64(%r11), %zmm17
+////	vmulpd			%zmm25, %zmm17, %zmm17
+////	vbroadcastsd	16+2*64(%r11), %zmm18
+////	vmulpd			%zmm25, %zmm18, %zmm18
+//	vbroadcastsd	16+3*64(%r11), %zmm19
+//	vmulpd			%zmm25, %zmm19, %zmm19
+//	vbroadcastsd	16+4*64(%r11), %zmm20
+//	vmulpd			%zmm25, %zmm20, %zmm20
+//	vbroadcastsd	16+5*64(%r11), %zmm21
+//	vmulpd			%zmm25, %zmm21, %zmm21
+//	vbroadcastsd	16+6*64(%r11), %zmm22
+//	vmulpd			%zmm25, %zmm22, %zmm22
+//	vbroadcastsd	16+7*64(%r11), %zmm23
+//	vmulpd			%zmm25, %zmm23, %zmm23
+////	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+////	vmovsd			%xmm17, 16+1*64(%r11)
+////	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+////	vmovsd			%xmm18, 16+2*64(%r11)
+//	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+//	vmovsd			%xmm19, 16+3*64(%r11)
+//	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+//	vmovsd			%xmm20, 16+4*64(%r11)
+//	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+//	vmovsd			%xmm21, 16+5*64(%r11)
+//	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+//	vmovsd			%xmm22, 16+6*64(%r11)
+//	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+//	vmovsd			%xmm23, 16+7*64(%r11)
+
+	movq	ARG1, %r10 // n
+	movq	ARG4, %r11
+
+	movq	$ 16, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0x01, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			0*64(%r13), %zmm24
+	vmulpd			%zmm24, %zmm0, %zmm1 {%k1}{z}
+	vmovapd			1*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x03, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	vmovapd			%zmm1, %zmm0 {%k1}
+	vbroadcastsd	16+2*64(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0
+	vmovapd			%zmm0, 2*64(%r13) {%k1}
+
+	movl	$ 0xf8, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+////	vmovapd			0*64(%r11), %zmm16
+////	vmovapd			1*64(%r11), %zmm17
+	vmovapd			2*64(%r11), %zmm18
+//	vmovapd			3*64(%r11), %zmm19
+//	vmovapd			4*64(%r11), %zmm20
+//	vmovapd			5*64(%r11), %zmm21
+//	vmovapd			6*64(%r11), %zmm22
+//	vmovapd			7*64(%r11), %zmm23
+////	vaddpd			%zmm0, %zmm16, %zmm16
+////	vbroadcastsd	16+1*64(%r11), %zmm24
+////	vfmadd231pd		%zmm0, %zmm24, %zmm17
+////	vaddpd			%zmm0, %zmm17, %zmm17
+////	vbroadcastsd	16+2*64(%r11), %zmm24
+////	vfmadd231pd		%zmm0, %zmm24, %zmm18
+	vaddpd			%zmm0, %zmm18, %zmm18
+//	vbroadcastsd	16+3*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm19
+//	vbroadcastsd	16+4*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm20
+//	vbroadcastsd	16+5*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm21
+//	vbroadcastsd	16+6*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm22
+//	vbroadcastsd	16+7*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+////	vmovapd			%zmm16, 0*64(%r11)
+////	vmovapd			%zmm17, 1*64(%r11)
+////	vfmadd231pd		%zmm18, %zmm18, %zmm25
+	vmovapd			%zmm18, 2*64(%r11)
+////	vfmadd231pd		%zmm19, %zmm19, %zmm26
+//	vmovapd			%zmm19, 3*64(%r11)
+//	vfmadd231pd		%zmm20, %zmm20, %zmm25
+//	vmovapd			%zmm20, 4*64(%r11)
+//	vfmadd231pd		%zmm21, %zmm21, %zmm26
+//	vmovapd			%zmm21, 5*64(%r11)
+//	vfmadd231pd		%zmm22, %zmm22, %zmm25
+//	vmovapd			%zmm22, 6*64(%r11)
+//	vfmadd231pd		%zmm23, %zmm23, %zmm26
+//	vmovapd			%zmm23, 7*64(%r11)
+
+	movq	ARG1, %r10 // n
+	movq	ARG4, %r11
+
+	movq	$ 16, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// fourth column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 24(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+
+	leaq	24+64*3(%r11), %r14 // XXX chech for reg overwrite
+	leaq	24(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vxorpd			%xmm31, %xmm24, %xmm27
+	vmovsd			%xmm27, 24+64*3(%r13) // pT[1+ps*1]
+
+//	vmovapd			3*64(%r11), %zmm0
+	vxorpd			%zmm0, %zmm0, %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+////	vbroadcastsd	24+1*64(%r11), %zmm17
+////	vmulpd			%zmm25, %zmm17, %zmm17
+////	vbroadcastsd	24+2*64(%r11), %zmm18
+////	vmulpd			%zmm25, %zmm18, %zmm18
+////	vbroadcastsd	24+3*64(%r11), %zmm19
+////	vmulpd			%zmm25, %zmm19, %zmm19
+//	vbroadcastsd	24+4*64(%r11), %zmm20
+//	vmulpd			%zmm25, %zmm20, %zmm20
+//	vbroadcastsd	24+5*64(%r11), %zmm21
+//	vmulpd			%zmm25, %zmm21, %zmm21
+//	vbroadcastsd	24+6*64(%r11), %zmm22
+//	vmulpd			%zmm25, %zmm22, %zmm22
+//	vbroadcastsd	24+7*64(%r11), %zmm23
+//	vmulpd			%zmm25, %zmm23, %zmm23
+////	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+////	vmovsd			%xmm17, 24+1*64(%r11)
+////	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+////	vmovsd			%xmm18, 24+2*64(%r11)
+////	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+////	vmovsd			%xmm19, 24+3*64(%r11)
+//	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+//	vmovsd			%xmm20, 24+4*64(%r11)
+//	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+//	vmovsd			%xmm21, 24+5*64(%r11)
+//	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+//	vmovsd			%xmm22, 24+6*64(%r11)
+//	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+//	vmovsd			%xmm23, 24+7*64(%r11)
+
+	movq	ARG1, %r10 // n
+	movq	ARG4, %r11
+
+	movq	$ 24, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0x01, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			0*64(%r13), %zmm24
+	vmulpd			%zmm24, %zmm0, %zmm1 {%k1}{z}
+	vmovapd			1*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x03, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	vmovapd			2*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x07, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	vmovapd			%zmm1, %zmm0 {%k1}
+	vbroadcastsd	24+3*64(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0
+	vmovapd			%zmm0, 3*64(%r13) {%k1}
+
+	movl	$ 0xf0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+////	vmovapd			0*64(%r11), %zmm16
+////	vmovapd			1*64(%r11), %zmm17
+////	vmovapd			2*64(%r11), %zmm18
+	vmovapd			3*64(%r11), %zmm19
+//	vmovapd			4*64(%r11), %zmm20
+//	vmovapd			5*64(%r11), %zmm21
+//	vmovapd			6*64(%r11), %zmm22
+//	vmovapd			7*64(%r11), %zmm23
+////	vaddpd			%zmm0, %zmm16, %zmm16
+////	vbroadcastsd	24+1*64(%r11), %zmm24
+////	vfmadd231pd		%zmm0, %zmm24, %zmm17
+////	vaddpd			%zmm0, %zmm17, %zmm17
+////	vbroadcastsd	24+2*64(%r11), %zmm24
+////	vfmadd231pd		%zmm0, %zmm24, %zmm18
+////	vaddpd			%zmm0, %zmm18, %zmm18
+////	vbroadcastsd	24+3*64(%r11), %zmm24
+////	vfmadd231pd		%zmm0, %zmm24, %zmm19
+	vaddpd			%zmm0, %zmm19, %zmm19
+//	vbroadcastsd	24+4*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm20
+//	vbroadcastsd	24+5*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm21
+//	vbroadcastsd	24+6*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm22
+//	vbroadcastsd	24+7*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+////	vmovapd			%zmm16, 0*64(%r11)
+////	vmovapd			%zmm17, 1*64(%r11)
+////	vfmadd231pd		%zmm18, %zmm18, %zmm25
+////	vmovapd			%zmm18, 2*64(%r11)
+////	vfmadd231pd		%zmm19, %zmm19, %zmm26
+	vmovapd			%zmm19, 3*64(%r11)
+////	vfmadd231pd		%zmm20, %zmm20, %zmm25
+//	vmovapd			%zmm20, 4*64(%r11)
+//	vfmadd231pd		%zmm21, %zmm21, %zmm26
+//	vmovapd			%zmm21, 5*64(%r11)
+//	vfmadd231pd		%zmm22, %zmm22, %zmm25
+//	vmovapd			%zmm22, 6*64(%r11)
+//	vfmadd231pd		%zmm23, %zmm23, %zmm26
+//	vmovapd			%zmm23, 7*64(%r11)
+
+	movq	ARG1, %r10 // n
+	movq	ARG4, %r11
+
+	movq	$ 24, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// fifth column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 32(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+
+	leaq	32+64*4(%r11), %r14 // XXX chech for reg overwrite
+	leaq	32(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vxorpd			%xmm31, %xmm24, %xmm27
+	vmovsd			%xmm27, 32+64*4(%r13) // pT[1+ps*1]
+
+//	vmovapd			4*64(%r11), %zmm0
+	vxorpd			%zmm0, %zmm0, %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+////	vbroadcastsd	32+1*64(%r11), %zmm17
+////	vmulpd			%zmm25, %zmm17, %zmm17
+////	vbroadcastsd	32+2*64(%r11), %zmm18
+////	vmulpd			%zmm25, %zmm18, %zmm18
+////	vbroadcastsd	32+3*64(%r11), %zmm19
+////	vmulpd			%zmm25, %zmm19, %zmm19
+////	vbroadcastsd	32+4*64(%r11), %zmm20
+////	vmulpd			%zmm25, %zmm20, %zmm20
+//	vbroadcastsd	32+5*64(%r11), %zmm21
+//	vmulpd			%zmm25, %zmm21, %zmm21
+//	vbroadcastsd	32+6*64(%r11), %zmm22
+//	vmulpd			%zmm25, %zmm22, %zmm22
+//	vbroadcastsd	32+7*64(%r11), %zmm23
+//	vmulpd			%zmm25, %zmm23, %zmm23
+////	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+////	vmovsd			%xmm17, 32+1*64(%r11)
+////	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+////	vmovsd			%xmm18, 32+2*64(%r11)
+////	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+////	vmovsd			%xmm19, 32+3*64(%r11)
+////	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+////	vmovsd			%xmm20, 32+4*64(%r11)
+//	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+//	vmovsd			%xmm21, 32+5*64(%r11)
+//	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+//	vmovsd			%xmm22, 32+6*64(%r11)
+//	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+//	vmovsd			%xmm23, 32+7*64(%r11)
+
+	movq	ARG1, %r10 // n
+	movq	ARG4, %r11
+
+	movq	$ 32, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0x01, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			0*64(%r13), %zmm24
+	vmulpd			%zmm24, %zmm0, %zmm1 {%k1}{z}
+	//
+	vmovapd			1*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x03, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			2*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x07, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			3*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x0f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			%zmm1, %zmm0 {%k1}
+	vbroadcastsd	32+4*64(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0
+	vmovapd			%zmm0, 4*64(%r13) {%k1}
+
+	movl	$ 0xe0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+////	vmovapd			0*64(%r11), %zmm16
+////	vmovapd			1*64(%r11), %zmm17
+////	vmovapd			2*64(%r11), %zmm18
+////	vmovapd			3*64(%r11), %zmm19
+	vmovapd			4*64(%r11), %zmm20
+//	vmovapd			5*64(%r11), %zmm21
+//	vmovapd			6*64(%r11), %zmm22
+//	vmovapd			7*64(%r11), %zmm23
+////	vaddpd			%zmm0, %zmm16, %zmm16
+////	vbroadcastsd	32+1*64(%r11), %zmm24
+////	vfmadd231pd		%zmm0, %zmm24, %zmm17
+////	vaddpd			%zmm0, %zmm17, %zmm17
+////	vbroadcastsd	32+2*64(%r11), %zmm24
+////	vfmadd231pd		%zmm0, %zmm24, %zmm18
+////	vaddpd			%zmm0, %zmm18, %zmm18
+////	vbroadcastsd	32+3*64(%r11), %zmm24
+////	vfmadd231pd		%zmm0, %zmm24, %zmm19
+////	vaddpd			%zmm0, %zmm19, %zmm19
+////	vbroadcastsd	32+4*64(%r11), %zmm24
+////	vfmadd231pd		%zmm0, %zmm24, %zmm20
+	vaddpd			%zmm0, %zmm20, %zmm20
+//	vbroadcastsd	32+5*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm21
+//	vbroadcastsd	32+6*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm22
+//	vbroadcastsd	32+7*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+////	vmovapd			%zmm16, 0*64(%r11)
+////	vmovapd			%zmm17, 1*64(%r11)
+////	vfmadd231pd		%zmm18, %zmm18, %zmm25
+////	vmovapd			%zmm18, 2*64(%r11)
+////	vfmadd231pd		%zmm19, %zmm19, %zmm26
+////	vmovapd			%zmm19, 3*64(%r11)
+////	vfmadd231pd		%zmm20, %zmm20, %zmm25
+	vmovapd			%zmm20, 4*64(%r11)
+////	vfmadd231pd		%zmm21, %zmm21, %zmm26
+//	vmovapd			%zmm21, 5*64(%r11)
+//	vfmadd231pd		%zmm22, %zmm22, %zmm25
+//	vmovapd			%zmm22, 6*64(%r11)
+//	vfmadd231pd		%zmm23, %zmm23, %zmm26
+//	vmovapd			%zmm23, 7*64(%r11)
+
+	movq	ARG1, %r10 // n
+	movq	ARG4, %r11
+
+	movq	$ 32, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// sixth column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 40(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+
+	leaq	40+64*5(%r11), %r14 // XXX chech for reg overwrite
+	leaq	40(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vxorpd			%xmm31, %xmm24, %xmm27
+	vmovsd			%xmm27, 40+64*5(%r13) // pT[1+ps*1]
+
+//	vmovapd			5*64(%r11), %zmm0
+	vxorpd			%zmm0, %zmm0, %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+////	vbroadcastsd	40+1*64(%r11), %zmm17
+////	vmulpd			%zmm25, %zmm17, %zmm17
+////	vbroadcastsd	40+2*64(%r11), %zmm18
+////	vmulpd			%zmm25, %zmm18, %zmm18
+////	vbroadcastsd	40+3*64(%r11), %zmm19
+////	vmulpd			%zmm25, %zmm19, %zmm19
+////	vbroadcastsd	40+4*64(%r11), %zmm20
+////	vmulpd			%zmm25, %zmm20, %zmm20
+////	vbroadcastsd	40+5*64(%r11), %zmm21
+////	vmulpd			%zmm25, %zmm21, %zmm21
+//	vbroadcastsd	40+6*64(%r11), %zmm22
+//	vmulpd			%zmm25, %zmm22, %zmm22
+//	vbroadcastsd	40+7*64(%r11), %zmm23
+//	vmulpd			%zmm25, %zmm23, %zmm23
+////	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+////	vmovsd			%xmm17, 40+1*64(%r11)
+////	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+////	vmovsd			%xmm18, 40+2*64(%r11)
+////	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+////	vmovsd			%xmm19, 40+3*64(%r11)
+////	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+////	vmovsd			%xmm20, 40+4*64(%r11)
+////	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+////	vmovsd			%xmm21, 40+5*64(%r11)
+//	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+//	vmovsd			%xmm22, 40+6*64(%r11)
+//	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+//	vmovsd			%xmm23, 40+7*64(%r11)
+
+	movq	ARG1, %r10 // n
+	movq	ARG4, %r11
+
+	movq	$ 40, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0x01, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			0*64(%r13), %zmm24
+	vmulpd			%zmm24, %zmm0, %zmm1 {%k1}{z}
+	//
+	vmovapd			1*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x03, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			2*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x07, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			3*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x0f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			4*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x1f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			%zmm1, %zmm0 {%k1}
+	vbroadcastsd	40+5*64(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0
+	vmovapd			%zmm0, 5*64(%r13) {%k1}
+
+	movl	$ 0xc0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+////	vmovapd			0*64(%r11), %zmm16
+////	vmovapd			1*64(%r11), %zmm17
+////	vmovapd			2*64(%r11), %zmm18
+////	vmovapd			3*64(%r11), %zmm19
+////	vmovapd			4*64(%r11), %zmm20
+	vmovapd			5*64(%r11), %zmm21
+//	vmovapd			6*64(%r11), %zmm22
+//	vmovapd			7*64(%r11), %zmm23
+////	vaddpd			%zmm0, %zmm16, %zmm16
+////	vbroadcastsd	40+1*64(%r11), %zmm24
+////	vfmadd231pd		%zmm0, %zmm24, %zmm17
+////	vaddpd			%zmm0, %zmm17, %zmm17
+////	vbroadcastsd	40+2*64(%r11), %zmm24
+////	vfmadd231pd		%zmm0, %zmm24, %zmm18
+////	vaddpd			%zmm0, %zmm18, %zmm18
+////	vbroadcastsd	40+3*64(%r11), %zmm24
+////	vfmadd231pd		%zmm0, %zmm24, %zmm19
+////	vaddpd			%zmm0, %zmm19, %zmm19
+////	vbroadcastsd	40+4*64(%r11), %zmm24
+////	vfmadd231pd		%zmm0, %zmm24, %zmm20
+////	vaddpd			%zmm0, %zmm20, %zmm20
+////	vbroadcastsd	40+5*64(%r11), %zmm24
+////	vfmadd231pd		%zmm0, %zmm24, %zmm21
+	vaddpd			%zmm0, %zmm21, %zmm21
+//	vbroadcastsd	40+6*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm22
+//	vbroadcastsd	40+7*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+////	vmovapd			%zmm16, 0*64(%r11)
+////	vmovapd			%zmm17, 1*64(%r11)
+////	vfmadd231pd		%zmm18, %zmm18, %zmm25
+////	vmovapd			%zmm18, 2*64(%r11)
+////	vfmadd231pd		%zmm19, %zmm19, %zmm26
+////	vmovapd			%zmm19, 3*64(%r11)
+////	vfmadd231pd		%zmm20, %zmm20, %zmm25
+////	vmovapd			%zmm20, 4*64(%r11)
+////	vfmadd231pd		%zmm21, %zmm21, %zmm26
+	vmovapd			%zmm21, 5*64(%r11)
+////	vfmadd231pd		%zmm22, %zmm22, %zmm25
+//	vmovapd			%zmm22, 6*64(%r11)
+//	vfmadd231pd		%zmm23, %zmm23, %zmm26
+//	vmovapd			%zmm23, 7*64(%r11)
+
+	movq	ARG1, %r10 // n
+	movq	ARG4, %r11
+
+	movq	$ 40, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// seventh column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 48(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+
+	leaq	48+64*6(%r11), %r14 // XXX chech for reg overwrite
+	leaq	48(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vxorpd			%xmm31, %xmm24, %xmm27
+	vmovsd			%xmm27, 48+64*6(%r13) // pT[1+ps*1]
+
+//	vmovapd			6*64(%r11), %zmm0
+	vxorpd			%zmm0, %zmm0, %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+////	vbroadcastsd	48+1*64(%r11), %zmm17
+////	vmulpd			%zmm25, %zmm17, %zmm17
+////	vbroadcastsd	48+2*64(%r11), %zmm18
+////	vmulpd			%zmm25, %zmm18, %zmm18
+////	vbroadcastsd	48+3*64(%r11), %zmm19
+////	vmulpd			%zmm25, %zmm19, %zmm19
+////	vbroadcastsd	48+4*64(%r11), %zmm20
+////	vmulpd			%zmm25, %zmm20, %zmm20
+////	vbroadcastsd	48+5*64(%r11), %zmm21
+////	vmulpd			%zmm25, %zmm21, %zmm21
+////	vbroadcastsd	48+6*64(%r11), %zmm22
+////	vmulpd			%zmm25, %zmm22, %zmm22
+//	vbroadcastsd	48+7*64(%r11), %zmm23
+//	vmulpd			%zmm25, %zmm23, %zmm23
+////	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+////	vmovsd			%xmm17, 48+1*64(%r11)
+////	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+////	vmovsd			%xmm18, 48+2*64(%r11)
+////	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+////	vmovsd			%xmm19, 48+3*64(%r11)
+////	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+////	vmovsd			%xmm20, 48+4*64(%r11)
+////	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+////	vmovsd			%xmm21, 48+5*64(%r11)
+////	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+////	vmovsd			%xmm22, 48+6*64(%r11)
+//	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+//	vmovsd			%xmm23, 48+7*64(%r11)
+
+	movq	ARG1, %r10 // n
+	movq	ARG4, %r11
+
+	movq	$ 48, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0x01, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			0*64(%r13), %zmm24
+	vmulpd			%zmm24, %zmm0, %zmm1 {%k1}{z}
+	//
+	vmovapd			1*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x03, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			2*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x07, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			3*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x0f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			4*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x1f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			5*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x3f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			%zmm1, %zmm0 {%k1}
+	vbroadcastsd	48+6*64(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0
+	vmovapd			%zmm0, 6*64(%r13) {%k1}
+
+	movl	$ 0x80, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+////	vmovapd			0*64(%r11), %zmm16
+////	vmovapd			1*64(%r11), %zmm17
+////	vmovapd			2*64(%r11), %zmm18
+////	vmovapd			3*64(%r11), %zmm19
+////	vmovapd			4*64(%r11), %zmm20
+////	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+//	vmovapd			7*64(%r11), %zmm23
+////	vaddpd			%zmm0, %zmm16, %zmm16
+////	vbroadcastsd	48+1*64(%r11), %zmm24
+////	vfmadd231pd		%zmm0, %zmm24, %zmm17
+////	vaddpd			%zmm0, %zmm17, %zmm17
+////	vbroadcastsd	48+2*64(%r11), %zmm24
+////	vfmadd231pd		%zmm0, %zmm24, %zmm18
+////	vaddpd			%zmm0, %zmm18, %zmm18
+////	vbroadcastsd	48+3*64(%r11), %zmm24
+////	vfmadd231pd		%zmm0, %zmm24, %zmm19
+////	vaddpd			%zmm0, %zmm19, %zmm19
+////	vbroadcastsd	48+4*64(%r11), %zmm24
+////	vfmadd231pd		%zmm0, %zmm24, %zmm20
+////	vaddpd			%zmm0, %zmm20, %zmm20
+////	vbroadcastsd	48+5*64(%r11), %zmm24
+////	vfmadd231pd		%zmm0, %zmm24, %zmm21
+////	vaddpd			%zmm0, %zmm21, %zmm21
+////	vbroadcastsd	48+6*64(%r11), %zmm24
+////	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vaddpd			%zmm0, %zmm22, %zmm22
+//	vbroadcastsd	48+7*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+////	vmovapd			%zmm16, 0*64(%r11)
+////	vmovapd			%zmm17, 1*64(%r11)
+////	vfmadd231pd		%zmm18, %zmm18, %zmm25
+////	vmovapd			%zmm18, 2*64(%r11)
+////	vfmadd231pd		%zmm19, %zmm19, %zmm26
+////	vmovapd			%zmm19, 3*64(%r11)
+////	vfmadd231pd		%zmm20, %zmm20, %zmm25
+////	vmovapd			%zmm20, 4*64(%r11)
+////	vfmadd231pd		%zmm21, %zmm21, %zmm26
+////	vmovapd			%zmm21, 5*64(%r11)
+////	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+////	vfmadd231pd		%zmm23, %zmm23, %zmm26
+//	vmovapd			%zmm23, 7*64(%r11)
+
+	movq	ARG1, %r10 // n
+	movq	ARG4, %r11
+
+	movq	$ 48, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// eigth column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 56(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+
+	leaq	56+64*7(%r11), %r14 // XXX chech for reg overwrite
+	leaq	56(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vxorpd			%xmm31, %xmm24, %xmm27
+	vmovsd			%xmm27, 56+64*7(%r13) // pT[1+ps*1]
+
+//	vmovapd			7*64(%r11), %zmm0
+	vxorpd			%zmm0, %zmm0, %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+////	vbroadcastsd	56+1*64(%r11), %zmm17
+////	vmulpd			%zmm25, %zmm17, %zmm17
+////	vbroadcastsd	56+2*64(%r11), %zmm18
+////	vmulpd			%zmm25, %zmm18, %zmm18
+////	vbroadcastsd	56+3*64(%r11), %zmm19
+////	vmulpd			%zmm25, %zmm19, %zmm19
+////	vbroadcastsd	56+4*64(%r11), %zmm20
+////	vmulpd			%zmm25, %zmm20, %zmm20
+////	vbroadcastsd	56+5*64(%r11), %zmm21
+////	vmulpd			%zmm25, %zmm21, %zmm21
+////	vbroadcastsd	56+6*64(%r11), %zmm22
+////	vmulpd			%zmm25, %zmm22, %zmm22
+////	vbroadcastsd	56+7*64(%r11), %zmm23
+////	vmulpd			%zmm25, %zmm23, %zmm23
+////	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+////	vmovsd			%xmm17, 56+1*64(%r11)
+////	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+////	vmovsd			%xmm18, 56+2*64(%r11)
+////	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+////	vmovsd			%xmm19, 56+3*64(%r11)
+////	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+////	vmovsd			%xmm20, 56+4*64(%r11)
+////	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+////	vmovsd			%xmm21, 56+5*64(%r11)
+////	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+////	vmovsd			%xmm22, 56+6*64(%r11)
+////	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+////	vmovsd			%xmm23, 56+7*64(%r11)
+
+	movq	ARG1, %r10 // n
+	movq	ARG4, %r11
+
+	movq	$ 56, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0x01, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			0*64(%r13), %zmm24
+	vmulpd			%zmm24, %zmm0, %zmm1 {%k1}{z}
+	//
+	vmovapd			1*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x03, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			2*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x07, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			3*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x0f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			4*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x1f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			5*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x3f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			6*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x7f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			%zmm1, %zmm0 {%k1}
+	vbroadcastsd	56+7*64(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0
+	vmovapd			%zmm0, 7*64(%r13) {%k1}
+
+102:
+
+1000:
+	EPILOGUE
+	
+	ret
+
+	FUN_END(kernel_dgelqf_pd_la_dlarft8_8_lib8)
 
 
 

--- a/kernel/avx512/kernel_dgelqf_lib8.S
+++ b/kernel/avx512/kernel_dgelqf_lib8.S
@@ -198,10 +198,10 @@ NAME:
 
 
 #if MACRO_LEVEL>=1
-	.macro INNER_KERNEL_1_DGELQF_DLARFT8_8_LIB8
+	.macro INNER_KERNEL_1_DGELQF_8_LIB8
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_1_dgelqf_dlarft8_8_lib8)
+	FUN_START(inner_kernel_1_dgelqf_8_lib8)
 #endif
 
 	cmpl	$ 7, %r10d
@@ -263,7 +263,7 @@ NAME:
 #else
 	ret
 
-	FUN_END(inner_kernel_1_dgelqf_dlarft8_8_lib8)
+	FUN_END(inner_kernel_1_dgelqf_8_lib8)
 #endif
 
 
@@ -271,10 +271,10 @@ NAME:
 
 
 #if MACRO_LEVEL>=1
-	.macro INNER_KERNEL_2_DGELQF_DLARFT8_8_LIB8
+	.macro INNER_KERNEL_2_DGELQF_8_LIB8
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_2_dgelqf_dlarft8_8_lib8)
+	FUN_START(inner_kernel_2_dgelqf_8_lib8)
 #endif
 
 	cmpl	$ 7, %r10d
@@ -345,15 +345,1204 @@ NAME:
 #else
 	ret
 
-	FUN_END(inner_kernel_2_dgelqf_dlarft8_8_lib8)
+	FUN_END(inner_kernel_2_dgelqf_8_lib8)
 #endif
 
 
 
 
 
+//                           1      2           3
+// void kernel_dgelqf_8_lib8(int n, double *pD, double *dD)
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dgelqf_8_lib8)
+	
+	PROLOGUE
+
+
+	movq	ARG2, %r11 // D
+	movq	ARG3, %r12 // dD
+
+	vxorpd			%xmm25, %xmm25, %xmm25
+	movq	ARG1, %r10 // n
+	subl	$ 1, %r10d
+	addq	$ 64, %r11
+100:
+	vmovsd			0(%r11), %xmm24
+	vfmadd231sd		%xmm24, %xmm24, %xmm25
+	subl	$ 1, %r10d
+	addq	$ 64, %r11
+	cmpl	$ 0, %r10d
+	jg		100b
+
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		101f
+	vmovsd			%xmm24, 0(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+	vmovsd			0+64*0(%r11), %xmm24 // alpha
+	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
+	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC00(%rip), %zmm31 // mask
+#else
+	vbroadcastsd	LC00(%rip), %zmm31 // mask
+#endif
+	vandpd			%xmm31, %xmm24, %xmm27
+	vxorpd			%xmm31, %xmm27, %xmm27
+	vxorpd			%xmm27, %xmm25, %xmm25 // beta
+	vmovsd			%xmm25, 0+64*0(%r11) // pD[0+ps*0]
+	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
+#else
+	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
+#endif
+	vmovsd			%xmm24, %xmm27, %xmm27
+	vmovddup		%xmm24, %xmm24
+	vmovsd			%xmm25, %xmm24, %xmm24
+	vdivpd			%xmm24, %xmm27, %xmm24
+	vmovsd			%xmm24, 0(%r12) // dD[0]
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
+
+	vmovapd			0*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+	vbroadcastsd	0+1*64(%r11), %zmm17
+	vmulpd			%zmm25, %zmm17, %zmm17
+	vbroadcastsd	0+2*64(%r11), %zmm18
+	vmulpd			%zmm25, %zmm18, %zmm18
+	vbroadcastsd	0+3*64(%r11), %zmm19
+	vmulpd			%zmm25, %zmm19, %zmm19
+	vbroadcastsd	0+4*64(%r11), %zmm20
+	vmulpd			%zmm25, %zmm20, %zmm20
+	vbroadcastsd	0+5*64(%r11), %zmm21
+	vmulpd			%zmm25, %zmm21, %zmm21
+	vbroadcastsd	0+6*64(%r11), %zmm22
+	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	0+7*64(%r11), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+	vmovsd			%xmm17, 0+1*64(%r11)
+	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+	vmovsd			%xmm18, 0+2*64(%r11)
+	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+	vmovsd			%xmm19, 0+3*64(%r11)
+	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+	vmovsd			%xmm20, 0+4*64(%r11)
+	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+	vmovsd			%xmm21, 0+5*64(%r11)
+	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+	vmovsd			%xmm22, 0+6*64(%r11)
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+	vmovsd			%xmm23, 0+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 0, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0xfe, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vbroadcastsd	0(%r12), %zmm25
+	vxorpd			%zmm31, %zmm25, %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+	vmovapd			0*64(%r11), %zmm16
+	vmovapd			1*64(%r11), %zmm17
+	vmovapd			2*64(%r11), %zmm18
+	vmovapd			3*64(%r11), %zmm19
+	vmovapd			4*64(%r11), %zmm20
+	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+	vmovapd			7*64(%r11), %zmm23
+	vaddpd			%zmm0, %zmm16, %zmm16
+	vbroadcastsd	0+1*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm17
+	vbroadcastsd	0+2*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm18
+	vbroadcastsd	0+3*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm19
+	vbroadcastsd	0+4*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm20
+	vbroadcastsd	0+5*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm21
+	vbroadcastsd	0+6*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vbroadcastsd	0+7*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+	vmovapd			%zmm16, 0*64(%r11)
+	vmovapd			%zmm17, 1*64(%r11)
+	vfmadd231pd		%zmm18, %zmm18, %zmm25
+	vmovapd			%zmm18, 2*64(%r11)
+	vfmadd231pd		%zmm19, %zmm19, %zmm26
+	vmovapd			%zmm19, 3*64(%r11)
+	vfmadd231pd		%zmm20, %zmm20, %zmm25
+	vmovapd			%zmm20, 4*64(%r11)
+	vfmadd231pd		%zmm21, %zmm21, %zmm26
+	vmovapd			%zmm21, 5*64(%r11)
+	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm23, 7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 0, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// second column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 8(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+	vmovsd			8+64*1(%r11), %xmm24 // alpha
+	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
+	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC00(%rip), %zmm31 // mask
+#else
+	vbroadcastsd	LC00(%rip), %zmm31 // mask
+#endif
+	vandpd			%xmm31, %xmm24, %xmm27
+	vxorpd			%xmm31, %xmm27, %xmm27
+	vxorpd			%xmm27, %xmm25, %xmm25 // beta
+	vmovsd			%xmm25, 8+64*1(%r11) // pD[1+ps*1]
+	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
+#else
+	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
+#endif
+	vmovsd			%xmm24, %xmm27, %xmm27
+	vmovddup		%xmm24, %xmm24
+	vmovsd			%xmm25, %xmm24, %xmm24
+	vdivpd			%xmm24, %xmm27, %xmm24
+	vmovsd			%xmm24, 8(%r12) // dD[1]
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
+
+	vmovapd			1*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+//	vbroadcastsd	8+1*64(%r11), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+	vbroadcastsd	8+2*64(%r11), %zmm18
+	vmulpd			%zmm25, %zmm18, %zmm18
+	vbroadcastsd	8+3*64(%r11), %zmm19
+	vmulpd			%zmm25, %zmm19, %zmm19
+	vbroadcastsd	8+4*64(%r11), %zmm20
+	vmulpd			%zmm25, %zmm20, %zmm20
+	vbroadcastsd	8+5*64(%r11), %zmm21
+	vmulpd			%zmm25, %zmm21, %zmm21
+	vbroadcastsd	8+6*64(%r11), %zmm22
+	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	8+7*64(%r11), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+//	vmovsd			%xmm17, 8+1*64(%r11)
+	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+	vmovsd			%xmm18, 8+2*64(%r11)
+	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+	vmovsd			%xmm19, 8+3*64(%r11)
+	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+	vmovsd			%xmm20, 8+4*64(%r11)
+	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+	vmovsd			%xmm21, 8+5*64(%r11)
+	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+	vmovsd			%xmm22, 8+6*64(%r11)
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+	vmovsd			%xmm23, 8+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 8, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0xfc, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vbroadcastsd	8(%r12), %zmm25
+	vxorpd			%zmm31, %zmm25, %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+//	vmovapd			0*64(%r11), %zmm16
+	vmovapd			1*64(%r11), %zmm17
+	vmovapd			2*64(%r11), %zmm18
+	vmovapd			3*64(%r11), %zmm19
+	vmovapd			4*64(%r11), %zmm20
+	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+	vmovapd			7*64(%r11), %zmm23
+//	vaddpd			%zmm0, %zmm16, %zmm16
+//	vbroadcastsd	8+1*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm17
+	vaddpd			%zmm0, %zmm17, %zmm17
+	vbroadcastsd	8+2*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm18
+	vbroadcastsd	8+3*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm19
+	vbroadcastsd	8+4*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm20
+	vbroadcastsd	8+5*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm21
+	vbroadcastsd	8+6*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vbroadcastsd	8+7*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+//	vmovapd			%zmm16, 0*64(%r11)
+	vmovapd			%zmm17, 1*64(%r11)
+//	vfmadd231pd		%zmm18, %zmm18, %zmm25
+	vmovapd			%zmm18, 2*64(%r11)
+	vfmadd231pd		%zmm19, %zmm19, %zmm26
+	vmovapd			%zmm19, 3*64(%r11)
+	vfmadd231pd		%zmm20, %zmm20, %zmm25
+	vmovapd			%zmm20, 4*64(%r11)
+	vfmadd231pd		%zmm21, %zmm21, %zmm26
+	vmovapd			%zmm21, 5*64(%r11)
+	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm23, 7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 8, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// third column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 16(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+	vmovsd			16+64*2(%r11), %xmm24 // alpha
+	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
+	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC00(%rip), %zmm31 // mask
+#else
+	vbroadcastsd	LC00(%rip), %zmm31 // mask
+#endif
+	vandpd			%xmm31, %xmm24, %xmm27
+	vxorpd			%xmm31, %xmm27, %xmm27
+	vxorpd			%xmm27, %xmm25, %xmm25 // beta
+	vmovsd			%xmm25, 16+64*2(%r11) // pD[1+ps*1]
+	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
+#else
+	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
+#endif
+	vmovsd			%xmm24, %xmm27, %xmm27
+	vmovddup		%xmm24, %xmm24
+	vmovsd			%xmm25, %xmm24, %xmm24
+	vdivpd			%xmm24, %xmm27, %xmm24
+	vmovsd			%xmm24, 16(%r12) // dD[1]
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
+
+	vmovapd			2*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+//	vbroadcastsd	16+1*64(%r11), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+//	vbroadcastsd	16+2*64(%r11), %zmm18
+//	vmulpd			%zmm25, %zmm18, %zmm18
+	vbroadcastsd	16+3*64(%r11), %zmm19
+	vmulpd			%zmm25, %zmm19, %zmm19
+	vbroadcastsd	16+4*64(%r11), %zmm20
+	vmulpd			%zmm25, %zmm20, %zmm20
+	vbroadcastsd	16+5*64(%r11), %zmm21
+	vmulpd			%zmm25, %zmm21, %zmm21
+	vbroadcastsd	16+6*64(%r11), %zmm22
+	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	16+7*64(%r11), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+//	vmovsd			%xmm17, 16+1*64(%r11)
+//	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+//	vmovsd			%xmm18, 16+2*64(%r11)
+	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+	vmovsd			%xmm19, 16+3*64(%r11)
+	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+	vmovsd			%xmm20, 16+4*64(%r11)
+	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+	vmovsd			%xmm21, 16+5*64(%r11)
+	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+	vmovsd			%xmm22, 16+6*64(%r11)
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+	vmovsd			%xmm23, 16+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 16, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0xf8, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vbroadcastsd	16(%r12), %zmm25
+	vxorpd			%zmm31, %zmm25, %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+//	vmovapd			0*64(%r11), %zmm16
+//	vmovapd			1*64(%r11), %zmm17
+	vmovapd			2*64(%r11), %zmm18
+	vmovapd			3*64(%r11), %zmm19
+	vmovapd			4*64(%r11), %zmm20
+	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+	vmovapd			7*64(%r11), %zmm23
+//	vaddpd			%zmm0, %zmm16, %zmm16
+//	vbroadcastsd	16+1*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm17
+//	vaddpd			%zmm0, %zmm17, %zmm17
+//	vbroadcastsd	16+2*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm18
+	vaddpd			%zmm0, %zmm18, %zmm18
+	vbroadcastsd	16+3*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm19
+	vbroadcastsd	16+4*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm20
+	vbroadcastsd	16+5*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm21
+	vbroadcastsd	16+6*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vbroadcastsd	16+7*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+//	vmovapd			%zmm16, 0*64(%r11)
+//	vmovapd			%zmm17, 1*64(%r11)
+//	vfmadd231pd		%zmm18, %zmm18, %zmm25
+	vmovapd			%zmm18, 2*64(%r11)
+//	vfmadd231pd		%zmm19, %zmm19, %zmm26
+	vmovapd			%zmm19, 3*64(%r11)
+	vfmadd231pd		%zmm20, %zmm20, %zmm25
+	vmovapd			%zmm20, 4*64(%r11)
+	vfmadd231pd		%zmm21, %zmm21, %zmm26
+	vmovapd			%zmm21, 5*64(%r11)
+	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm23, 7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 16, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// fourth column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 24(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+	vmovsd			24+64*3(%r11), %xmm24 // alpha
+	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
+	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC00(%rip), %zmm31 // mask
+#else
+	vbroadcastsd	LC00(%rip), %zmm31 // mask
+#endif
+	vandpd			%xmm31, %xmm24, %xmm27
+	vxorpd			%xmm31, %xmm27, %xmm27
+	vxorpd			%xmm27, %xmm25, %xmm25 // beta
+	vmovsd			%xmm25, 24+64*3(%r11) // pD[1+ps*1]
+	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
+#else
+	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
+#endif
+	vmovsd			%xmm24, %xmm27, %xmm27
+	vmovddup		%xmm24, %xmm24
+	vmovsd			%xmm25, %xmm24, %xmm24
+	vdivpd			%xmm24, %xmm27, %xmm24
+	vmovsd			%xmm24, 24(%r12) // dD[1]
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
+
+	vmovapd			3*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+//	vbroadcastsd	24+1*64(%r11), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+//	vbroadcastsd	24+2*64(%r11), %zmm18
+//	vmulpd			%zmm25, %zmm18, %zmm18
+//	vbroadcastsd	24+3*64(%r11), %zmm19
+//	vmulpd			%zmm25, %zmm19, %zmm19
+	vbroadcastsd	24+4*64(%r11), %zmm20
+	vmulpd			%zmm25, %zmm20, %zmm20
+	vbroadcastsd	24+5*64(%r11), %zmm21
+	vmulpd			%zmm25, %zmm21, %zmm21
+	vbroadcastsd	24+6*64(%r11), %zmm22
+	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	24+7*64(%r11), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+//	vmovsd			%xmm17, 24+1*64(%r11)
+//	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+//	vmovsd			%xmm18, 24+2*64(%r11)
+//	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+//	vmovsd			%xmm19, 24+3*64(%r11)
+	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+	vmovsd			%xmm20, 24+4*64(%r11)
+	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+	vmovsd			%xmm21, 24+5*64(%r11)
+	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+	vmovsd			%xmm22, 24+6*64(%r11)
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+	vmovsd			%xmm23, 24+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 24, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0xf0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vbroadcastsd	24(%r12), %zmm25
+	vxorpd			%zmm31, %zmm25, %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+//	vmovapd			0*64(%r11), %zmm16
+//	vmovapd			1*64(%r11), %zmm17
+//	vmovapd			2*64(%r11), %zmm18
+	vmovapd			3*64(%r11), %zmm19
+	vmovapd			4*64(%r11), %zmm20
+	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+	vmovapd			7*64(%r11), %zmm23
+//	vaddpd			%zmm0, %zmm16, %zmm16
+//	vbroadcastsd	24+1*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm17
+//	vaddpd			%zmm0, %zmm17, %zmm17
+//	vbroadcastsd	24+2*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm18
+//	vaddpd			%zmm0, %zmm18, %zmm18
+//	vbroadcastsd	24+3*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm19
+	vaddpd			%zmm0, %zmm19, %zmm19
+	vbroadcastsd	24+4*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm20
+	vbroadcastsd	24+5*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm21
+	vbroadcastsd	24+6*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vbroadcastsd	24+7*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+//	vmovapd			%zmm16, 0*64(%r11)
+//	vmovapd			%zmm17, 1*64(%r11)
+//	vfmadd231pd		%zmm18, %zmm18, %zmm25
+//	vmovapd			%zmm18, 2*64(%r11)
+//	vfmadd231pd		%zmm19, %zmm19, %zmm26
+	vmovapd			%zmm19, 3*64(%r11)
+//	vfmadd231pd		%zmm20, %zmm20, %zmm25
+	vmovapd			%zmm20, 4*64(%r11)
+	vfmadd231pd		%zmm21, %zmm21, %zmm26
+	vmovapd			%zmm21, 5*64(%r11)
+	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm23, 7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 24, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// fifth column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 32(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+	vmovsd			32+64*4(%r11), %xmm24 // alpha
+	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
+	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC00(%rip), %zmm31 // mask
+#else
+	vbroadcastsd	LC00(%rip), %zmm31 // mask
+#endif
+	vandpd			%xmm31, %xmm24, %xmm27
+	vxorpd			%xmm31, %xmm27, %xmm27
+	vxorpd			%xmm27, %xmm25, %xmm25 // beta
+	vmovsd			%xmm25, 32+64*4(%r11) // pD[1+ps*1]
+	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
+#else
+	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
+#endif
+	vmovsd			%xmm24, %xmm27, %xmm27
+	vmovddup		%xmm24, %xmm24
+	vmovsd			%xmm25, %xmm24, %xmm24
+	vdivpd			%xmm24, %xmm27, %xmm24
+	vmovsd			%xmm24, 32(%r12) // dD[1]
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
+
+	vmovapd			4*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+//	vbroadcastsd	32+1*64(%r11), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+//	vbroadcastsd	32+2*64(%r11), %zmm18
+//	vmulpd			%zmm25, %zmm18, %zmm18
+//	vbroadcastsd	32+3*64(%r11), %zmm19
+//	vmulpd			%zmm25, %zmm19, %zmm19
+//	vbroadcastsd	32+4*64(%r11), %zmm20
+//	vmulpd			%zmm25, %zmm20, %zmm20
+	vbroadcastsd	32+5*64(%r11), %zmm21
+	vmulpd			%zmm25, %zmm21, %zmm21
+	vbroadcastsd	32+6*64(%r11), %zmm22
+	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	32+7*64(%r11), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+//	vmovsd			%xmm17, 32+1*64(%r11)
+//	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+//	vmovsd			%xmm18, 32+2*64(%r11)
+//	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+//	vmovsd			%xmm19, 32+3*64(%r11)
+//	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+//	vmovsd			%xmm20, 32+4*64(%r11)
+	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+	vmovsd			%xmm21, 32+5*64(%r11)
+	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+	vmovsd			%xmm22, 32+6*64(%r11)
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+	vmovsd			%xmm23, 32+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 32, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0xe0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vbroadcastsd	32(%r12), %zmm25
+	vxorpd			%zmm31, %zmm25, %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+//	vmovapd			0*64(%r11), %zmm16
+//	vmovapd			1*64(%r11), %zmm17
+//	vmovapd			2*64(%r11), %zmm18
+//	vmovapd			3*64(%r11), %zmm19
+	vmovapd			4*64(%r11), %zmm20
+	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+	vmovapd			7*64(%r11), %zmm23
+//	vaddpd			%zmm0, %zmm16, %zmm16
+//	vbroadcastsd	32+1*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm17
+//	vaddpd			%zmm0, %zmm17, %zmm17
+//	vbroadcastsd	32+2*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm18
+//	vaddpd			%zmm0, %zmm18, %zmm18
+//	vbroadcastsd	32+3*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm19
+//	vaddpd			%zmm0, %zmm19, %zmm19
+//	vbroadcastsd	32+4*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm20
+	vaddpd			%zmm0, %zmm20, %zmm20
+	vbroadcastsd	32+5*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm21
+	vbroadcastsd	32+6*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vbroadcastsd	32+7*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+//	vmovapd			%zmm16, 0*64(%r11)
+//	vmovapd			%zmm17, 1*64(%r11)
+//	vfmadd231pd		%zmm18, %zmm18, %zmm25
+//	vmovapd			%zmm18, 2*64(%r11)
+//	vfmadd231pd		%zmm19, %zmm19, %zmm26
+//	vmovapd			%zmm19, 3*64(%r11)
+//	vfmadd231pd		%zmm20, %zmm20, %zmm25
+	vmovapd			%zmm20, 4*64(%r11)
+//	vfmadd231pd		%zmm21, %zmm21, %zmm26
+	vmovapd			%zmm21, 5*64(%r11)
+	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm23, 7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 32, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// sixth column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 40(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+	vmovsd			40+64*5(%r11), %xmm24 // alpha
+	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
+	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC00(%rip), %zmm31 // mask
+#else
+	vbroadcastsd	LC00(%rip), %zmm31 // mask
+#endif
+	vandpd			%xmm31, %xmm24, %xmm27
+	vxorpd			%xmm31, %xmm27, %xmm27
+	vxorpd			%xmm27, %xmm25, %xmm25 // beta
+	vmovsd			%xmm25, 40+64*5(%r11) // pD[1+ps*1]
+	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
+#else
+	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
+#endif
+	vmovsd			%xmm24, %xmm27, %xmm27
+	vmovddup		%xmm24, %xmm24
+	vmovsd			%xmm25, %xmm24, %xmm24
+	vdivpd			%xmm24, %xmm27, %xmm24
+	vmovsd			%xmm24, 40(%r12) // dD[1]
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
+
+	vmovapd			5*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+//	vbroadcastsd	40+1*64(%r11), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+//	vbroadcastsd	40+2*64(%r11), %zmm18
+//	vmulpd			%zmm25, %zmm18, %zmm18
+//	vbroadcastsd	40+3*64(%r11), %zmm19
+//	vmulpd			%zmm25, %zmm19, %zmm19
+//	vbroadcastsd	40+4*64(%r11), %zmm20
+//	vmulpd			%zmm25, %zmm20, %zmm20
+//	vbroadcastsd	40+5*64(%r11), %zmm21
+//	vmulpd			%zmm25, %zmm21, %zmm21
+	vbroadcastsd	40+6*64(%r11), %zmm22
+	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	40+7*64(%r11), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+//	vmovsd			%xmm17, 40+1*64(%r11)
+//	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+//	vmovsd			%xmm18, 40+2*64(%r11)
+//	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+//	vmovsd			%xmm19, 40+3*64(%r11)
+//	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+//	vmovsd			%xmm20, 40+4*64(%r11)
+//	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+//	vmovsd			%xmm21, 40+5*64(%r11)
+	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+	vmovsd			%xmm22, 40+6*64(%r11)
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+	vmovsd			%xmm23, 40+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 40, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0xc0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vbroadcastsd	40(%r12), %zmm25
+	vxorpd			%zmm31, %zmm25, %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+//	vmovapd			0*64(%r11), %zmm16
+//	vmovapd			1*64(%r11), %zmm17
+//	vmovapd			2*64(%r11), %zmm18
+//	vmovapd			3*64(%r11), %zmm19
+//	vmovapd			4*64(%r11), %zmm20
+	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+	vmovapd			7*64(%r11), %zmm23
+//	vaddpd			%zmm0, %zmm16, %zmm16
+//	vbroadcastsd	40+1*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm17
+//	vaddpd			%zmm0, %zmm17, %zmm17
+//	vbroadcastsd	40+2*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm18
+//	vaddpd			%zmm0, %zmm18, %zmm18
+//	vbroadcastsd	40+3*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm19
+//	vaddpd			%zmm0, %zmm19, %zmm19
+//	vbroadcastsd	40+4*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm20
+//	vaddpd			%zmm0, %zmm20, %zmm20
+//	vbroadcastsd	40+5*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm21
+	vaddpd			%zmm0, %zmm21, %zmm21
+	vbroadcastsd	40+6*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vbroadcastsd	40+7*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+//	vmovapd			%zmm16, 0*64(%r11)
+//	vmovapd			%zmm17, 1*64(%r11)
+//	vfmadd231pd		%zmm18, %zmm18, %zmm25
+//	vmovapd			%zmm18, 2*64(%r11)
+//	vfmadd231pd		%zmm19, %zmm19, %zmm26
+//	vmovapd			%zmm19, 3*64(%r11)
+//	vfmadd231pd		%zmm20, %zmm20, %zmm25
+//	vmovapd			%zmm20, 4*64(%r11)
+//	vfmadd231pd		%zmm21, %zmm21, %zmm26
+	vmovapd			%zmm21, 5*64(%r11)
+//	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm23, 7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 40, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// seventh column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 48(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+	vmovsd			48+64*6(%r11), %xmm24 // alpha
+	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
+	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC00(%rip), %zmm31 // mask
+#else
+	vbroadcastsd	LC00(%rip), %zmm31 // mask
+#endif
+	vandpd			%xmm31, %xmm24, %xmm27
+	vxorpd			%xmm31, %xmm27, %xmm27
+	vxorpd			%xmm27, %xmm25, %xmm25 // beta
+	vmovsd			%xmm25, 48+64*6(%r11) // pD[1+ps*1]
+	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
+#else
+	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
+#endif
+	vmovsd			%xmm24, %xmm27, %xmm27
+	vmovddup		%xmm24, %xmm24
+	vmovsd			%xmm25, %xmm24, %xmm24
+	vdivpd			%xmm24, %xmm27, %xmm24
+	vmovsd			%xmm24, 48(%r12) // dD[1]
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
+
+	vmovapd			6*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+//	vbroadcastsd	48+1*64(%r11), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+//	vbroadcastsd	48+2*64(%r11), %zmm18
+//	vmulpd			%zmm25, %zmm18, %zmm18
+//	vbroadcastsd	48+3*64(%r11), %zmm19
+//	vmulpd			%zmm25, %zmm19, %zmm19
+//	vbroadcastsd	48+4*64(%r11), %zmm20
+//	vmulpd			%zmm25, %zmm20, %zmm20
+//	vbroadcastsd	48+5*64(%r11), %zmm21
+//	vmulpd			%zmm25, %zmm21, %zmm21
+//	vbroadcastsd	48+6*64(%r11), %zmm22
+//	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	48+7*64(%r11), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+//	vmovsd			%xmm17, 48+1*64(%r11)
+//	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+//	vmovsd			%xmm18, 48+2*64(%r11)
+//	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+//	vmovsd			%xmm19, 48+3*64(%r11)
+//	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+//	vmovsd			%xmm20, 48+4*64(%r11)
+//	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+//	vmovsd			%xmm21, 48+5*64(%r11)
+//	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+//	vmovsd			%xmm22, 48+6*64(%r11)
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+	vmovsd			%xmm23, 48+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 48, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0x80, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vbroadcastsd	48(%r12), %zmm25
+	vxorpd			%zmm31, %zmm25, %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+//	vmovapd			0*64(%r11), %zmm16
+//	vmovapd			1*64(%r11), %zmm17
+//	vmovapd			2*64(%r11), %zmm18
+//	vmovapd			3*64(%r11), %zmm19
+//	vmovapd			4*64(%r11), %zmm20
+//	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+	vmovapd			7*64(%r11), %zmm23
+//	vaddpd			%zmm0, %zmm16, %zmm16
+//	vbroadcastsd	48+1*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm17
+//	vaddpd			%zmm0, %zmm17, %zmm17
+//	vbroadcastsd	48+2*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm18
+//	vaddpd			%zmm0, %zmm18, %zmm18
+//	vbroadcastsd	48+3*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm19
+//	vaddpd			%zmm0, %zmm19, %zmm19
+//	vbroadcastsd	48+4*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm20
+//	vaddpd			%zmm0, %zmm20, %zmm20
+//	vbroadcastsd	48+5*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm21
+//	vaddpd			%zmm0, %zmm21, %zmm21
+//	vbroadcastsd	48+6*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vaddpd			%zmm0, %zmm22, %zmm22
+	vbroadcastsd	48+7*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+//	vmovapd			%zmm16, 0*64(%r11)
+//	vmovapd			%zmm17, 1*64(%r11)
+//	vfmadd231pd		%zmm18, %zmm18, %zmm25
+//	vmovapd			%zmm18, 2*64(%r11)
+//	vfmadd231pd		%zmm19, %zmm19, %zmm26
+//	vmovapd			%zmm19, 3*64(%r11)
+//	vfmadd231pd		%zmm20, %zmm20, %zmm25
+//	vmovapd			%zmm20, 4*64(%r11)
+//	vfmadd231pd		%zmm21, %zmm21, %zmm26
+//	vmovapd			%zmm21, 5*64(%r11)
+//	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+//	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm23, 7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 48, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// eigth column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 56(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+	vmovsd			56+64*7(%r11), %xmm24 // alpha
+	vfmadd231sd		%xmm24, %xmm24, %xmm25 // beta
+	vsqrtsd			%xmm25, %xmm25, %xmm25 // beta
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC00(%rip), %zmm31 // mask
+#else
+	vbroadcastsd	LC00(%rip), %zmm31 // mask
+#endif
+	vandpd			%xmm31, %xmm24, %xmm27
+	vxorpd			%xmm31, %xmm27, %xmm27
+	vxorpd			%xmm27, %xmm25, %xmm25 // beta
+	vmovsd			%xmm25, 56+64*7(%r11) // pD[1+ps*1]
+	vsubsd			%xmm24, %xmm25, %xmm24 // beta-alpha
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovddup		.LC00+1*8(%rip), %xmm27 // -1.0
+#else
+	vmovddup		LC00+1*8(%rip), %xmm27 // -1.0
+#endif
+	vmovsd			%xmm24, %xmm27, %xmm27
+	vmovddup		%xmm24, %xmm24
+	vmovsd			%xmm25, %xmm24, %xmm24
+	vdivpd			%xmm24, %xmm27, %xmm24
+	vmovsd			%xmm24, 56(%r12) // dD[1]
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
+
+	vmovapd			7*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+//	vbroadcastsd	56+1*64(%r11), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+//	vbroadcastsd	56+2*64(%r11), %zmm18
+//	vmulpd			%zmm25, %zmm18, %zmm18
+//	vbroadcastsd	56+3*64(%r11), %zmm19
+//	vmulpd			%zmm25, %zmm19, %zmm19
+//	vbroadcastsd	56+4*64(%r11), %zmm20
+//	vmulpd			%zmm25, %zmm20, %zmm20
+//	vbroadcastsd	56+5*64(%r11), %zmm21
+//	vmulpd			%zmm25, %zmm21, %zmm21
+//	vbroadcastsd	56+6*64(%r11), %zmm22
+//	vmulpd			%zmm25, %zmm22, %zmm22
+//	vbroadcastsd	56+7*64(%r11), %zmm23
+//	vmulpd			%zmm25, %zmm23, %zmm23
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+//	vmovsd			%xmm17, 56+1*64(%r11)
+//	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+//	vmovsd			%xmm18, 56+2*64(%r11)
+//	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+//	vmovsd			%xmm19, 56+3*64(%r11)
+//	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+//	vmovsd			%xmm20, 56+4*64(%r11)
+//	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+//	vmovsd			%xmm21, 56+5*64(%r11)
+//	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+//	vmovsd			%xmm22, 56+6*64(%r11)
+//	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+//	vmovsd			%xmm23, 56+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 56, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+102:
+
+	EPILOGUE
+	
+	ret
+
+	FUN_END(kernel_dgelqf_8_lib8)
+
+
+
+
+
 //                                  1      2           3           4
-// void kernel_dgelqf_dlarft8_8_lib8(int n, double *pD, double *dD, double *pT, double *beta)
+// void kernel_dgelqf_dlarft8_8_lib8(int n, double *pD, double *dD, double *pT)
 
 	.p2align 4,,15
 	GLOB_FUN_START(kernel_dgelqf_dlarft8_8_lib8)
@@ -471,9 +1660,9 @@ NAME:
 	movq	$ 0, %r14 // XXX chech for reg overwrite
 
 #if MACRO_LEVEL>=1
-	INNER_KERNEL_1_DGELQF_DLARFT8_8_LIB8
+	INNER_KERNEL_1_DGELQF_8_LIB8
 #else
-	CALL(inner_kernel_1_dgelqf_dlarft8_8_lib8)
+	CALL(inner_kernel_1_dgelqf_8_lib8)
 #endif
 
 	movl	$ 0xfe, %ebx // XXX check for not reg overwrite
@@ -528,9 +1717,9 @@ NAME:
 	movq	$ 0, %r14 // XXX chech for reg overwrite
 
 #if MACRO_LEVEL>=1
-	INNER_KERNEL_2_DGELQF_DLARFT8_8_LIB8
+	INNER_KERNEL_2_DGELQF_8_LIB8
 #else
-	CALL(inner_kernel_2_dgelqf_dlarft8_8_lib8)
+	CALL(inner_kernel_2_dgelqf_8_lib8)
 #endif
 
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -622,9 +1811,9 @@ NAME:
 	movq	$ 8, %r14 // XXX chech for reg overwrite
 
 #if MACRO_LEVEL>=1
-	INNER_KERNEL_1_DGELQF_DLARFT8_8_LIB8
+	INNER_KERNEL_1_DGELQF_8_LIB8
 #else
-	CALL(inner_kernel_1_dgelqf_dlarft8_8_lib8)
+	CALL(inner_kernel_1_dgelqf_8_lib8)
 #endif
 
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -692,9 +1881,9 @@ NAME:
 	movq	$ 8, %r14 // XXX chech for reg overwrite
 
 #if MACRO_LEVEL>=1
-	INNER_KERNEL_2_DGELQF_DLARFT8_8_LIB8
+	INNER_KERNEL_2_DGELQF_8_LIB8
 #else
-	CALL(inner_kernel_2_dgelqf_dlarft8_8_lib8)
+	CALL(inner_kernel_2_dgelqf_8_lib8)
 #endif
 
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -786,9 +1975,9 @@ NAME:
 	movq	$ 16, %r14 // XXX chech for reg overwrite
 
 #if MACRO_LEVEL>=1
-	INNER_KERNEL_1_DGELQF_DLARFT8_8_LIB8
+	INNER_KERNEL_1_DGELQF_8_LIB8
 #else
-	CALL(inner_kernel_1_dgelqf_dlarft8_8_lib8)
+	CALL(inner_kernel_1_dgelqf_8_lib8)
 #endif
 
 	movl	$ 0x01, %ebx // XXX check for not reg overwrite
@@ -863,9 +2052,9 @@ NAME:
 	movq	$ 16, %r14 // XXX chech for reg overwrite
 
 #if MACRO_LEVEL>=1
-	INNER_KERNEL_2_DGELQF_DLARFT8_8_LIB8
+	INNER_KERNEL_2_DGELQF_8_LIB8
 #else
-	CALL(inner_kernel_2_dgelqf_dlarft8_8_lib8)
+	CALL(inner_kernel_2_dgelqf_8_lib8)
 #endif
 
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -957,9 +2146,9 @@ NAME:
 	movq	$ 24, %r14 // XXX chech for reg overwrite
 
 #if MACRO_LEVEL>=1
-	INNER_KERNEL_1_DGELQF_DLARFT8_8_LIB8
+	INNER_KERNEL_1_DGELQF_8_LIB8
 #else
-	CALL(inner_kernel_1_dgelqf_dlarft8_8_lib8)
+	CALL(inner_kernel_1_dgelqf_8_lib8)
 #endif
 
 	movl	$ 0x01, %ebx // XXX check for not reg overwrite
@@ -1045,9 +2234,9 @@ NAME:
 	movq	$ 24, %r14 // XXX chech for reg overwrite
 
 #if MACRO_LEVEL>=1
-	INNER_KERNEL_2_DGELQF_DLARFT8_8_LIB8
+	INNER_KERNEL_2_DGELQF_8_LIB8
 #else
-	CALL(inner_kernel_2_dgelqf_dlarft8_8_lib8)
+	CALL(inner_kernel_2_dgelqf_8_lib8)
 #endif
 
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -1139,9 +2328,9 @@ NAME:
 	movq	$ 32, %r14 // XXX chech for reg overwrite
 
 #if MACRO_LEVEL>=1
-	INNER_KERNEL_1_DGELQF_DLARFT8_8_LIB8
+	INNER_KERNEL_1_DGELQF_8_LIB8
 #else
-	CALL(inner_kernel_1_dgelqf_dlarft8_8_lib8)
+	CALL(inner_kernel_1_dgelqf_8_lib8)
 #endif
 
 	movl	$ 0x01, %ebx // XXX check for not reg overwrite
@@ -1242,9 +2431,9 @@ NAME:
 	movq	$ 32, %r14 // XXX chech for reg overwrite
 
 #if MACRO_LEVEL>=1
-	INNER_KERNEL_2_DGELQF_DLARFT8_8_LIB8
+	INNER_KERNEL_2_DGELQF_8_LIB8
 #else
-	CALL(inner_kernel_2_dgelqf_dlarft8_8_lib8)
+	CALL(inner_kernel_2_dgelqf_8_lib8)
 #endif
 
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -1336,9 +2525,9 @@ NAME:
 	movq	$ 40, %r14 // XXX chech for reg overwrite
 
 #if MACRO_LEVEL>=1
-	INNER_KERNEL_1_DGELQF_DLARFT8_8_LIB8
+	INNER_KERNEL_1_DGELQF_8_LIB8
 #else
-	CALL(inner_kernel_1_dgelqf_dlarft8_8_lib8)
+	CALL(inner_kernel_1_dgelqf_8_lib8)
 #endif
 
 	movl	$ 0x01, %ebx // XXX check for not reg overwrite
@@ -1451,9 +2640,9 @@ NAME:
 	movq	$ 40, %r14 // XXX chech for reg overwrite
 
 #if MACRO_LEVEL>=1
-	INNER_KERNEL_2_DGELQF_DLARFT8_8_LIB8
+	INNER_KERNEL_2_DGELQF_8_LIB8
 #else
-	CALL(inner_kernel_2_dgelqf_dlarft8_8_lib8)
+	CALL(inner_kernel_2_dgelqf_8_lib8)
 #endif
 
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -1545,9 +2734,9 @@ NAME:
 	movq	$ 48, %r14 // XXX chech for reg overwrite
 
 #if MACRO_LEVEL>=1
-	INNER_KERNEL_1_DGELQF_DLARFT8_8_LIB8
+	INNER_KERNEL_1_DGELQF_8_LIB8
 #else
-	CALL(inner_kernel_1_dgelqf_dlarft8_8_lib8)
+	CALL(inner_kernel_1_dgelqf_8_lib8)
 #endif
 
 	movl	$ 0x01, %ebx // XXX check for not reg overwrite
@@ -1672,9 +2861,9 @@ NAME:
 	movq	$ 48, %r14 // XXX chech for reg overwrite
 
 #if MACRO_LEVEL>=1
-	INNER_KERNEL_2_DGELQF_DLARFT8_8_LIB8
+	INNER_KERNEL_2_DGELQF_8_LIB8
 #else
-	CALL(inner_kernel_2_dgelqf_dlarft8_8_lib8)
+	CALL(inner_kernel_2_dgelqf_8_lib8)
 #endif
 
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -1766,9 +2955,9 @@ NAME:
 	movq	$ 56, %r14 // XXX chech for reg overwrite
 
 #if MACRO_LEVEL>=1
-	INNER_KERNEL_1_DGELQF_DLARFT8_8_LIB8
+	INNER_KERNEL_1_DGELQF_8_LIB8
 #else
-	CALL(inner_kernel_1_dgelqf_dlarft8_8_lib8)
+	CALL(inner_kernel_1_dgelqf_8_lib8)
 #endif
 
 	movl	$ 0x01, %ebx // XXX check for not reg overwrite

--- a/kernel/avx512/kernel_dgelqf_lib8.S
+++ b/kernel/avx512/kernel_dgelqf_lib8.S
@@ -352,6 +352,16 @@ NAME:
 
 
 
+// input
+// r14      <- pD
+// r15      <- dD
+// zmm25    <- sigma
+//
+// output
+// zmm24[0] <- beta
+// zmm25    <- tmp
+// zmm31    <- sign mask
+//
 #if MACRO_LEVEL>=1
 	.macro INNER_EDGE_DGELQF_LIB8
 #else
@@ -383,12 +393,86 @@ NAME:
 	vdivpd			%xmm24, %xmm27, %xmm24
 	vmovsd			%xmm24, 0(%r15) // dD[0]
 
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
+
 #if MACRO_LEVEL>=1
 	.endm
 #else
 	ret
 
 	FUN_END(inner_edge_dgelqf_lib8)
+#endif
+
+
+
+
+
+// input
+// r14   <- pD
+// r15   <- dD
+// zmm25 <- sigma
+//
+// output
+// zmm24[0] <- beta
+// zmm25    <- tmp
+// zmm31    <- sign mask
+//
+#if MACRO_LEVEL>=1
+	.macro INNER_EDGE_DGELQF_PD_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vmovsd			0(%r14), %xmm24 // alpha
+	vmovapd			%xmm25, %xmm26 // beta
+	vfmadd231sd		%xmm24, %xmm24, %xmm26 // beta
+	vsqrtsd			%xmm26, %xmm26, %xmm26 // beta
+	vmovsd			%xmm26, 0(%r14) // pD[0+ps*0]
+
+	vxorpd			%xmm27, %xmm27, %xmm27
+	vucomisd		%xmm27, %xmm24
+	jbe		111f
+	// alpha>0
+	vaddsd			%xmm26, %xmm24, %xmm24 // tmp
+	vdivsd			%xmm24, %xmm25, %xmm24 // tmp
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC00(%rip), %zmm31 // mask
+#else
+	vbroadcastsd	LC00(%rip), %zmm31 // mask
+#endif
+	vxorpd			%xmm31, %xmm24, %xmm24
+	jmp		112f
+111: // alpha<=0
+	vsubsd			%xmm26, %xmm24, %xmm24 // tmp
+112:
+	vmulsd			%xmm24, %xmm24, %xmm27 // tmp*tmp
+	vaddsd			%xmm27, %xmm25, %xmm25 // sigma+tmp*tmp
+	vaddsd			%xmm27, %xmm27, %xmm27 // 2*tmp*tmp
+	vdivsd			%xmm25, %xmm27, %xmm26
+	vmovsd			%xmm26, 0(%r15) // dD[0]
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovsd			.LC00+16(%rip), %xmm27
+#else
+	vmovsd			LC00+16(%rip), %xmm27
+#endif
+	vdivsd			%xmm24, %xmm27, %xmm24 // tmp
+	vbroadcastsd	%xmm24, %zmm25
+	
+	vmovapd			%xmm26, %xmm24
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_edge_dgelqf_pd_lib8)
 #endif
 
 
@@ -437,13 +521,6 @@ NAME:
 #else
 	CALL(inner_edge_dgelqf_lib8)
 #endif
-
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+1*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+1*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
 
 	vmovapd			0*64(%r11), %zmm0
 	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
@@ -573,13 +650,6 @@ NAME:
 	CALL(inner_edge_dgelqf_lib8)
 #endif
 
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+1*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+1*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
-
 	vmovapd			1*64(%r11), %zmm0
 	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
 //	vbroadcastsd	8+1*64(%r11), %zmm17
@@ -708,13 +778,6 @@ NAME:
 #else
 	CALL(inner_edge_dgelqf_lib8)
 #endif
-
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+1*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+1*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
 
 	vmovapd			2*64(%r11), %zmm0
 	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
@@ -847,13 +910,6 @@ NAME:
 	CALL(inner_edge_dgelqf_lib8)
 #endif
 
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+1*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+1*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
-
 	vmovapd			3*64(%r11), %zmm0
 	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
 //	vbroadcastsd	24+1*64(%r11), %zmm17
@@ -985,13 +1041,6 @@ NAME:
 #else
 	CALL(inner_edge_dgelqf_lib8)
 #endif
-
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+1*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+1*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
 
 	vmovapd			4*64(%r11), %zmm0
 	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
@@ -1126,13 +1175,6 @@ NAME:
 	CALL(inner_edge_dgelqf_lib8)
 #endif
 
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+1*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+1*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
-
 	vmovapd			5*64(%r11), %zmm0
 	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
 //	vbroadcastsd	40+1*64(%r11), %zmm17
@@ -1266,13 +1308,6 @@ NAME:
 #else
 	CALL(inner_edge_dgelqf_lib8)
 #endif
-
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+1*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+1*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
 
 	vmovapd			6*64(%r11), %zmm0
 	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
@@ -1409,13 +1444,6 @@ NAME:
 	CALL(inner_edge_dgelqf_lib8)
 #endif
 
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+1*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+1*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
-
 	vmovapd			7*64(%r11), %zmm0
 	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
 //	vbroadcastsd	56+1*64(%r11), %zmm17
@@ -1531,13 +1559,6 @@ NAME:
 
 	vxorpd			%xmm31, %xmm24, %xmm27
 	vmovsd			%xmm27, 0+64*0(%r13) // pT[0+ps*0]
-
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+1*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+1*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
 
 	vmovapd			0*64(%r11), %zmm0
 	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
@@ -1669,13 +1690,6 @@ NAME:
 
 	vxorpd			%xmm31, %xmm24, %xmm27
 	vmovsd			%xmm27, 8+64*1(%r13) // pT[1+ps*1]
-
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+1*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+1*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
 
 	vmovapd			1*64(%r11), %zmm0
 	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
@@ -1820,13 +1834,6 @@ NAME:
 
 	vxorpd			%xmm31, %xmm24, %xmm27
 	vmovsd			%xmm27, 16+64*2(%r13) // pT[1+ps*1]
-
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+1*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+1*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
 
 	vmovapd			2*64(%r11), %zmm0
 	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
@@ -1978,13 +1985,6 @@ NAME:
 
 	vxorpd			%xmm31, %xmm24, %xmm27
 	vmovsd			%xmm27, 24+64*3(%r13) // pT[1+ps*1]
-
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+1*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+1*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
 
 	vmovapd			3*64(%r11), %zmm0
 	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
@@ -2147,13 +2147,6 @@ NAME:
 
 	vxorpd			%xmm31, %xmm24, %xmm27
 	vmovsd			%xmm27, 32+64*4(%r13) // pT[1+ps*1]
-
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+1*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+1*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
 
 	vmovapd			4*64(%r11), %zmm0
 	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
@@ -2331,13 +2324,6 @@ NAME:
 
 	vxorpd			%xmm31, %xmm24, %xmm27
 	vmovsd			%xmm27, 40+64*5(%r13) // pT[1+ps*1]
-
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+1*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+1*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
 
 	vmovapd			5*64(%r11), %zmm0
 	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
@@ -2527,13 +2513,6 @@ NAME:
 
 	vxorpd			%xmm31, %xmm24, %xmm27
 	vmovsd			%xmm27, 48+64*6(%r13) // pT[1+ps*1]
-
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+1*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+1*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
 
 	vmovapd			6*64(%r11), %zmm0
 	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
@@ -2736,13 +2715,6 @@ NAME:
 	vxorpd			%xmm31, %xmm24, %xmm27
 	vmovsd			%xmm27, 56+64*7(%r13) // pT[1+ps*1]
 
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+1*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+1*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm24, %zmm27, %zmm25 // tmp
-
 	vmovapd			7*64(%r11), %zmm0
 	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
 //	vbroadcastsd	56+1*64(%r11), %zmm17
@@ -2868,6 +2840,2372 @@ NAME:
 	ret
 
 	FUN_END(kernel_dgelqf_dlarft8_8_lib8)
+
+
+
+
+
+//                           1      2           3
+// void kernel_dgelqf_pd_8_lib8(int n, double *pD, double *dD)
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dgelqf_pd_8_lib8)
+	
+	PROLOGUE
+
+
+	movq	ARG2, %r11 // D
+	movq	ARG3, %r12 // dD
+
+	vxorpd			%xmm25, %xmm25, %xmm25
+	movq	ARG1, %r10 // n
+	subl	$ 1, %r10d
+	addq	$ 64, %r11
+100:
+	vmovsd			0(%r11), %xmm24
+	vfmadd231sd		%xmm24, %xmm24, %xmm25
+	subl	$ 1, %r10d
+	addq	$ 64, %r11
+	cmpl	$ 0, %r10d
+	jg		100b
+
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		101f
+	vmovsd			%xmm24, 0(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+
+	leaq	0+64*0(%r11), %r14 // XXX chech for reg overwrite
+	leaq	0(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vmovapd			0*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+	vbroadcastsd	0+1*64(%r11), %zmm17
+	vmulpd			%zmm25, %zmm17, %zmm17
+	vbroadcastsd	0+2*64(%r11), %zmm18
+	vmulpd			%zmm25, %zmm18, %zmm18
+	vbroadcastsd	0+3*64(%r11), %zmm19
+	vmulpd			%zmm25, %zmm19, %zmm19
+	vbroadcastsd	0+4*64(%r11), %zmm20
+	vmulpd			%zmm25, %zmm20, %zmm20
+	vbroadcastsd	0+5*64(%r11), %zmm21
+	vmulpd			%zmm25, %zmm21, %zmm21
+	vbroadcastsd	0+6*64(%r11), %zmm22
+	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	0+7*64(%r11), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+	vmovsd			%xmm17, 0+1*64(%r11)
+	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+	vmovsd			%xmm18, 0+2*64(%r11)
+	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+	vmovsd			%xmm19, 0+3*64(%r11)
+	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+	vmovsd			%xmm20, 0+4*64(%r11)
+	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+	vmovsd			%xmm21, 0+5*64(%r11)
+	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+	vmovsd			%xmm22, 0+6*64(%r11)
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+	vmovsd			%xmm23, 0+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 0, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0xfe, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vbroadcastsd	0(%r12), %zmm25
+	vxorpd			%zmm31, %zmm25, %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+	vmovapd			0*64(%r11), %zmm16
+	vmovapd			1*64(%r11), %zmm17
+	vmovapd			2*64(%r11), %zmm18
+	vmovapd			3*64(%r11), %zmm19
+	vmovapd			4*64(%r11), %zmm20
+	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+	vmovapd			7*64(%r11), %zmm23
+	vaddpd			%zmm0, %zmm16, %zmm16
+	vbroadcastsd	0+1*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm17
+	vbroadcastsd	0+2*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm18
+	vbroadcastsd	0+3*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm19
+	vbroadcastsd	0+4*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm20
+	vbroadcastsd	0+5*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm21
+	vbroadcastsd	0+6*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vbroadcastsd	0+7*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+	vmovapd			%zmm16, 0*64(%r11)
+	vmovapd			%zmm17, 1*64(%r11)
+	vfmadd231pd		%zmm18, %zmm18, %zmm25
+	vmovapd			%zmm18, 2*64(%r11)
+	vfmadd231pd		%zmm19, %zmm19, %zmm26
+	vmovapd			%zmm19, 3*64(%r11)
+	vfmadd231pd		%zmm20, %zmm20, %zmm25
+	vmovapd			%zmm20, 4*64(%r11)
+	vfmadd231pd		%zmm21, %zmm21, %zmm26
+	vmovapd			%zmm21, 5*64(%r11)
+	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm23, 7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 0, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// second column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 8(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+	leaq	8+64*1(%r11), %r14 // XXX chech for reg overwrite
+	leaq	8(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vmovapd			1*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+//	vbroadcastsd	8+1*64(%r11), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+	vbroadcastsd	8+2*64(%r11), %zmm18
+	vmulpd			%zmm25, %zmm18, %zmm18
+	vbroadcastsd	8+3*64(%r11), %zmm19
+	vmulpd			%zmm25, %zmm19, %zmm19
+	vbroadcastsd	8+4*64(%r11), %zmm20
+	vmulpd			%zmm25, %zmm20, %zmm20
+	vbroadcastsd	8+5*64(%r11), %zmm21
+	vmulpd			%zmm25, %zmm21, %zmm21
+	vbroadcastsd	8+6*64(%r11), %zmm22
+	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	8+7*64(%r11), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+//	vmovsd			%xmm17, 8+1*64(%r11)
+	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+	vmovsd			%xmm18, 8+2*64(%r11)
+	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+	vmovsd			%xmm19, 8+3*64(%r11)
+	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+	vmovsd			%xmm20, 8+4*64(%r11)
+	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+	vmovsd			%xmm21, 8+5*64(%r11)
+	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+	vmovsd			%xmm22, 8+6*64(%r11)
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+	vmovsd			%xmm23, 8+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 8, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0xfc, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vbroadcastsd	8(%r12), %zmm25
+	vxorpd			%zmm31, %zmm25, %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+//	vmovapd			0*64(%r11), %zmm16
+	vmovapd			1*64(%r11), %zmm17
+	vmovapd			2*64(%r11), %zmm18
+	vmovapd			3*64(%r11), %zmm19
+	vmovapd			4*64(%r11), %zmm20
+	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+	vmovapd			7*64(%r11), %zmm23
+//	vaddpd			%zmm0, %zmm16, %zmm16
+//	vbroadcastsd	8+1*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm17
+	vaddpd			%zmm0, %zmm17, %zmm17
+	vbroadcastsd	8+2*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm18
+	vbroadcastsd	8+3*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm19
+	vbroadcastsd	8+4*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm20
+	vbroadcastsd	8+5*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm21
+	vbroadcastsd	8+6*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vbroadcastsd	8+7*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+//	vmovapd			%zmm16, 0*64(%r11)
+	vmovapd			%zmm17, 1*64(%r11)
+//	vfmadd231pd		%zmm18, %zmm18, %zmm25
+	vmovapd			%zmm18, 2*64(%r11)
+	vfmadd231pd		%zmm19, %zmm19, %zmm26
+	vmovapd			%zmm19, 3*64(%r11)
+	vfmadd231pd		%zmm20, %zmm20, %zmm25
+	vmovapd			%zmm20, 4*64(%r11)
+	vfmadd231pd		%zmm21, %zmm21, %zmm26
+	vmovapd			%zmm21, 5*64(%r11)
+	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm23, 7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 8, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// third column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 16(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+	leaq	16+64*2(%r11), %r14 // XXX chech for reg overwrite
+	leaq	16(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vmovapd			2*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+//	vbroadcastsd	16+1*64(%r11), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+//	vbroadcastsd	16+2*64(%r11), %zmm18
+//	vmulpd			%zmm25, %zmm18, %zmm18
+	vbroadcastsd	16+3*64(%r11), %zmm19
+	vmulpd			%zmm25, %zmm19, %zmm19
+	vbroadcastsd	16+4*64(%r11), %zmm20
+	vmulpd			%zmm25, %zmm20, %zmm20
+	vbroadcastsd	16+5*64(%r11), %zmm21
+	vmulpd			%zmm25, %zmm21, %zmm21
+	vbroadcastsd	16+6*64(%r11), %zmm22
+	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	16+7*64(%r11), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+//	vmovsd			%xmm17, 16+1*64(%r11)
+//	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+//	vmovsd			%xmm18, 16+2*64(%r11)
+	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+	vmovsd			%xmm19, 16+3*64(%r11)
+	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+	vmovsd			%xmm20, 16+4*64(%r11)
+	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+	vmovsd			%xmm21, 16+5*64(%r11)
+	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+	vmovsd			%xmm22, 16+6*64(%r11)
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+	vmovsd			%xmm23, 16+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 16, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0xf8, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vbroadcastsd	16(%r12), %zmm25
+	vxorpd			%zmm31, %zmm25, %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+//	vmovapd			0*64(%r11), %zmm16
+//	vmovapd			1*64(%r11), %zmm17
+	vmovapd			2*64(%r11), %zmm18
+	vmovapd			3*64(%r11), %zmm19
+	vmovapd			4*64(%r11), %zmm20
+	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+	vmovapd			7*64(%r11), %zmm23
+//	vaddpd			%zmm0, %zmm16, %zmm16
+//	vbroadcastsd	16+1*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm17
+//	vaddpd			%zmm0, %zmm17, %zmm17
+//	vbroadcastsd	16+2*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm18
+	vaddpd			%zmm0, %zmm18, %zmm18
+	vbroadcastsd	16+3*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm19
+	vbroadcastsd	16+4*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm20
+	vbroadcastsd	16+5*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm21
+	vbroadcastsd	16+6*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vbroadcastsd	16+7*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+//	vmovapd			%zmm16, 0*64(%r11)
+//	vmovapd			%zmm17, 1*64(%r11)
+//	vfmadd231pd		%zmm18, %zmm18, %zmm25
+	vmovapd			%zmm18, 2*64(%r11)
+//	vfmadd231pd		%zmm19, %zmm19, %zmm26
+	vmovapd			%zmm19, 3*64(%r11)
+	vfmadd231pd		%zmm20, %zmm20, %zmm25
+	vmovapd			%zmm20, 4*64(%r11)
+	vfmadd231pd		%zmm21, %zmm21, %zmm26
+	vmovapd			%zmm21, 5*64(%r11)
+	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm23, 7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 16, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// fourth column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 24(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+
+	leaq	24+64*3(%r11), %r14 // XXX chech for reg overwrite
+	leaq	24(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vmovapd			3*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+//	vbroadcastsd	24+1*64(%r11), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+//	vbroadcastsd	24+2*64(%r11), %zmm18
+//	vmulpd			%zmm25, %zmm18, %zmm18
+//	vbroadcastsd	24+3*64(%r11), %zmm19
+//	vmulpd			%zmm25, %zmm19, %zmm19
+	vbroadcastsd	24+4*64(%r11), %zmm20
+	vmulpd			%zmm25, %zmm20, %zmm20
+	vbroadcastsd	24+5*64(%r11), %zmm21
+	vmulpd			%zmm25, %zmm21, %zmm21
+	vbroadcastsd	24+6*64(%r11), %zmm22
+	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	24+7*64(%r11), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+//	vmovsd			%xmm17, 24+1*64(%r11)
+//	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+//	vmovsd			%xmm18, 24+2*64(%r11)
+//	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+//	vmovsd			%xmm19, 24+3*64(%r11)
+	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+	vmovsd			%xmm20, 24+4*64(%r11)
+	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+	vmovsd			%xmm21, 24+5*64(%r11)
+	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+	vmovsd			%xmm22, 24+6*64(%r11)
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+	vmovsd			%xmm23, 24+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 24, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0xf0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vbroadcastsd	24(%r12), %zmm25
+	vxorpd			%zmm31, %zmm25, %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+//	vmovapd			0*64(%r11), %zmm16
+//	vmovapd			1*64(%r11), %zmm17
+//	vmovapd			2*64(%r11), %zmm18
+	vmovapd			3*64(%r11), %zmm19
+	vmovapd			4*64(%r11), %zmm20
+	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+	vmovapd			7*64(%r11), %zmm23
+//	vaddpd			%zmm0, %zmm16, %zmm16
+//	vbroadcastsd	24+1*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm17
+//	vaddpd			%zmm0, %zmm17, %zmm17
+//	vbroadcastsd	24+2*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm18
+//	vaddpd			%zmm0, %zmm18, %zmm18
+//	vbroadcastsd	24+3*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm19
+	vaddpd			%zmm0, %zmm19, %zmm19
+	vbroadcastsd	24+4*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm20
+	vbroadcastsd	24+5*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm21
+	vbroadcastsd	24+6*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vbroadcastsd	24+7*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+//	vmovapd			%zmm16, 0*64(%r11)
+//	vmovapd			%zmm17, 1*64(%r11)
+//	vfmadd231pd		%zmm18, %zmm18, %zmm25
+//	vmovapd			%zmm18, 2*64(%r11)
+//	vfmadd231pd		%zmm19, %zmm19, %zmm26
+	vmovapd			%zmm19, 3*64(%r11)
+//	vfmadd231pd		%zmm20, %zmm20, %zmm25
+	vmovapd			%zmm20, 4*64(%r11)
+	vfmadd231pd		%zmm21, %zmm21, %zmm26
+	vmovapd			%zmm21, 5*64(%r11)
+	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm23, 7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 24, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// fifth column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 32(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+
+	leaq	32+64*4(%r11), %r14 // XXX chech for reg overwrite
+	leaq	32(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vmovapd			4*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+//	vbroadcastsd	32+1*64(%r11), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+//	vbroadcastsd	32+2*64(%r11), %zmm18
+//	vmulpd			%zmm25, %zmm18, %zmm18
+//	vbroadcastsd	32+3*64(%r11), %zmm19
+//	vmulpd			%zmm25, %zmm19, %zmm19
+//	vbroadcastsd	32+4*64(%r11), %zmm20
+//	vmulpd			%zmm25, %zmm20, %zmm20
+	vbroadcastsd	32+5*64(%r11), %zmm21
+	vmulpd			%zmm25, %zmm21, %zmm21
+	vbroadcastsd	32+6*64(%r11), %zmm22
+	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	32+7*64(%r11), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+//	vmovsd			%xmm17, 32+1*64(%r11)
+//	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+//	vmovsd			%xmm18, 32+2*64(%r11)
+//	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+//	vmovsd			%xmm19, 32+3*64(%r11)
+//	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+//	vmovsd			%xmm20, 32+4*64(%r11)
+	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+	vmovsd			%xmm21, 32+5*64(%r11)
+	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+	vmovsd			%xmm22, 32+6*64(%r11)
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+	vmovsd			%xmm23, 32+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 32, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0xe0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vbroadcastsd	32(%r12), %zmm25
+	vxorpd			%zmm31, %zmm25, %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+//	vmovapd			0*64(%r11), %zmm16
+//	vmovapd			1*64(%r11), %zmm17
+//	vmovapd			2*64(%r11), %zmm18
+//	vmovapd			3*64(%r11), %zmm19
+	vmovapd			4*64(%r11), %zmm20
+	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+	vmovapd			7*64(%r11), %zmm23
+//	vaddpd			%zmm0, %zmm16, %zmm16
+//	vbroadcastsd	32+1*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm17
+//	vaddpd			%zmm0, %zmm17, %zmm17
+//	vbroadcastsd	32+2*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm18
+//	vaddpd			%zmm0, %zmm18, %zmm18
+//	vbroadcastsd	32+3*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm19
+//	vaddpd			%zmm0, %zmm19, %zmm19
+//	vbroadcastsd	32+4*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm20
+	vaddpd			%zmm0, %zmm20, %zmm20
+	vbroadcastsd	32+5*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm21
+	vbroadcastsd	32+6*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vbroadcastsd	32+7*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+//	vmovapd			%zmm16, 0*64(%r11)
+//	vmovapd			%zmm17, 1*64(%r11)
+//	vfmadd231pd		%zmm18, %zmm18, %zmm25
+//	vmovapd			%zmm18, 2*64(%r11)
+//	vfmadd231pd		%zmm19, %zmm19, %zmm26
+//	vmovapd			%zmm19, 3*64(%r11)
+//	vfmadd231pd		%zmm20, %zmm20, %zmm25
+	vmovapd			%zmm20, 4*64(%r11)
+//	vfmadd231pd		%zmm21, %zmm21, %zmm26
+	vmovapd			%zmm21, 5*64(%r11)
+	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm23, 7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 32, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// sixth column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 40(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+
+	leaq	40+64*5(%r11), %r14 // XXX chech for reg overwrite
+	leaq	40(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vmovapd			5*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+//	vbroadcastsd	40+1*64(%r11), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+//	vbroadcastsd	40+2*64(%r11), %zmm18
+//	vmulpd			%zmm25, %zmm18, %zmm18
+//	vbroadcastsd	40+3*64(%r11), %zmm19
+//	vmulpd			%zmm25, %zmm19, %zmm19
+//	vbroadcastsd	40+4*64(%r11), %zmm20
+//	vmulpd			%zmm25, %zmm20, %zmm20
+//	vbroadcastsd	40+5*64(%r11), %zmm21
+//	vmulpd			%zmm25, %zmm21, %zmm21
+	vbroadcastsd	40+6*64(%r11), %zmm22
+	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	40+7*64(%r11), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+//	vmovsd			%xmm17, 40+1*64(%r11)
+//	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+//	vmovsd			%xmm18, 40+2*64(%r11)
+//	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+//	vmovsd			%xmm19, 40+3*64(%r11)
+//	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+//	vmovsd			%xmm20, 40+4*64(%r11)
+//	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+//	vmovsd			%xmm21, 40+5*64(%r11)
+	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+	vmovsd			%xmm22, 40+6*64(%r11)
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+	vmovsd			%xmm23, 40+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 40, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0xc0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vbroadcastsd	40(%r12), %zmm25
+	vxorpd			%zmm31, %zmm25, %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+//	vmovapd			0*64(%r11), %zmm16
+//	vmovapd			1*64(%r11), %zmm17
+//	vmovapd			2*64(%r11), %zmm18
+//	vmovapd			3*64(%r11), %zmm19
+//	vmovapd			4*64(%r11), %zmm20
+	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+	vmovapd			7*64(%r11), %zmm23
+//	vaddpd			%zmm0, %zmm16, %zmm16
+//	vbroadcastsd	40+1*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm17
+//	vaddpd			%zmm0, %zmm17, %zmm17
+//	vbroadcastsd	40+2*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm18
+//	vaddpd			%zmm0, %zmm18, %zmm18
+//	vbroadcastsd	40+3*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm19
+//	vaddpd			%zmm0, %zmm19, %zmm19
+//	vbroadcastsd	40+4*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm20
+//	vaddpd			%zmm0, %zmm20, %zmm20
+//	vbroadcastsd	40+5*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm21
+	vaddpd			%zmm0, %zmm21, %zmm21
+	vbroadcastsd	40+6*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vbroadcastsd	40+7*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+//	vmovapd			%zmm16, 0*64(%r11)
+//	vmovapd			%zmm17, 1*64(%r11)
+//	vfmadd231pd		%zmm18, %zmm18, %zmm25
+//	vmovapd			%zmm18, 2*64(%r11)
+//	vfmadd231pd		%zmm19, %zmm19, %zmm26
+//	vmovapd			%zmm19, 3*64(%r11)
+//	vfmadd231pd		%zmm20, %zmm20, %zmm25
+//	vmovapd			%zmm20, 4*64(%r11)
+//	vfmadd231pd		%zmm21, %zmm21, %zmm26
+	vmovapd			%zmm21, 5*64(%r11)
+//	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm23, 7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 40, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// seventh column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 48(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+
+	leaq	48+64*6(%r11), %r14 // XXX chech for reg overwrite
+	leaq	48(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vmovapd			6*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+//	vbroadcastsd	48+1*64(%r11), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+//	vbroadcastsd	48+2*64(%r11), %zmm18
+//	vmulpd			%zmm25, %zmm18, %zmm18
+//	vbroadcastsd	48+3*64(%r11), %zmm19
+//	vmulpd			%zmm25, %zmm19, %zmm19
+//	vbroadcastsd	48+4*64(%r11), %zmm20
+//	vmulpd			%zmm25, %zmm20, %zmm20
+//	vbroadcastsd	48+5*64(%r11), %zmm21
+//	vmulpd			%zmm25, %zmm21, %zmm21
+//	vbroadcastsd	48+6*64(%r11), %zmm22
+//	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	48+7*64(%r11), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+//	vmovsd			%xmm17, 48+1*64(%r11)
+//	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+//	vmovsd			%xmm18, 48+2*64(%r11)
+//	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+//	vmovsd			%xmm19, 48+3*64(%r11)
+//	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+//	vmovsd			%xmm20, 48+4*64(%r11)
+//	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+//	vmovsd			%xmm21, 48+5*64(%r11)
+//	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+//	vmovsd			%xmm22, 48+6*64(%r11)
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+	vmovsd			%xmm23, 48+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 48, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0x80, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vbroadcastsd	48(%r12), %zmm25
+	vxorpd			%zmm31, %zmm25, %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+//	vmovapd			0*64(%r11), %zmm16
+//	vmovapd			1*64(%r11), %zmm17
+//	vmovapd			2*64(%r11), %zmm18
+//	vmovapd			3*64(%r11), %zmm19
+//	vmovapd			4*64(%r11), %zmm20
+//	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+	vmovapd			7*64(%r11), %zmm23
+//	vaddpd			%zmm0, %zmm16, %zmm16
+//	vbroadcastsd	48+1*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm17
+//	vaddpd			%zmm0, %zmm17, %zmm17
+//	vbroadcastsd	48+2*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm18
+//	vaddpd			%zmm0, %zmm18, %zmm18
+//	vbroadcastsd	48+3*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm19
+//	vaddpd			%zmm0, %zmm19, %zmm19
+//	vbroadcastsd	48+4*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm20
+//	vaddpd			%zmm0, %zmm20, %zmm20
+//	vbroadcastsd	48+5*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm21
+//	vaddpd			%zmm0, %zmm21, %zmm21
+//	vbroadcastsd	48+6*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vaddpd			%zmm0, %zmm22, %zmm22
+	vbroadcastsd	48+7*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+//	vmovapd			%zmm16, 0*64(%r11)
+//	vmovapd			%zmm17, 1*64(%r11)
+//	vfmadd231pd		%zmm18, %zmm18, %zmm25
+//	vmovapd			%zmm18, 2*64(%r11)
+//	vfmadd231pd		%zmm19, %zmm19, %zmm26
+//	vmovapd			%zmm19, 3*64(%r11)
+//	vfmadd231pd		%zmm20, %zmm20, %zmm25
+//	vmovapd			%zmm20, 4*64(%r11)
+//	vfmadd231pd		%zmm21, %zmm21, %zmm26
+//	vmovapd			%zmm21, 5*64(%r11)
+//	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+//	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm23, 7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 48, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// eigth column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 56(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+
+	leaq	56+64*7(%r11), %r14 // XXX chech for reg overwrite
+	leaq	56(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vmovapd			7*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+//	vbroadcastsd	56+1*64(%r11), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+//	vbroadcastsd	56+2*64(%r11), %zmm18
+//	vmulpd			%zmm25, %zmm18, %zmm18
+//	vbroadcastsd	56+3*64(%r11), %zmm19
+//	vmulpd			%zmm25, %zmm19, %zmm19
+//	vbroadcastsd	56+4*64(%r11), %zmm20
+//	vmulpd			%zmm25, %zmm20, %zmm20
+//	vbroadcastsd	56+5*64(%r11), %zmm21
+//	vmulpd			%zmm25, %zmm21, %zmm21
+//	vbroadcastsd	56+6*64(%r11), %zmm22
+//	vmulpd			%zmm25, %zmm22, %zmm22
+//	vbroadcastsd	56+7*64(%r11), %zmm23
+//	vmulpd			%zmm25, %zmm23, %zmm23
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+//	vmovsd			%xmm17, 56+1*64(%r11)
+//	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+//	vmovsd			%xmm18, 56+2*64(%r11)
+//	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+//	vmovsd			%xmm19, 56+3*64(%r11)
+//	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+//	vmovsd			%xmm20, 56+4*64(%r11)
+//	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+//	vmovsd			%xmm21, 56+5*64(%r11)
+//	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+//	vmovsd			%xmm22, 56+6*64(%r11)
+//	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+//	vmovsd			%xmm23, 56+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 56, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+102:
+
+	EPILOGUE
+	
+	ret
+
+	FUN_END(kernel_dgelqf_pd_8_lib8)
+
+
+
+
+
+//                                  1      2           3           4
+// void kernel_dgelqf_pd_dlarft8_8_lib8(int n, double *pD, double *dD, double *pT)
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dgelqf_pd_dlarft8_8_lib8)
+	
+	PROLOGUE
+
+	// zero T
+
+	movq	ARG4, %r10 // T
+
+	vxorpd			%zmm24, %zmm24, %zmm24
+	vmovapd			%zmm24, 0*64(%r10)
+	vmovapd			%zmm24, 1*64(%r10)
+	vmovapd			%zmm24, 2*64(%r10)
+	vmovapd			%zmm24, 3*64(%r10)
+	vmovapd			%zmm24, 4*64(%r10)
+	vmovapd			%zmm24, 5*64(%r10)
+	vmovapd			%zmm24, 6*64(%r10)
+	vmovapd			%zmm24, 7*64(%r10)
+
+	// first column
+
+	movq	ARG2, %r11 // D
+	movq	ARG3, %r12 // dD
+	movq	ARG4, %r13 // T
+
+	vxorpd			%xmm25, %xmm25, %xmm25
+	movq	ARG1, %r10 // n
+	subl	$ 1, %r10d
+	addq	$ 64, %r11
+100:
+	vmovsd			0(%r11), %xmm24
+	vfmadd231sd		%xmm24, %xmm24, %xmm25
+	subl	$ 1, %r10d
+	addq	$ 64, %r11
+	cmpl	$ 0, %r10d
+	jg		100b
+
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		101f
+	vmovsd			%xmm24, 0(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+
+	leaq	0+64*0(%r11), %r14 // XXX chech for reg overwrite
+	leaq	0(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vxorpd			%xmm31, %xmm24, %xmm27
+	vmovsd			%xmm27, 0+64*0(%r13) // pT[0+ps*0]
+
+	vmovapd			0*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+	vbroadcastsd	0+1*64(%r11), %zmm17
+	vmulpd			%zmm25, %zmm17, %zmm17
+	vbroadcastsd	0+2*64(%r11), %zmm18
+	vmulpd			%zmm25, %zmm18, %zmm18
+	vbroadcastsd	0+3*64(%r11), %zmm19
+	vmulpd			%zmm25, %zmm19, %zmm19
+	vbroadcastsd	0+4*64(%r11), %zmm20
+	vmulpd			%zmm25, %zmm20, %zmm20
+	vbroadcastsd	0+5*64(%r11), %zmm21
+	vmulpd			%zmm25, %zmm21, %zmm21
+	vbroadcastsd	0+6*64(%r11), %zmm22
+	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	0+7*64(%r11), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+	vmovsd			%xmm17, 0+1*64(%r11)
+	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+	vmovsd			%xmm18, 0+2*64(%r11)
+	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+	vmovsd			%xmm19, 0+3*64(%r11)
+	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+	vmovsd			%xmm20, 0+4*64(%r11)
+	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+	vmovsd			%xmm21, 0+5*64(%r11)
+	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+	vmovsd			%xmm22, 0+6*64(%r11)
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+	vmovsd			%xmm23, 0+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 0, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0xfe, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vbroadcastsd	0(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+	vmovapd			0*64(%r11), %zmm16
+	vmovapd			1*64(%r11), %zmm17
+	vmovapd			2*64(%r11), %zmm18
+	vmovapd			3*64(%r11), %zmm19
+	vmovapd			4*64(%r11), %zmm20
+	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+	vmovapd			7*64(%r11), %zmm23
+	vaddpd			%zmm0, %zmm16, %zmm16
+	vbroadcastsd	0+1*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm17
+	vbroadcastsd	0+2*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm18
+	vbroadcastsd	0+3*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm19
+	vbroadcastsd	0+4*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm20
+	vbroadcastsd	0+5*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm21
+	vbroadcastsd	0+6*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vbroadcastsd	0+7*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+	vmovapd			%zmm16, 0*64(%r11)
+	vmovapd			%zmm17, 1*64(%r11)
+	vfmadd231pd		%zmm18, %zmm18, %zmm25
+	vmovapd			%zmm18, 2*64(%r11)
+	vfmadd231pd		%zmm19, %zmm19, %zmm26
+	vmovapd			%zmm19, 3*64(%r11)
+	vfmadd231pd		%zmm20, %zmm20, %zmm25
+	vmovapd			%zmm20, 4*64(%r11)
+	vfmadd231pd		%zmm21, %zmm21, %zmm26
+	vmovapd			%zmm21, 5*64(%r11)
+	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm23, 7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 0, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// second column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 8(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+
+	leaq	8+64*1(%r11), %r14 // XXX chech for reg overwrite
+	leaq	8(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vxorpd			%xmm31, %xmm24, %xmm27
+	vmovsd			%xmm27, 8+64*1(%r13) // pT[1+ps*1]
+
+	vmovapd			1*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+//	vbroadcastsd	8+1*64(%r11), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+	vbroadcastsd	8+2*64(%r11), %zmm18
+	vmulpd			%zmm25, %zmm18, %zmm18
+	vbroadcastsd	8+3*64(%r11), %zmm19
+	vmulpd			%zmm25, %zmm19, %zmm19
+	vbroadcastsd	8+4*64(%r11), %zmm20
+	vmulpd			%zmm25, %zmm20, %zmm20
+	vbroadcastsd	8+5*64(%r11), %zmm21
+	vmulpd			%zmm25, %zmm21, %zmm21
+	vbroadcastsd	8+6*64(%r11), %zmm22
+	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	8+7*64(%r11), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+//	vmovsd			%xmm17, 8+1*64(%r11)
+	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+	vmovsd			%xmm18, 8+2*64(%r11)
+	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+	vmovsd			%xmm19, 8+3*64(%r11)
+	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+	vmovsd			%xmm20, 8+4*64(%r11)
+	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+	vmovsd			%xmm21, 8+5*64(%r11)
+	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+	vmovsd			%xmm22, 8+6*64(%r11)
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+	vmovsd			%xmm23, 8+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 8, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC00+16(%rip), %zmm27 // 1.0
+#else
+	vbroadcastsd	LC00+16(%rip), %zmm27 // 1.0
+#endif
+	movl	$ 0x01, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			0+64*0(%r13), %zmm27 {%k1}
+	vmulpd			%zmm27, %zmm0, %zmm0
+	vbroadcastsd	8+64*1(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0
+	vmovapd			%zmm0, 1*64(%r13) {%k1}
+
+	movl	$ 0xfc, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+//	vmovapd			0*64(%r11), %zmm16
+	vmovapd			1*64(%r11), %zmm17
+	vmovapd			2*64(%r11), %zmm18
+	vmovapd			3*64(%r11), %zmm19
+	vmovapd			4*64(%r11), %zmm20
+	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+	vmovapd			7*64(%r11), %zmm23
+//	vaddpd			%zmm0, %zmm16, %zmm16
+//	vbroadcastsd	8+1*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm17
+	vaddpd			%zmm0, %zmm17, %zmm17
+	vbroadcastsd	8+2*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm18
+	vbroadcastsd	8+3*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm19
+	vbroadcastsd	8+4*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm20
+	vbroadcastsd	8+5*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm21
+	vbroadcastsd	8+6*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vbroadcastsd	8+7*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+//	vmovapd			%zmm16, 0*64(%r11)
+	vmovapd			%zmm17, 1*64(%r11)
+//	vfmadd231pd		%zmm18, %zmm18, %zmm25
+	vmovapd			%zmm18, 2*64(%r11)
+	vfmadd231pd		%zmm19, %zmm19, %zmm26
+	vmovapd			%zmm19, 3*64(%r11)
+	vfmadd231pd		%zmm20, %zmm20, %zmm25
+	vmovapd			%zmm20, 4*64(%r11)
+	vfmadd231pd		%zmm21, %zmm21, %zmm26
+	vmovapd			%zmm21, 5*64(%r11)
+	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm23, 7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 8, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// third column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 16(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+
+	leaq	16+64*2(%r11), %r14 // XXX chech for reg overwrite
+	leaq	16(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vxorpd			%xmm31, %xmm24, %xmm27
+	vmovsd			%xmm27, 16+64*2(%r13) // pT[1+ps*1]
+
+	vmovapd			2*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+//	vbroadcastsd	16+1*64(%r11), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+//	vbroadcastsd	16+2*64(%r11), %zmm18
+//	vmulpd			%zmm25, %zmm18, %zmm18
+	vbroadcastsd	16+3*64(%r11), %zmm19
+	vmulpd			%zmm25, %zmm19, %zmm19
+	vbroadcastsd	16+4*64(%r11), %zmm20
+	vmulpd			%zmm25, %zmm20, %zmm20
+	vbroadcastsd	16+5*64(%r11), %zmm21
+	vmulpd			%zmm25, %zmm21, %zmm21
+	vbroadcastsd	16+6*64(%r11), %zmm22
+	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	16+7*64(%r11), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+//	vmovsd			%xmm17, 16+1*64(%r11)
+//	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+//	vmovsd			%xmm18, 16+2*64(%r11)
+	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+	vmovsd			%xmm19, 16+3*64(%r11)
+	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+	vmovsd			%xmm20, 16+4*64(%r11)
+	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+	vmovsd			%xmm21, 16+5*64(%r11)
+	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+	vmovsd			%xmm22, 16+6*64(%r11)
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+	vmovsd			%xmm23, 16+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 16, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0x01, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			0*64(%r13), %zmm24
+	vmulpd			%zmm24, %zmm0, %zmm1 {%k1}{z}
+	vmovapd			1*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x03, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	vmovapd			%zmm1, %zmm0 {%k1}
+	vbroadcastsd	16+2*64(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0
+	vmovapd			%zmm0, 2*64(%r13) {%k1}
+
+	movl	$ 0xf8, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+//	vmovapd			0*64(%r11), %zmm16
+//	vmovapd			1*64(%r11), %zmm17
+	vmovapd			2*64(%r11), %zmm18
+	vmovapd			3*64(%r11), %zmm19
+	vmovapd			4*64(%r11), %zmm20
+	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+	vmovapd			7*64(%r11), %zmm23
+//	vaddpd			%zmm0, %zmm16, %zmm16
+//	vbroadcastsd	16+1*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm17
+//	vaddpd			%zmm0, %zmm17, %zmm17
+//	vbroadcastsd	16+2*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm18
+	vaddpd			%zmm0, %zmm18, %zmm18
+	vbroadcastsd	16+3*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm19
+	vbroadcastsd	16+4*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm20
+	vbroadcastsd	16+5*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm21
+	vbroadcastsd	16+6*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vbroadcastsd	16+7*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+//	vmovapd			%zmm16, 0*64(%r11)
+//	vmovapd			%zmm17, 1*64(%r11)
+//	vfmadd231pd		%zmm18, %zmm18, %zmm25
+	vmovapd			%zmm18, 2*64(%r11)
+//	vfmadd231pd		%zmm19, %zmm19, %zmm26
+	vmovapd			%zmm19, 3*64(%r11)
+	vfmadd231pd		%zmm20, %zmm20, %zmm25
+	vmovapd			%zmm20, 4*64(%r11)
+	vfmadd231pd		%zmm21, %zmm21, %zmm26
+	vmovapd			%zmm21, 5*64(%r11)
+	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm23, 7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 16, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// fourth column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 24(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+
+	leaq	24+64*3(%r11), %r14 // XXX chech for reg overwrite
+	leaq	24(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vxorpd			%xmm31, %xmm24, %xmm27
+	vmovsd			%xmm27, 24+64*3(%r13) // pT[1+ps*1]
+
+	vmovapd			3*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+//	vbroadcastsd	24+1*64(%r11), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+//	vbroadcastsd	24+2*64(%r11), %zmm18
+//	vmulpd			%zmm25, %zmm18, %zmm18
+//	vbroadcastsd	24+3*64(%r11), %zmm19
+//	vmulpd			%zmm25, %zmm19, %zmm19
+	vbroadcastsd	24+4*64(%r11), %zmm20
+	vmulpd			%zmm25, %zmm20, %zmm20
+	vbroadcastsd	24+5*64(%r11), %zmm21
+	vmulpd			%zmm25, %zmm21, %zmm21
+	vbroadcastsd	24+6*64(%r11), %zmm22
+	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	24+7*64(%r11), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+//	vmovsd			%xmm17, 24+1*64(%r11)
+//	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+//	vmovsd			%xmm18, 24+2*64(%r11)
+//	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+//	vmovsd			%xmm19, 24+3*64(%r11)
+	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+	vmovsd			%xmm20, 24+4*64(%r11)
+	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+	vmovsd			%xmm21, 24+5*64(%r11)
+	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+	vmovsd			%xmm22, 24+6*64(%r11)
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+	vmovsd			%xmm23, 24+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 24, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0x01, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			0*64(%r13), %zmm24
+	vmulpd			%zmm24, %zmm0, %zmm1 {%k1}{z}
+	vmovapd			1*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x03, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	vmovapd			2*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x07, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	vmovapd			%zmm1, %zmm0 {%k1}
+	vbroadcastsd	24+3*64(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0
+	vmovapd			%zmm0, 3*64(%r13) {%k1}
+
+	movl	$ 0xf0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+//	vmovapd			0*64(%r11), %zmm16
+//	vmovapd			1*64(%r11), %zmm17
+//	vmovapd			2*64(%r11), %zmm18
+	vmovapd			3*64(%r11), %zmm19
+	vmovapd			4*64(%r11), %zmm20
+	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+	vmovapd			7*64(%r11), %zmm23
+//	vaddpd			%zmm0, %zmm16, %zmm16
+//	vbroadcastsd	24+1*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm17
+//	vaddpd			%zmm0, %zmm17, %zmm17
+//	vbroadcastsd	24+2*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm18
+//	vaddpd			%zmm0, %zmm18, %zmm18
+//	vbroadcastsd	24+3*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm19
+	vaddpd			%zmm0, %zmm19, %zmm19
+	vbroadcastsd	24+4*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm20
+	vbroadcastsd	24+5*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm21
+	vbroadcastsd	24+6*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vbroadcastsd	24+7*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+//	vmovapd			%zmm16, 0*64(%r11)
+//	vmovapd			%zmm17, 1*64(%r11)
+//	vfmadd231pd		%zmm18, %zmm18, %zmm25
+//	vmovapd			%zmm18, 2*64(%r11)
+//	vfmadd231pd		%zmm19, %zmm19, %zmm26
+	vmovapd			%zmm19, 3*64(%r11)
+//	vfmadd231pd		%zmm20, %zmm20, %zmm25
+	vmovapd			%zmm20, 4*64(%r11)
+	vfmadd231pd		%zmm21, %zmm21, %zmm26
+	vmovapd			%zmm21, 5*64(%r11)
+	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm23, 7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 24, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// fifth column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 32(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+
+	leaq	32+64*4(%r11), %r14 // XXX chech for reg overwrite
+	leaq	32(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vxorpd			%xmm31, %xmm24, %xmm27
+	vmovsd			%xmm27, 32+64*4(%r13) // pT[1+ps*1]
+
+	vmovapd			4*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+//	vbroadcastsd	32+1*64(%r11), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+//	vbroadcastsd	32+2*64(%r11), %zmm18
+//	vmulpd			%zmm25, %zmm18, %zmm18
+//	vbroadcastsd	32+3*64(%r11), %zmm19
+//	vmulpd			%zmm25, %zmm19, %zmm19
+//	vbroadcastsd	32+4*64(%r11), %zmm20
+//	vmulpd			%zmm25, %zmm20, %zmm20
+	vbroadcastsd	32+5*64(%r11), %zmm21
+	vmulpd			%zmm25, %zmm21, %zmm21
+	vbroadcastsd	32+6*64(%r11), %zmm22
+	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	32+7*64(%r11), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+//	vmovsd			%xmm17, 32+1*64(%r11)
+//	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+//	vmovsd			%xmm18, 32+2*64(%r11)
+//	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+//	vmovsd			%xmm19, 32+3*64(%r11)
+//	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+//	vmovsd			%xmm20, 32+4*64(%r11)
+	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+	vmovsd			%xmm21, 32+5*64(%r11)
+	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+	vmovsd			%xmm22, 32+6*64(%r11)
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+	vmovsd			%xmm23, 32+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 32, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0x01, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			0*64(%r13), %zmm24
+	vmulpd			%zmm24, %zmm0, %zmm1 {%k1}{z}
+	//
+	vmovapd			1*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x03, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			2*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x07, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			3*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x0f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			%zmm1, %zmm0 {%k1}
+	vbroadcastsd	32+4*64(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0
+	vmovapd			%zmm0, 4*64(%r13) {%k1}
+
+	movl	$ 0xe0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+//	vmovapd			0*64(%r11), %zmm16
+//	vmovapd			1*64(%r11), %zmm17
+//	vmovapd			2*64(%r11), %zmm18
+//	vmovapd			3*64(%r11), %zmm19
+	vmovapd			4*64(%r11), %zmm20
+	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+	vmovapd			7*64(%r11), %zmm23
+//	vaddpd			%zmm0, %zmm16, %zmm16
+//	vbroadcastsd	32+1*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm17
+//	vaddpd			%zmm0, %zmm17, %zmm17
+//	vbroadcastsd	32+2*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm18
+//	vaddpd			%zmm0, %zmm18, %zmm18
+//	vbroadcastsd	32+3*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm19
+//	vaddpd			%zmm0, %zmm19, %zmm19
+//	vbroadcastsd	32+4*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm20
+	vaddpd			%zmm0, %zmm20, %zmm20
+	vbroadcastsd	32+5*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm21
+	vbroadcastsd	32+6*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vbroadcastsd	32+7*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+//	vmovapd			%zmm16, 0*64(%r11)
+//	vmovapd			%zmm17, 1*64(%r11)
+//	vfmadd231pd		%zmm18, %zmm18, %zmm25
+//	vmovapd			%zmm18, 2*64(%r11)
+//	vfmadd231pd		%zmm19, %zmm19, %zmm26
+//	vmovapd			%zmm19, 3*64(%r11)
+//	vfmadd231pd		%zmm20, %zmm20, %zmm25
+	vmovapd			%zmm20, 4*64(%r11)
+//	vfmadd231pd		%zmm21, %zmm21, %zmm26
+	vmovapd			%zmm21, 5*64(%r11)
+	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm23, 7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 32, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// sixth column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 40(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+
+	leaq	40+64*5(%r11), %r14 // XXX chech for reg overwrite
+	leaq	40(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vxorpd			%xmm31, %xmm24, %xmm27
+	vmovsd			%xmm27, 40+64*5(%r13) // pT[1+ps*1]
+
+	vmovapd			5*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+//	vbroadcastsd	40+1*64(%r11), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+//	vbroadcastsd	40+2*64(%r11), %zmm18
+//	vmulpd			%zmm25, %zmm18, %zmm18
+//	vbroadcastsd	40+3*64(%r11), %zmm19
+//	vmulpd			%zmm25, %zmm19, %zmm19
+//	vbroadcastsd	40+4*64(%r11), %zmm20
+//	vmulpd			%zmm25, %zmm20, %zmm20
+//	vbroadcastsd	40+5*64(%r11), %zmm21
+//	vmulpd			%zmm25, %zmm21, %zmm21
+	vbroadcastsd	40+6*64(%r11), %zmm22
+	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	40+7*64(%r11), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+//	vmovsd			%xmm17, 40+1*64(%r11)
+//	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+//	vmovsd			%xmm18, 40+2*64(%r11)
+//	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+//	vmovsd			%xmm19, 40+3*64(%r11)
+//	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+//	vmovsd			%xmm20, 40+4*64(%r11)
+//	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+//	vmovsd			%xmm21, 40+5*64(%r11)
+	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+	vmovsd			%xmm22, 40+6*64(%r11)
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+	vmovsd			%xmm23, 40+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 40, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0x01, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			0*64(%r13), %zmm24
+	vmulpd			%zmm24, %zmm0, %zmm1 {%k1}{z}
+	//
+	vmovapd			1*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x03, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			2*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x07, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			3*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x0f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			4*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x1f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			%zmm1, %zmm0 {%k1}
+	vbroadcastsd	40+5*64(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0
+	vmovapd			%zmm0, 5*64(%r13) {%k1}
+
+	movl	$ 0xc0, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+//	vmovapd			0*64(%r11), %zmm16
+//	vmovapd			1*64(%r11), %zmm17
+//	vmovapd			2*64(%r11), %zmm18
+//	vmovapd			3*64(%r11), %zmm19
+//	vmovapd			4*64(%r11), %zmm20
+	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+	vmovapd			7*64(%r11), %zmm23
+//	vaddpd			%zmm0, %zmm16, %zmm16
+//	vbroadcastsd	40+1*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm17
+//	vaddpd			%zmm0, %zmm17, %zmm17
+//	vbroadcastsd	40+2*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm18
+//	vaddpd			%zmm0, %zmm18, %zmm18
+//	vbroadcastsd	40+3*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm19
+//	vaddpd			%zmm0, %zmm19, %zmm19
+//	vbroadcastsd	40+4*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm20
+//	vaddpd			%zmm0, %zmm20, %zmm20
+//	vbroadcastsd	40+5*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm21
+	vaddpd			%zmm0, %zmm21, %zmm21
+	vbroadcastsd	40+6*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vbroadcastsd	40+7*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+//	vmovapd			%zmm16, 0*64(%r11)
+//	vmovapd			%zmm17, 1*64(%r11)
+//	vfmadd231pd		%zmm18, %zmm18, %zmm25
+//	vmovapd			%zmm18, 2*64(%r11)
+//	vfmadd231pd		%zmm19, %zmm19, %zmm26
+//	vmovapd			%zmm19, 3*64(%r11)
+//	vfmadd231pd		%zmm20, %zmm20, %zmm25
+//	vmovapd			%zmm20, 4*64(%r11)
+//	vfmadd231pd		%zmm21, %zmm21, %zmm26
+	vmovapd			%zmm21, 5*64(%r11)
+//	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm23, 7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 40, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// seventh column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 48(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+
+	leaq	48+64*6(%r11), %r14 // XXX chech for reg overwrite
+	leaq	48(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vxorpd			%xmm31, %xmm24, %xmm27
+	vmovsd			%xmm27, 48+64*6(%r13) // pT[1+ps*1]
+
+	vmovapd			6*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+//	vbroadcastsd	48+1*64(%r11), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+//	vbroadcastsd	48+2*64(%r11), %zmm18
+//	vmulpd			%zmm25, %zmm18, %zmm18
+//	vbroadcastsd	48+3*64(%r11), %zmm19
+//	vmulpd			%zmm25, %zmm19, %zmm19
+//	vbroadcastsd	48+4*64(%r11), %zmm20
+//	vmulpd			%zmm25, %zmm20, %zmm20
+//	vbroadcastsd	48+5*64(%r11), %zmm21
+//	vmulpd			%zmm25, %zmm21, %zmm21
+//	vbroadcastsd	48+6*64(%r11), %zmm22
+//	vmulpd			%zmm25, %zmm22, %zmm22
+	vbroadcastsd	48+7*64(%r11), %zmm23
+	vmulpd			%zmm25, %zmm23, %zmm23
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+//	vmovsd			%xmm17, 48+1*64(%r11)
+//	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+//	vmovsd			%xmm18, 48+2*64(%r11)
+//	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+//	vmovsd			%xmm19, 48+3*64(%r11)
+//	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+//	vmovsd			%xmm20, 48+4*64(%r11)
+//	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+//	vmovsd			%xmm21, 48+5*64(%r11)
+//	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+//	vmovsd			%xmm22, 48+6*64(%r11)
+	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+	vmovsd			%xmm23, 48+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 48, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0x01, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			0*64(%r13), %zmm24
+	vmulpd			%zmm24, %zmm0, %zmm1 {%k1}{z}
+	//
+	vmovapd			1*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x03, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			2*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x07, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			3*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x0f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			4*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x1f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			5*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x3f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			%zmm1, %zmm0 {%k1}
+	vbroadcastsd	48+6*64(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0
+	vmovapd			%zmm0, 6*64(%r13) {%k1}
+
+	movl	$ 0x80, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			%zmm0, %zmm0 {%k1}{z}
+
+	movq	ARG2, %r11 // D
+//	vmovapd			0*64(%r11), %zmm16
+//	vmovapd			1*64(%r11), %zmm17
+//	vmovapd			2*64(%r11), %zmm18
+//	vmovapd			3*64(%r11), %zmm19
+//	vmovapd			4*64(%r11), %zmm20
+//	vmovapd			5*64(%r11), %zmm21
+	vmovapd			6*64(%r11), %zmm22
+	vmovapd			7*64(%r11), %zmm23
+//	vaddpd			%zmm0, %zmm16, %zmm16
+//	vbroadcastsd	48+1*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm17
+//	vaddpd			%zmm0, %zmm17, %zmm17
+//	vbroadcastsd	48+2*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm18
+//	vaddpd			%zmm0, %zmm18, %zmm18
+//	vbroadcastsd	48+3*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm19
+//	vaddpd			%zmm0, %zmm19, %zmm19
+//	vbroadcastsd	48+4*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm20
+//	vaddpd			%zmm0, %zmm20, %zmm20
+//	vbroadcastsd	48+5*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm21
+//	vaddpd			%zmm0, %zmm21, %zmm21
+//	vbroadcastsd	48+6*64(%r11), %zmm24
+//	vfmadd231pd		%zmm0, %zmm24, %zmm22
+	vaddpd			%zmm0, %zmm22, %zmm22
+	vbroadcastsd	48+7*64(%r11), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm23
+	vxorpd			%zmm25, %zmm25, %zmm25
+	vxorpd			%zmm26, %zmm26, %zmm26 // part acc
+//	vmovapd			%zmm16, 0*64(%r11)
+//	vmovapd			%zmm17, 1*64(%r11)
+//	vfmadd231pd		%zmm18, %zmm18, %zmm25
+//	vmovapd			%zmm18, 2*64(%r11)
+//	vfmadd231pd		%zmm19, %zmm19, %zmm26
+//	vmovapd			%zmm19, 3*64(%r11)
+//	vfmadd231pd		%zmm20, %zmm20, %zmm25
+//	vmovapd			%zmm20, 4*64(%r11)
+//	vfmadd231pd		%zmm21, %zmm21, %zmm26
+//	vmovapd			%zmm21, 5*64(%r11)
+//	vfmadd231pd		%zmm22, %zmm22, %zmm25
+	vmovapd			%zmm22, 6*64(%r11)
+//	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm23, 7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 48, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_2_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_2_dgelqf_8_lib8)
+#endif
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd	%zmm25, %zmm27, %zmm25  // beta
+
+
+	// eigth column
+102:
+	vxorpd			%xmm24, %xmm24, %xmm24
+	vucomisd		%xmm24, %xmm25
+	jne		101f
+//	jp		111f
+	vmovsd			%xmm24, 56(%r12)
+	jmp		102f
+
+101:
+	movq	ARG2, %r11 // D
+
+	leaq	56+64*7(%r11), %r14 // XXX chech for reg overwrite
+	leaq	56(%r12), %r15 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DGELQF_PD_LIB8
+#else
+	CALL(inner_edge_dgelqf_pd_lib8)
+#endif
+
+	vxorpd			%xmm31, %xmm24, %xmm27
+	vmovsd			%xmm27, 56+64*7(%r13) // pT[1+ps*1]
+
+	vmovapd			7*64(%r11), %zmm0
+	vxorpd			%zmm1, %zmm1, %zmm1 // part acc
+//	vbroadcastsd	56+1*64(%r11), %zmm17
+//	vmulpd			%zmm25, %zmm17, %zmm17
+//	vbroadcastsd	56+2*64(%r11), %zmm18
+//	vmulpd			%zmm25, %zmm18, %zmm18
+//	vbroadcastsd	56+3*64(%r11), %zmm19
+//	vmulpd			%zmm25, %zmm19, %zmm19
+//	vbroadcastsd	56+4*64(%r11), %zmm20
+//	vmulpd			%zmm25, %zmm20, %zmm20
+//	vbroadcastsd	56+5*64(%r11), %zmm21
+//	vmulpd			%zmm25, %zmm21, %zmm21
+//	vbroadcastsd	56+6*64(%r11), %zmm22
+//	vmulpd			%zmm25, %zmm22, %zmm22
+//	vbroadcastsd	56+7*64(%r11), %zmm23
+//	vmulpd			%zmm25, %zmm23, %zmm23
+//	vfmadd231pd		1*64(%r11), %zmm17, %zmm0
+//	vmovsd			%xmm17, 56+1*64(%r11)
+//	vfmadd231pd		2*64(%r11), %zmm18, %zmm1
+//	vmovsd			%xmm18, 56+2*64(%r11)
+//	vfmadd231pd		3*64(%r11), %zmm19, %zmm0
+//	vmovsd			%xmm19, 56+3*64(%r11)
+//	vfmadd231pd		4*64(%r11), %zmm20, %zmm1
+//	vmovsd			%xmm20, 56+4*64(%r11)
+//	vfmadd231pd		5*64(%r11), %zmm21, %zmm0
+//	vmovsd			%xmm21, 56+5*64(%r11)
+//	vfmadd231pd		6*64(%r11), %zmm22, %zmm1
+//	vmovsd			%xmm22, 56+6*64(%r11)
+//	vfmadd231pd		7*64(%r11), %zmm23, %zmm0
+//	vmovsd			%xmm23, 56+7*64(%r11)
+	movq	ARG1, %r10 // n
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+
+	movq	$ 56, %r14 // XXX chech for reg overwrite
+
+#if MACRO_LEVEL>=1
+	INNER_KERNEL_1_DGELQF_8_LIB8
+#else
+	CALL(inner_kernel_1_dgelqf_8_lib8)
+#endif
+
+	movl	$ 0x01, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vmovapd			0*64(%r13), %zmm24
+	vmulpd			%zmm24, %zmm0, %zmm1 {%k1}{z}
+	//
+	vmovapd			1*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x03, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			2*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x07, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			3*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x0f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			4*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x1f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			5*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x3f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			6*64(%r13), %zmm24
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	movl	$ 0x7f, %ebx // XXX check for not reg overwrite
+	kmovd	%ebx, %k1 // XXX check for not reg overwrite
+	vfmadd231pd		%zmm24, %zmm26, %zmm1 {%k1}
+	//
+	vmovapd			%zmm1, %zmm0 {%k1}
+	vbroadcastsd	56+7*64(%r13), %zmm25
+	vmulpd			%zmm25, %zmm0, %zmm0
+	vmovapd			%zmm0, 7*64(%r13) {%k1}
+
+102:
+
+	EPILOGUE
+	
+	ret
+
+	FUN_END(kernel_dgelqf_pd_dlarft8_8_lib8)
 
 
 

--- a/kernel/avx512/kernel_dgemm_16x8_lib.S
+++ b/kernel/avx512/kernel_dgemm_16x8_lib.S
@@ -3244,6 +3244,7 @@
 // r12   <- sda
 // r13   <- B
 // r14   <- ldb
+// k1    <- m_mask
 // zmm0  <- []
 // ...
 // zmm15 <- []
@@ -7238,14 +7239,14 @@
 
 	// prefetch D
 
-//	movq	ARG10, %r10 // D
-//	movq	ARG11, %r11 // ldd
-//	sall	$ 3, %r11d
+	movq	ARG10, %r10 // D
+	movq	ARG11, %r11 // ldd
+	sall	$ 3, %r11d
 
 #if MACRO_LEVEL>=1
-//	INNER_PREFETCH0_8X4_LIB
+	INNER_PREFETCH0_16X8_LIB
 #else
-//	CALL(inner_prefetch0_8x4_lib)
+	CALL(inner_prefetch0_16x8_lib)
 #endif
 
 
@@ -7413,14 +7414,14 @@
 
 	// prefetch D
 
-//	movq	ARG10, %r10 // D
-//	movq	ARG11, %r11 // ldd
-//	sall	$ 3, %r11d
+	movq	ARG10, %r10 // D
+	movq	ARG11, %r11 // ldd
+	sall	$ 3, %r11d
 
 #if MACRO_LEVEL>=1
-//	INNER_PREFETCH0_8X4_LIB
+	INNER_PREFETCH0_8X16_LIB
 #else
-//	CALL(inner_prefetch0_8x4_lib)
+	CALL(inner_prefetch0_8x16_lib)
 #endif
 
 

--- a/kernel/avx512/kernel_dgemm_16x8_lib.S
+++ b/kernel/avx512/kernel_dgemm_16x8_lib.S
@@ -6556,6 +6556,63 @@
 
 
 
+// common inner routine with file scope
+//
+// prefetch
+//
+// input arguments:
+// r10  <- D
+// r11  <- ldd
+//
+// output arguments:
+
+#if MACRO_LEVEL>=1
+	.macro INNER_PREFETCH0_16X8_LIB
+#else
+	.p2align 4,,15
+	FUN_START(inner_prefetch0_16x8_lib)
+#endif
+
+	leaq		0(%r11, %r11, 2), %r12
+	leaq		0(%r10, %r11, 4), %r13
+
+	prefetcht0	0(%r10)
+	prefetcht0	64(%r10)
+	prefetcht0	127(%r10)
+	prefetcht0	0(%r10, %r11)
+	prefetcht0	64(%r10, %r11)
+	prefetcht0	127(%r10, %r11)
+	prefetcht0	0(%r10, %r11, 2)
+	prefetcht0	64(%r10, %r11, 2)
+	prefetcht0	127(%r10, %r11, 2)
+	prefetcht0	0(%r10, %r12)
+	prefetcht0	64(%r10, %r12)
+	prefetcht0	127(%r10, %r12)
+	prefetcht0	0(%r13)
+	prefetcht0	64(%r13)
+	prefetcht0	127(%r13)
+	prefetcht0	0(%r13, %r11)
+	prefetcht0	64(%r13, %r11)
+	prefetcht0	127(%r13, %r11)
+	prefetcht0	0(%r13, %r11, 2)
+	prefetcht0	64(%r13, %r11, 2)
+	prefetcht0	127(%r13, %r11, 2)
+	prefetcht0	0(%r13, %r12)
+	prefetcht0	64(%r13, %r12)
+	prefetcht0	127(%r13, %r12)
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_prefetch0_16x8_lib)
+#endif
+
+
+
+
+
 //                                 1      2              3          4        5          6             7          8        9          10
 // void kernel_dgemm_nt_16x8_lib88cc(int k, double *alpha, double *A, int sda, double *B, double *beta, double *C, int ldc, double *D, int ldd);
 
@@ -6571,23 +6628,23 @@
 
 	// prefetch C
 
-//	movq		ARG6, %r10 // beta
-//	vmovsd		0(%r10), %xmm14
-//	vxorpd		%xmm15, %xmm15, %xmm15 // 0.0
-//	vucomisd	%xmm15, %xmm14 // beta==0.0 ?
-//	je			100f // end
+	movq		ARG6, %r10 // beta
+	vmovsd		0(%r10), %xmm14
+	vxorpd		%xmm15, %xmm15, %xmm15 // 0.0
+	vucomisd	%xmm15, %xmm14 // beta==0.0 ?
+	je			100f // end
 
-//	movq	ARG7, %r10 // C
-//	movq	ARG8, %r11 // ldc
-//	sall	$ 3, %r11d
+	movq	ARG7, %r10 // C
+	movq	ARG8, %r11 // ldc
+	sall	$ 3, %r11d
 
 #if MACRO_LEVEL>=1
-//	INNER_PREFETCH0_8X4_LIB
+	INNER_PREFETCH0_16X8_LIB
 #else
-//	CALL(inner_prefetch0_8x4_lib)
+	CALL(inner_prefetch0_16x8_lib)
 #endif
 
-//100:
+100:
 
 
 	// call inner dgemm kernel nn

--- a/kernel/avx512/kernel_dgemm_16x8_lib.S
+++ b/kernel/avx512/kernel_dgemm_16x8_lib.S
@@ -389,6 +389,7 @@
 // r12   <- sda
 // r13   <- B
 // r14   <- ldb
+// k1    <- m_mask
 // zmm0  <- []
 // ...
 // zmm15 <- []
@@ -396,10 +397,10 @@
 // output arguments:
 
 #if MACRO_LEVEL>=2
-	.macro INNER_KERNEL_DGEMM_NT_16X7_LIB8C
+	.macro INNER_KERNEL_DGEMM_NT_2VX8_LIB8C
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_dgemm_nt_16x7_lib8c)
+	FUN_START(inner_kernel_dgemm_nt_2vx8_lib8c)
 #endif
 
 	cmpl	$ 0, %r10d
@@ -418,7 +419,7 @@
 	// unroll 0
 //	prefetcht0		0(%r13, %r14, 8)
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -440,15 +441,15 @@
 	vbroadcastsd	48(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm6
 	vfmadd231pd		%zmm26, %zmm24, %zmm14
-//	vbroadcastsd	56(%r13), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm7
-//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
 	addq	%r14, %r13
 
 	// unroll 1
 //	prefetcht0		0(%r13, %r14, 8)
 	vmovapd			1*64(%r11), %zmm25 // A
-	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -470,15 +471,15 @@
 	vbroadcastsd	48(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm6
 	vfmadd231pd		%zmm26, %zmm24, %zmm14
-//	vbroadcastsd	56(%r13), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm7
-//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
 	addq	%r14, %r13
 
 	// unroll 2
 //	prefetcht0		0(%r13, %r14, 8)
 	vmovapd			2*64(%r11), %zmm25 // A
-	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -500,15 +501,15 @@
 	vbroadcastsd	48(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm6
 	vfmadd231pd		%zmm26, %zmm24, %zmm14
-//	vbroadcastsd	56(%r13), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm7
-//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
 	addq	%r14, %r13
 
 	// unroll 3
 //	prefetcht0		0(%r13, %r14, 8)
 	vmovapd			3*64(%r11), %zmm25 // A
-	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -530,9 +531,9 @@
 	vbroadcastsd	48(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm6
 	vfmadd231pd		%zmm26, %zmm24, %zmm14
-//	vbroadcastsd	56(%r13), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm7
-//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
 	addq	%r14, %r13
 
 	subl	$ 4, %r10d
@@ -549,7 +550,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -571,14 +572,14 @@
 	vbroadcastsd	48(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm6
 	vfmadd231pd		%zmm26, %zmm24, %zmm14
-//	vbroadcastsd	56(%r13), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm7
-//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
 	addq	%r14, %r13
 
 	// unroll 1
 	vmovapd			1*64(%r11), %zmm25 // A
-	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -600,14 +601,14 @@
 	vbroadcastsd	48(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm6
 	vfmadd231pd		%zmm26, %zmm24, %zmm14
-//	vbroadcastsd	56(%r13), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm7
-//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
 	addq	%r14, %r13
 
 	// unroll 2
 	vmovapd			2*64(%r11), %zmm25 // A
-	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -629,14 +630,14 @@
 	vbroadcastsd	48(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm6
 	vfmadd231pd		%zmm26, %zmm24, %zmm14
-//	vbroadcastsd	56(%r13), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm7
-//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
 	addq	%r14, %r13
 
 	// unroll 3
 	vmovapd			3*64(%r11), %zmm25 // A
-	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -658,9 +659,9 @@
 	vbroadcastsd	48(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm6
 	vfmadd231pd		%zmm26, %zmm24, %zmm14
-//	vbroadcastsd	56(%r13), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm7
-//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
 	addq	%r14, %r13
 
 	subl	$ 4, %r10d
@@ -679,7 +680,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -701,9 +702,9 @@
 	vbroadcastsd	48(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm6
 	vfmadd231pd		%zmm26, %zmm24, %zmm14
-//	vbroadcastsd	56(%r13), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm7
-//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
 	addq	%r14, %r13
 
 	subl	$ 1, %r10d
@@ -720,7 +721,7 @@
 #else
 	ret
 
-	FUN_END(inner_kernel_dgemm_nt_16x7_lib8c)
+	FUN_END(inner_kernel_dgemm_nt_2vx8_lib8c)
 #endif
 
 
@@ -742,10 +743,10 @@
 // output arguments:
 
 #if MACRO_LEVEL>=2
-	.macro INNER_KERNEL_DGEMM_NT_16X6_LIB8C
+	.macro INNER_KERNEL_DGEMM_NT_2VX7_LIB8C
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_dgemm_nt_16x6_lib8c)
+	FUN_START(inner_kernel_dgemm_nt_2vx7_lib8c)
 #endif
 
 	cmpl	$ 0, %r10d
@@ -764,7 +765,7 @@
 	// unroll 0
 //	prefetcht0		0(%r13, %r14, 8)
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -783,9 +784,9 @@
 	vbroadcastsd	40(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm5
 	vfmadd231pd		%zmm26, %zmm24, %zmm13
-//	vbroadcastsd	48(%r13), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm6
-//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
 //	vbroadcastsd	56(%r13), %zmm24 // B
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 //	vfmadd231pd		%zmm26, %zmm24, %zmm15
@@ -794,7 +795,7 @@
 	// unroll 1
 //	prefetcht0		0(%r13, %r14, 8)
 	vmovapd			1*64(%r11), %zmm25 // A
-	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -813,9 +814,9 @@
 	vbroadcastsd	40(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm5
 	vfmadd231pd		%zmm26, %zmm24, %zmm13
-//	vbroadcastsd	48(%r13), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm6
-//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
 //	vbroadcastsd	56(%r13), %zmm24 // B
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 //	vfmadd231pd		%zmm26, %zmm24, %zmm15
@@ -824,7 +825,7 @@
 	// unroll 2
 //	prefetcht0		0(%r13, %r14, 8)
 	vmovapd			2*64(%r11), %zmm25 // A
-	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -843,9 +844,9 @@
 	vbroadcastsd	40(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm5
 	vfmadd231pd		%zmm26, %zmm24, %zmm13
-//	vbroadcastsd	48(%r13), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm6
-//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
 //	vbroadcastsd	56(%r13), %zmm24 // B
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 //	vfmadd231pd		%zmm26, %zmm24, %zmm15
@@ -854,7 +855,7 @@
 	// unroll 3
 //	prefetcht0		0(%r13, %r14, 8)
 	vmovapd			3*64(%r11), %zmm25 // A
-	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -873,9 +874,9 @@
 	vbroadcastsd	40(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm5
 	vfmadd231pd		%zmm26, %zmm24, %zmm13
-//	vbroadcastsd	48(%r13), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm6
-//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
 //	vbroadcastsd	56(%r13), %zmm24 // B
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 //	vfmadd231pd		%zmm26, %zmm24, %zmm15
@@ -895,7 +896,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -914,9 +915,9 @@
 	vbroadcastsd	40(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm5
 	vfmadd231pd		%zmm26, %zmm24, %zmm13
-//	vbroadcastsd	48(%r13), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm6
-//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
 //	vbroadcastsd	56(%r13), %zmm24 // B
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 //	vfmadd231pd		%zmm26, %zmm24, %zmm15
@@ -924,7 +925,7 @@
 
 	// unroll 1
 	vmovapd			1*64(%r11), %zmm25 // A
-	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -943,9 +944,9 @@
 	vbroadcastsd	40(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm5
 	vfmadd231pd		%zmm26, %zmm24, %zmm13
-//	vbroadcastsd	48(%r13), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm6
-//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
 //	vbroadcastsd	56(%r13), %zmm24 // B
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 //	vfmadd231pd		%zmm26, %zmm24, %zmm15
@@ -953,7 +954,7 @@
 
 	// unroll 2
 	vmovapd			2*64(%r11), %zmm25 // A
-	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -972,9 +973,9 @@
 	vbroadcastsd	40(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm5
 	vfmadd231pd		%zmm26, %zmm24, %zmm13
-//	vbroadcastsd	48(%r13), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm6
-//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
 //	vbroadcastsd	56(%r13), %zmm24 // B
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 //	vfmadd231pd		%zmm26, %zmm24, %zmm15
@@ -982,7 +983,7 @@
 
 	// unroll 3
 	vmovapd			3*64(%r11), %zmm25 // A
-	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1001,9 +1002,9 @@
 	vbroadcastsd	40(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm5
 	vfmadd231pd		%zmm26, %zmm24, %zmm13
-//	vbroadcastsd	48(%r13), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm6
-//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
 //	vbroadcastsd	56(%r13), %zmm24 // B
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 //	vfmadd231pd		%zmm26, %zmm24, %zmm15
@@ -1025,7 +1026,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1044,9 +1045,9 @@
 	vbroadcastsd	40(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm5
 	vfmadd231pd		%zmm26, %zmm24, %zmm13
-//	vbroadcastsd	48(%r13), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm6
-//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
 //	vbroadcastsd	56(%r13), %zmm24 // B
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 //	vfmadd231pd		%zmm26, %zmm24, %zmm15
@@ -1066,7 +1067,7 @@
 #else
 	ret
 
-	FUN_END(inner_kernel_dgemm_nt_16x6_lib8c)
+	FUN_END(inner_kernel_dgemm_nt_2vx7_lib8c)
 #endif
 
 
@@ -1088,10 +1089,10 @@
 // output arguments:
 
 #if MACRO_LEVEL>=2
-	.macro INNER_KERNEL_DGEMM_NT_16X5_LIB8C
+	.macro INNER_KERNEL_DGEMM_NT_2VX6_LIB8C
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_dgemm_nt_16x5_lib8c)
+	FUN_START(inner_kernel_dgemm_nt_2vx6_lib8c)
 #endif
 
 	cmpl	$ 0, %r10d
@@ -1110,7 +1111,353 @@
 	// unroll 0
 //	prefetcht0		0(%r13, %r14, 8)
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	addq	%r14, %r13
+
+	// unroll 1
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	addq	%r14, %r13
+
+	// unroll 2
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	addq	%r14, %r13
+
+	// unroll 3
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	addq	%r14, %r13
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean4-up
+
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	addq	%r14, %r13
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	addq	%r14, %r13
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	addq	%r14, %r13
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	addq	%r14, %r13
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	addq	%r14, %r13
+
+	subl	$ 1, %r10d
+	addq	$ 1*64, %r11
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_2vx6_lib8c)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- sda
+// r13   <- B
+// r14   <- ldb
+// zmm0  <- []
+// ...
+// zmm15 <- []
+//
+// output arguments:
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_2VX5_LIB8C
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_2vx5_lib8c)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// preload
+
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1140,7 +1487,7 @@
 	// unroll 1
 //	prefetcht0		0(%r13, %r14, 8)
 	vmovapd			1*64(%r11), %zmm25 // A
-	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1170,7 +1517,7 @@
 	// unroll 2
 //	prefetcht0		0(%r13, %r14, 8)
 	vmovapd			2*64(%r11), %zmm25 // A
-	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1200,7 +1547,7 @@
 	// unroll 3
 //	prefetcht0		0(%r13, %r14, 8)
 	vmovapd			3*64(%r11), %zmm25 // A
-	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1241,7 +1588,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1270,7 +1617,7 @@
 
 	// unroll 1
 	vmovapd			1*64(%r11), %zmm25 // A
-	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1299,7 +1646,7 @@
 
 	// unroll 2
 	vmovapd			2*64(%r11), %zmm25 // A
-	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1328,7 +1675,7 @@
 
 	// unroll 3
 	vmovapd			3*64(%r11), %zmm25 // A
-	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1371,7 +1718,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1412,7 +1759,7 @@
 #else
 	ret
 
-	FUN_END(inner_kernel_dgemm_nt_16x5_lib8c)
+	FUN_END(inner_kernel_dgemm_nt_2vx5_lib8c)
 #endif
 
 
@@ -1435,10 +1782,10 @@
 // output arguments:
 
 #if MACRO_LEVEL>=2
-	.macro INNER_KERNEL_DGEMM_NT_16X4_LIB8C
+	.macro INNER_KERNEL_DGEMM_NT_2VX4_LIB8C
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_dgemm_nt_16x4_lib8c)
+	FUN_START(inner_kernel_dgemm_nt_2vx4_lib8c)
 #endif
 
 	cmpl	$ 0, %r10d
@@ -1457,7 +1804,7 @@
 	// unroll 0
 //	prefetcht0		0(%r13, %r14, 8)
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1475,7 +1822,7 @@
 	// unroll 1
 //	prefetcht0		0(%r13, %r14, 8)
 	vmovapd			1*64(%r11), %zmm25 // A
-	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1493,7 +1840,7 @@
 	// unroll 2
 //	prefetcht0		0(%r13, %r14, 8)
 	vmovapd			2*64(%r11), %zmm25 // A
-	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1511,7 +1858,7 @@
 	// unroll 3
 //	prefetcht0		0(%r13, %r14, 8)
 	vmovapd			3*64(%r11), %zmm25 // A
-	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1540,7 +1887,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1557,7 +1904,7 @@
 
 	// unroll 1
 	vmovapd			1*64(%r11), %zmm25 // A
-	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1574,7 +1921,7 @@
 
 	// unroll 2
 	vmovapd			2*64(%r11), %zmm25 // A
-	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1591,7 +1938,7 @@
 
 	// unroll 3
 	vmovapd			3*64(%r11), %zmm25 // A
-	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1622,7 +1969,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1651,7 +1998,7 @@
 #else
 	ret
 
-	FUN_END(inner_kernel_dgemm_nt_16x4_lib8c)
+	FUN_END(inner_kernel_dgemm_nt_2vx4_lib8c)
 #endif
 
 
@@ -1674,10 +2021,10 @@
 // output arguments:
 
 #if MACRO_LEVEL>=2
-	.macro INNER_KERNEL_DGEMM_NT_16X3_LIB8C
+	.macro INNER_KERNEL_DGEMM_NT_2VX3_LIB8C
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_dgemm_nt_16x3_lib8c)
+	FUN_START(inner_kernel_dgemm_nt_2vx3_lib8c)
 #endif
 
 	cmpl	$ 0, %r10d
@@ -1696,7 +2043,7 @@
 	// unroll 0
 //	prefetcht0		0(%r13, %r14, 8)
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1714,7 +2061,7 @@
 	// unroll 1
 //	prefetcht0		0(%r13, %r14, 8)
 	vmovapd			1*64(%r11), %zmm25 // A
-	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1732,7 +2079,7 @@
 	// unroll 2
 //	prefetcht0		0(%r13, %r14, 8)
 	vmovapd			2*64(%r11), %zmm25 // A
-	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1750,7 +2097,7 @@
 	// unroll 3
 //	prefetcht0		0(%r13, %r14, 8)
 	vmovapd			3*64(%r11), %zmm25 // A
-	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1779,7 +2126,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1796,7 +2143,7 @@
 
 	// unroll 1
 	vmovapd			1*64(%r11), %zmm25 // A
-	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1813,7 +2160,7 @@
 
 	// unroll 2
 	vmovapd			2*64(%r11), %zmm25 // A
-	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1830,7 +2177,7 @@
 
 	// unroll 3
 	vmovapd			3*64(%r11), %zmm25 // A
-	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1861,7 +2208,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1890,7 +2237,7 @@
 #else
 	ret
 
-	FUN_END(inner_kernel_dgemm_nt_16x3_lib8c)
+	FUN_END(inner_kernel_dgemm_nt_2vx3_lib8c)
 #endif
 
 
@@ -1913,10 +2260,10 @@
 // output arguments:
 
 #if MACRO_LEVEL>=2
-	.macro INNER_KERNEL_DGEMM_NT_16X2_LIB8C
+	.macro INNER_KERNEL_DGEMM_NT_2VX2_LIB8C
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_dgemm_nt_16x2_lib8c)
+	FUN_START(inner_kernel_dgemm_nt_2vx2_lib8c)
 #endif
 
 	cmpl	$ 0, %r10d
@@ -1935,7 +2282,7 @@
 	// unroll 0
 //	prefetcht0		0(%r13, %r14, 8)
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1953,7 +2300,7 @@
 	// unroll 1
 //	prefetcht0		0(%r13, %r14, 8)
 	vmovapd			1*64(%r11), %zmm25 // A
-	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1971,7 +2318,7 @@
 	// unroll 2
 //	prefetcht0		0(%r13, %r14, 8)
 	vmovapd			2*64(%r11), %zmm25 // A
-	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -1989,7 +2336,7 @@
 	// unroll 3
 //	prefetcht0		0(%r13, %r14, 8)
 	vmovapd			3*64(%r11), %zmm25 // A
-	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -2018,7 +2365,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -2035,7 +2382,7 @@
 
 	// unroll 1
 	vmovapd			1*64(%r11), %zmm25 // A
-	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -2052,7 +2399,7 @@
 
 	// unroll 2
 	vmovapd			2*64(%r11), %zmm25 // A
-	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -2069,7 +2416,7 @@
 
 	// unroll 3
 	vmovapd			3*64(%r11), %zmm25 // A
-	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -2100,7 +2447,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -2129,7 +2476,7 @@
 #else
 	ret
 
-	FUN_END(inner_kernel_dgemm_nt_16x2_lib8c)
+	FUN_END(inner_kernel_dgemm_nt_2vx2_lib8c)
 #endif
 
 
@@ -2152,10 +2499,10 @@
 // output arguments:
 
 #if MACRO_LEVEL>=2
-	.macro INNER_KERNEL_DGEMM_NT_16X1_LIB8C
+	.macro INNER_KERNEL_DGEMM_NT_2VX1_LIB8C
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_dgemm_nt_16x1_lib8c)
+	FUN_START(inner_kernel_dgemm_nt_2vx1_lib8c)
 #endif
 
 	cmpl	$ 0, %r10d
@@ -2174,7 +2521,7 @@
 	// unroll 0
 //	prefetcht0		0(%r13, %r14, 8)
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -2192,7 +2539,7 @@
 	// unroll 1
 //	prefetcht0		0(%r13, %r14, 8)
 	vmovapd			1*64(%r11), %zmm25 // A
-	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -2210,7 +2557,7 @@
 	// unroll 2
 //	prefetcht0		0(%r13, %r14, 8)
 	vmovapd			2*64(%r11), %zmm25 // A
-	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -2228,7 +2575,7 @@
 	// unroll 3
 //	prefetcht0		0(%r13, %r14, 8)
 	vmovapd			3*64(%r11), %zmm25 // A
-	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -2257,7 +2604,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -2274,7 +2621,7 @@
 
 	// unroll 1
 	vmovapd			1*64(%r11), %zmm25 // A
-	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -2291,7 +2638,7 @@
 
 	// unroll 2
 	vmovapd			2*64(%r11), %zmm25 // A
-	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -2308,7 +2655,7 @@
 
 	// unroll 3
 	vmovapd			3*64(%r11), %zmm25 // A
-	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -2339,7 +2686,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -2368,7 +2715,162 @@
 #else
 	ret
 
-	FUN_END(inner_kernel_dgemm_nt_16x1_lib8c)
+	FUN_END(inner_kernel_dgemm_nt_2vx1_lib8c)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B
+// r14   <- ldb
+// r15   <- m1
+// rax   <- n1
+// zmm0  <- []
+// ...
+// zmm15 <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// r14   <- ldb
+// r15   <- m1
+// rax   <- n1
+// zmm0  <- []
+// ...
+// zmm15 <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_16X8_VS_LIB8C
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_16x8_vs_lib8c)
+#endif
+
+	// compute mask for rows
+	vcvtsi2sd	%r15d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC01(%rip), %zmm24
+#elif defined(OS_MAC)
+	vmovupd		LC01(%rip), %zmm24
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm24, %zmm25
+	vpmovq2m	%zmm25, %k1
+
+	cmpl	$ 1, %eax
+	jg		100f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_2VX1_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nt_2vx1_lib8c)
+#endif
+	
+	jmp		107f
+
+100:
+
+	cmpl	$ 2, %eax
+	jg		101f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_2VX2_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nt_2vx2_lib8c)
+#endif
+	
+	jmp		107f
+
+101:
+
+	cmpl	$ 3, %eax
+	jg		102f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_2VX3_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nt_2vx3_lib8c)
+#endif
+	
+	jmp		107f
+
+102:
+
+	cmpl	$ 4, %eax
+	jg		103f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_2VX4_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nt_2vx4_lib8c)
+#endif
+	
+	jmp		107f
+
+103:
+
+	cmpl	$ 5, %eax
+	jg		104f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_2VX5_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nt_2vx5_lib8c)
+#endif
+	
+	jmp		107f
+
+104:
+
+	cmpl	$ 6, %eax
+	jg		105f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_2VX6_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nt_2vx6_lib8c)
+#endif
+	
+	jmp		107f
+
+105:
+
+	cmpl	$ 7, %eax
+	jg		106f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_2VX7_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nt_2vx7_lib8c)
+#endif
+	
+	jmp		107f
+
+106:
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_2VX8_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nt_2vx8_lib8c)
+#endif
+
+107:
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_16x8_vs_lib8c)
 #endif
 
 
@@ -2735,10 +3237,10 @@
 // output arguments:
 
 #if MACRO_LEVEL>=2
-	.macro INNER_KERNEL_DGEMM_NN_16X7_LIB8C
+	.macro INNER_KERNEL_DGEMM_NN_2VX8_LIB8C
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_dgemm_nn_16x7_lib8c)
+	FUN_START(inner_kernel_dgemm_nn_2vx8_lib8c)
 #endif
 
 	cmpl	$ 0, %r10d
@@ -2762,7 +3264,352 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vbroadcastsd	0*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vbroadcastsd	0*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vbroadcastsd	0*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vbroadcastsd	0*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
+	vbroadcastsd	1*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vbroadcastsd	1*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vbroadcastsd	1*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vbroadcastsd	1*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vbroadcastsd	1*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vbroadcastsd	1*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vbroadcastsd	1*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vbroadcastsd	1*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
+	vbroadcastsd	2*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vbroadcastsd	2*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vbroadcastsd	2*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vbroadcastsd	2*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vbroadcastsd	2*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vbroadcastsd	2*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vbroadcastsd	2*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vbroadcastsd	2*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
+	vbroadcastsd	3*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vbroadcastsd	3*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vbroadcastsd	3*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vbroadcastsd	3*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vbroadcastsd	3*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vbroadcastsd	3*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vbroadcastsd	3*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vbroadcastsd	3*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+	addq	$ 4*8, %r13
+	addq	$ 4*8, %r15
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean4-up
+
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vbroadcastsd	0*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vbroadcastsd	0*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vbroadcastsd	0*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vbroadcastsd	0*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
+	vbroadcastsd	1*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vbroadcastsd	1*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vbroadcastsd	1*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vbroadcastsd	1*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vbroadcastsd	1*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vbroadcastsd	1*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vbroadcastsd	1*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vbroadcastsd	1*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
+	vbroadcastsd	2*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vbroadcastsd	2*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vbroadcastsd	2*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vbroadcastsd	2*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vbroadcastsd	2*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vbroadcastsd	2*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vbroadcastsd	2*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vbroadcastsd	2*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
+	vbroadcastsd	3*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vbroadcastsd	3*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vbroadcastsd	3*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vbroadcastsd	3*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vbroadcastsd	3*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vbroadcastsd	3*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vbroadcastsd	3*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vbroadcastsd	3*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+	addq	$ 4*8, %r13
+	addq	$ 4*8, %r15
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vbroadcastsd	0*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vbroadcastsd	0*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vbroadcastsd	0*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vbroadcastsd	0*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+
+	subl	$ 1, %r10d
+	addq	$ 1*64, %r11
+	addq	$ 1*8, %r13
+	addq	$ 1*8, %r15
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_2vx8_lib8c)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- sda
+// r13   <- B
+// r14   <- ldb
+// zmm0  <- []
+// ...
+// zmm15 <- []
+//
+// output arguments:
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_2VX7_LIB8C
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_2vx7_lib8c)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	leaq	0(%r13, %r14, 4), %r15
+	leaq	0(%r14, %r14, 2), %rax
+
+	// preload
+
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+//	prefetcht0		32(%r13)
+//	...
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -2790,7 +3637,7 @@
 
 	// unroll 1
 	vmovapd			1*64(%r11), %zmm25 // A
-	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	1*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -2818,7 +3665,7 @@
 
 	// unroll 2
 	vmovapd			2*64(%r11), %zmm25 // A
-	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	2*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -2846,7 +3693,7 @@
 
 	// unroll 3
 	vmovapd			3*64(%r11), %zmm25 // A
-	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	3*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -2888,7 +3735,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -2916,7 +3763,7 @@
 
 	// unroll 1
 	vmovapd			1*64(%r11), %zmm25 // A
-	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	1*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -2944,7 +3791,7 @@
 
 	// unroll 2
 	vmovapd			2*64(%r11), %zmm25 // A
-	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	2*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -2972,7 +3819,7 @@
 
 	// unroll 3
 	vmovapd			3*64(%r11), %zmm25 // A
-	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	3*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -3016,7 +3863,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -3058,7 +3905,7 @@
 #else
 	ret
 
-	FUN_END(inner_kernel_dgemm_nn_16x7_lib8c)
+	FUN_END(inner_kernel_dgemm_nn_2vx7_lib8c)
 #endif
 
 
@@ -3080,10 +3927,10 @@
 // output arguments:
 
 #if MACRO_LEVEL>=2
-	.macro INNER_KERNEL_DGEMM_NN_16X6_LIB8C
+	.macro INNER_KERNEL_DGEMM_NN_2VX6_LIB8C
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_dgemm_nn_16x6_lib8c)
+	FUN_START(inner_kernel_dgemm_nn_2vx6_lib8c)
 #endif
 
 	cmpl	$ 0, %r10d
@@ -3107,7 +3954,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -3135,7 +3982,7 @@
 
 	// unroll 1
 	vmovapd			1*64(%r11), %zmm25 // A
-	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	1*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -3163,7 +4010,7 @@
 
 	// unroll 2
 	vmovapd			2*64(%r11), %zmm25 // A
-	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	2*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -3191,7 +4038,7 @@
 
 	// unroll 3
 	vmovapd			3*64(%r11), %zmm25 // A
-	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	3*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -3233,7 +4080,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -3261,7 +4108,7 @@
 
 	// unroll 1
 	vmovapd			1*64(%r11), %zmm25 // A
-	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	1*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -3289,7 +4136,7 @@
 
 	// unroll 2
 	vmovapd			2*64(%r11), %zmm25 // A
-	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	2*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -3317,7 +4164,7 @@
 
 	// unroll 3
 	vmovapd			3*64(%r11), %zmm25 // A
-	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	3*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -3361,7 +4208,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -3403,7 +4250,7 @@
 #else
 	ret
 
-	FUN_END(inner_kernel_dgemm_nn_16x6_lib8c)
+	FUN_END(inner_kernel_dgemm_nn_2vx6_lib8c)
 #endif
 
 
@@ -3425,10 +4272,10 @@
 // output arguments:
 
 #if MACRO_LEVEL>=2
-	.macro INNER_KERNEL_DGEMM_NN_16X5_LIB8C
+	.macro INNER_KERNEL_DGEMM_NN_2VX5_LIB8C
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_dgemm_nn_16x5_lib8c)
+	FUN_START(inner_kernel_dgemm_nn_2vx5_lib8c)
 #endif
 
 	cmpl	$ 0, %r10d
@@ -3452,7 +4299,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -3480,7 +4327,7 @@
 
 	// unroll 1
 	vmovapd			1*64(%r11), %zmm25 // A
-	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	1*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -3508,7 +4355,7 @@
 
 	// unroll 2
 	vmovapd			2*64(%r11), %zmm25 // A
-	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	2*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -3536,7 +4383,7 @@
 
 	// unroll 3
 	vmovapd			3*64(%r11), %zmm25 // A
-	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	3*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -3578,7 +4425,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -3606,7 +4453,7 @@
 
 	// unroll 1
 	vmovapd			1*64(%r11), %zmm25 // A
-	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	1*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -3634,7 +4481,7 @@
 
 	// unroll 2
 	vmovapd			2*64(%r11), %zmm25 // A
-	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	2*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -3662,7 +4509,7 @@
 
 	// unroll 3
 	vmovapd			3*64(%r11), %zmm25 // A
-	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	3*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -3706,7 +4553,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -3748,7 +4595,7 @@
 #else
 	ret
 
-	FUN_END(inner_kernel_dgemm_nn_16x5_lib8c)
+	FUN_END(inner_kernel_dgemm_nn_2vx5_lib8c)
 #endif
 
 
@@ -3771,10 +4618,10 @@
 // output arguments:
 
 #if MACRO_LEVEL>=2
-	.macro INNER_KERNEL_DGEMM_NN_16X4_LIB8C
+	.macro INNER_KERNEL_DGEMM_NN_2VX4_LIB8C
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_dgemm_nn_16x4_lib8c)
+	FUN_START(inner_kernel_dgemm_nn_2vx4_lib8c)
 #endif
 
 	cmpl	$ 0, %r10d
@@ -3797,7 +4644,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -3813,7 +4660,7 @@
 
 	// unroll 1
 	vmovapd			1*64(%r11), %zmm25 // A
-	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	1*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -3829,7 +4676,7 @@
 
 	// unroll 2
 	vmovapd			2*64(%r11), %zmm25 // A
-	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	2*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -3845,7 +4692,7 @@
 
 	// unroll 3
 	vmovapd			3*64(%r11), %zmm25 // A
-	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	3*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -3875,7 +4722,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -3891,7 +4738,7 @@
 
 	// unroll 1
 	vmovapd			1*64(%r11), %zmm25 // A
-	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	1*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -3907,7 +4754,7 @@
 
 	// unroll 2
 	vmovapd			2*64(%r11), %zmm25 // A
-	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	2*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -3923,7 +4770,7 @@
 
 	// unroll 3
 	vmovapd			3*64(%r11), %zmm25 // A
-	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	3*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -3955,7 +4802,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -3985,7 +4832,7 @@
 #else
 	ret
 
-	FUN_END(inner_kernel_dgemm_nn_16x4_lib8c)
+	FUN_END(inner_kernel_dgemm_nn_2vx4_lib8c)
 #endif
 
 
@@ -4008,10 +4855,10 @@
 // output arguments:
 
 #if MACRO_LEVEL>=2
-	.macro INNER_KERNEL_DGEMM_NN_16X3_LIB8C
+	.macro INNER_KERNEL_DGEMM_NN_2VX3_LIB8C
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_dgemm_nn_16x3_lib8c)
+	FUN_START(inner_kernel_dgemm_nn_2vx3_lib8c)
 #endif
 
 	cmpl	$ 0, %r10d
@@ -4034,7 +4881,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -4050,7 +4897,7 @@
 
 	// unroll 1
 	vmovapd			1*64(%r11), %zmm25 // A
-	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	1*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -4066,7 +4913,7 @@
 
 	// unroll 2
 	vmovapd			2*64(%r11), %zmm25 // A
-	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	2*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -4082,7 +4929,7 @@
 
 	// unroll 3
 	vmovapd			3*64(%r11), %zmm25 // A
-	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	3*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -4112,7 +4959,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -4128,7 +4975,7 @@
 
 	// unroll 1
 	vmovapd			1*64(%r11), %zmm25 // A
-	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	1*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -4144,7 +4991,7 @@
 
 	// unroll 2
 	vmovapd			2*64(%r11), %zmm25 // A
-	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	2*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -4160,7 +5007,7 @@
 
 	// unroll 3
 	vmovapd			3*64(%r11), %zmm25 // A
-	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	3*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -4192,7 +5039,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -4222,7 +5069,7 @@
 #else
 	ret
 
-	FUN_END(inner_kernel_dgemm_nn_16x3_lib8c)
+	FUN_END(inner_kernel_dgemm_nn_2vx3_lib8c)
 #endif
 
 
@@ -4245,10 +5092,10 @@
 // output arguments:
 
 #if MACRO_LEVEL>=2
-	.macro INNER_KERNEL_DGEMM_NN_16X2_LIB8C
+	.macro INNER_KERNEL_DGEMM_NN_2VX2_LIB8C
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_dgemm_nn_16x2_lib8c)
+	FUN_START(inner_kernel_dgemm_nn_2vx2_lib8c)
 #endif
 
 	cmpl	$ 0, %r10d
@@ -4271,7 +5118,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -4287,7 +5134,7 @@
 
 	// unroll 1
 	vmovapd			1*64(%r11), %zmm25 // A
-	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	1*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -4303,7 +5150,7 @@
 
 	// unroll 2
 	vmovapd			2*64(%r11), %zmm25 // A
-	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	2*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -4319,7 +5166,7 @@
 
 	// unroll 3
 	vmovapd			3*64(%r11), %zmm25 // A
-	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	3*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -4349,7 +5196,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -4365,7 +5212,7 @@
 
 	// unroll 1
 	vmovapd			1*64(%r11), %zmm25 // A
-	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	1*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -4381,7 +5228,7 @@
 
 	// unroll 2
 	vmovapd			2*64(%r11), %zmm25 // A
-	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	2*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -4397,7 +5244,7 @@
 
 	// unroll 3
 	vmovapd			3*64(%r11), %zmm25 // A
-	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	3*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -4429,7 +5276,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -4459,7 +5306,7 @@
 #else
 	ret
 
-	FUN_END(inner_kernel_dgemm_nn_16x2_lib8c)
+	FUN_END(inner_kernel_dgemm_nn_2vx2_lib8c)
 #endif
 
 
@@ -4482,10 +5329,10 @@
 // output arguments:
 
 #if MACRO_LEVEL>=2
-	.macro INNER_KERNEL_DGEMM_NN_16X1_LIB8C
+	.macro INNER_KERNEL_DGEMM_NN_2VX1_LIB8C
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_dgemm_nn_16x1_lib8c)
+	FUN_START(inner_kernel_dgemm_nn_2vx1_lib8c)
 #endif
 
 	cmpl	$ 0, %r10d
@@ -4508,7 +5355,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -4524,7 +5371,7 @@
 
 	// unroll 1
 	vmovapd			1*64(%r11), %zmm25 // A
-	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	1*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -4540,7 +5387,7 @@
 
 	// unroll 2
 	vmovapd			2*64(%r11), %zmm25 // A
-	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	2*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -4556,7 +5403,7 @@
 
 	// unroll 3
 	vmovapd			3*64(%r11), %zmm25 // A
-	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	3*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -4586,7 +5433,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -4602,7 +5449,7 @@
 
 	// unroll 1
 	vmovapd			1*64(%r11), %zmm25 // A
-	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	1*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -4618,7 +5465,7 @@
 
 	// unroll 2
 	vmovapd			2*64(%r11), %zmm25 // A
-	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	2*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -4634,7 +5481,7 @@
 
 	// unroll 3
 	vmovapd			3*64(%r11), %zmm25 // A
-	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	3*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -4666,7 +5513,7 @@
 
 	// unroll 0
 	vmovapd			0*64(%r11), %zmm25 // A
-	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 {%k1}{z} // A
 	vbroadcastsd	0*8(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vfmadd231pd		%zmm26, %zmm24, %zmm8
@@ -4696,7 +5543,162 @@
 #else
 	ret
 
-	FUN_END(inner_kernel_dgemm_nn_16x1_lib8c)
+	FUN_END(inner_kernel_dgemm_nn_2vx1_lib8c)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B
+// r14   <- ldb
+// r15   <- m1
+// rax   <- n1
+// zmm0  <- []
+// ...
+// zmm15 <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// r14   <- ldb
+// r15   <- m1
+// rax   <- n1
+// zmm0  <- []
+// ...
+// zmm15 <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_16X8_VS_LIB8C
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_16x8_vs_lib8c)
+#endif
+
+	// compute mask for rows
+	vcvtsi2sd	%r15d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC01(%rip), %zmm24
+#elif defined(OS_MAC)
+	vmovupd		LC01(%rip), %zmm24
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm24, %zmm25
+	vpmovq2m	%zmm25, %k1
+
+	cmpl	$ 1, %eax
+	jg		100f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_2VX1_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nn_2vx1_lib8c)
+#endif
+	
+	jmp		107f
+
+100:
+
+	cmpl	$ 2, %eax
+	jg		101f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_2VX2_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nn_2vx2_lib8c)
+#endif
+	
+	jmp		107f
+
+101:
+
+	cmpl	$ 3, %eax
+	jg		102f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_2VX3_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nn_2vx3_lib8c)
+#endif
+	
+	jmp		107f
+
+102:
+
+	cmpl	$ 4, %eax
+	jg		103f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_2VX4_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nn_2vx4_lib8c)
+#endif
+	
+	jmp		107f
+
+103:
+
+	cmpl	$ 5, %eax
+	jg		104f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_2VX5_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nn_2vx5_lib8c)
+#endif
+	
+	jmp		107f
+
+104:
+
+	cmpl	$ 6, %eax
+	jg		105f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_2VX6_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nn_2vx6_lib8c)
+#endif
+	
+	jmp		107f
+
+105:
+
+	cmpl	$ 7, %eax
+	jg		106f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_2VX7_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nn_2vx7_lib8c)
+#endif
+	
+	jmp		107f
+
+106:
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_2VX8_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nn_2vx8_lib8c)
+#endif
+
+107:
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_16x8_vs_lib8c)
 #endif
 
 
@@ -5660,11 +6662,13 @@
 	movq	ARG4, %r12 // sda
 	sall	$ 6, %r12d // 8*sda*sizeof(double)
 	movq	ARG5, %r13  // B
+	movq	ARG11, %r14 // m1
+	movq	ARG12, %r15 // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_16X8_LIB8
+	INNER_KERNEL_DGEMM_NT_16X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_16x8_lib8)
+	CALL(inner_kernel_dgemm_nt_16x8_vs_lib8)
 #endif
 
 
@@ -5814,113 +6818,14 @@
 	movq	ARG5, %r13  // B
 	movq	ARG6, %r14  // ldb
 	sall	$ 3, %r14d
-
-
-	movq	ARG13, %r15  // n1
-	cmpl	$ 1, %r15d
-	jg		100f
+	movq	ARG12, %r15 // m1
+	movq	ARG13, %rax // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_16X1_LIB8C
+	INNER_KERNEL_DGEMM_NT_16X8_VS_LIB8C
 #else
-	CALL(inner_kernel_dgemm_nt_16x1_lib8c)
+	CALL(inner_kernel_dgemm_nt_16x8_vs_lib8c)
 #endif
-	
-	jmp		107f
-
-100:
-
-	movq	ARG13, %r15  // n1
-	cmpl	$ 2, %r15d
-	jg		101f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_16X2_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nt_16x2_lib8c)
-#endif
-
-	jmp		107f
-
-101:
-
-	movq	ARG13, %r15  // n1
-	cmpl	$ 3, %r15d
-	jg		102f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_16X3_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nt_16x3_lib8c)
-#endif
-
-	jmp		107f
-
-102:
-
-	movq	ARG13, %r15  // n1
-	cmpl	$ 4, %r15d
-	jg		103f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_16X4_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nt_16x4_lib8c)
-#endif
-
-	jmp		107f
-
-103:
-
-	movq	ARG13, %r15  // n1
-	cmpl	$ 5, %r15d
-	jg		104f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_16X5_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nt_16x5_lib8c)
-#endif
-
-	jmp		107f
-
-104:
-
-	movq	ARG13, %r15  // n1
-	cmpl	$ 6, %r15d
-	jg		105f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_16X6_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nt_16x6_lib8c)
-#endif
-
-	jmp		107f
-
-105:
-
-	movq	ARG13, %r15  // n1
-	cmpl	$ 7, %r15d
-	jg		106f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_16X7_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nt_16x7_lib8c)
-#endif
-
-	jmp		107f
-
-106:
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_16X8_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nt_16x8_lib8c)
-#endif
-
-107:
 
 
 	// prefetch D
@@ -6089,113 +6994,14 @@
 	movq	ARG3, %r13  // A
 	movq	ARG4, %r14  // lda
 	sall	$ 3, %r14d
-
-
-	movq	ARG12, %r15  // m1
-	cmpl	$ 1, %r15d
-	jg		100f
+	movq	ARG13, %r15 // n1
+	movq	ARG12, %rax // m1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_16X1_LIB8C
+	INNER_KERNEL_DGEMM_NT_16X8_VS_LIB8C
 #else
-	CALL(inner_kernel_dgemm_nt_16x1_lib8c)
+	CALL(inner_kernel_dgemm_nt_16x8_vs_lib8c)
 #endif
-	
-	jmp		107f
-
-100:
-
-	movq	ARG12, %r15  // m1
-	cmpl	$ 2, %r15d
-	jg		101f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_16X2_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nt_16x2_lib8c)
-#endif
-
-	jmp		107f
-
-101:
-
-	movq	ARG12, %r15  // m1
-	cmpl	$ 3, %r15d
-	jg		102f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_16X3_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nt_16x3_lib8c)
-#endif
-
-	jmp		107f
-
-102:
-
-	movq	ARG12, %r15  // m1
-	cmpl	$ 4, %r15d
-	jg		103f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_16X4_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nt_16x4_lib8c)
-#endif
-
-	jmp		107f
-
-103:
-
-	movq	ARG12, %r15  // m1
-	cmpl	$ 5, %r15d
-	jg		104f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_16X5_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nt_16x5_lib8c)
-#endif
-
-	jmp		107f
-
-104:
-
-	movq	ARG12, %r15  // m1
-	cmpl	$ 6, %r15d
-	jg		105f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_16X6_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nt_16x6_lib8c)
-#endif
-
-	jmp		107f
-
-105:
-
-	movq	ARG12, %r15  // m1
-	cmpl	$ 7, %r15d
-	jg		106f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_16X7_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nt_16x7_lib8c)
-#endif
-
-	jmp		107f
-
-106:
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_16X8_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nt_16x8_lib8c)
-#endif
-
-107:
 
 #if MACRO_LEVEL>=1
 	INNER_TRAN_16X8_LIB8
@@ -6363,113 +7169,14 @@
 	movq	ARG5, %r13  // B
 	movq	ARG6, %r14  // ldb
 	sall	$ 3, %r14d
-
-
-	movq	ARG13, %r15  // n1
-	cmpl	$ 1, %r15d
-	jg		100f
+	movq	ARG12, %r15 // m1
+	movq	ARG13, %rax // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_16X1_LIB8C
+	INNER_KERNEL_DGEMM_NN_16X8_VS_LIB8C
 #else
-	CALL(inner_kernel_dgemm_nn_16x1_lib8c)
+	CALL(inner_kernel_dgemm_nn_16x8_vs_lib8c)
 #endif
-	
-	jmp		107f
-
-100:
-
-	movq	ARG13, %r15  // n1
-	cmpl	$ 2, %r15d
-	jg		101f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_16X2_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nn_16x2_lib8c)
-#endif
-
-	jmp		107f
-
-101:
-
-	movq	ARG13, %r15  // n1
-	cmpl	$ 3, %r15d
-	jg		102f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_16X3_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nn_16x3_lib8c)
-#endif
-
-	jmp		107f
-
-102:
-
-	movq	ARG13, %r15  // n1
-	cmpl	$ 4, %r15d
-	jg		103f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_16X4_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nn_16x4_lib8c)
-#endif
-
-	jmp		107f
-
-103:
-
-	movq	ARG13, %r15  // n1
-	cmpl	$ 5, %r15d
-	jg		104f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_16X5_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nn_16x5_lib8c)
-#endif
-
-	jmp		107f
-
-104:
-
-	movq	ARG13, %r15  // n1
-	cmpl	$ 6, %r15d
-	jg		105f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_16X6_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nn_16x6_lib8c)
-#endif
-
-	jmp		107f
-
-105:
-
-	movq	ARG13, %r15  // n1
-	cmpl	$ 7, %r15d
-	jg		106f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_16X7_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nn_16x7_lib8c)
-#endif
-
-	jmp		107f
-
-106:
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_16X8_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nn_16x8_lib8c)
-#endif
-
-107:
 
 
 	// prefetch D
@@ -6638,113 +7345,14 @@
 	movq	ARG3, %r13  // A
 	movq	ARG4, %r14  // lda
 	sall	$ 3, %r14d
-
-
-	movq	ARG12, %r15  // m1
-	cmpl	$ 1, %r15d
-	jg		100f
+	movq	ARG13, %r15 // n1
+	movq	ARG12, %rax // m1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_16X1_LIB8C
+	INNER_KERNEL_DGEMM_NN_16X8_VS_LIB8C
 #else
-	CALL(inner_kernel_dgemm_nn_16x1_lib8c)
+	CALL(inner_kernel_dgemm_nn_16x8_vs_lib8c)
 #endif
-	
-	jmp		107f
-
-100:
-
-	movq	ARG12, %r15  // m1
-	cmpl	$ 2, %r15d
-	jg		101f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_16X2_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nn_16x2_lib8c)
-#endif
-
-	jmp		107f
-
-101:
-
-	movq	ARG12, %r15  // m1
-	cmpl	$ 3, %r15d
-	jg		102f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_16X3_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nn_16x3_lib8c)
-#endif
-
-	jmp		107f
-
-102:
-
-	movq	ARG12, %r15  // m1
-	cmpl	$ 4, %r15d
-	jg		103f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_16X4_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nn_16x4_lib8c)
-#endif
-
-	jmp		107f
-
-103:
-
-	movq	ARG12, %r15  // m1
-	cmpl	$ 5, %r15d
-	jg		104f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_16X5_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nn_16x5_lib8c)
-#endif
-
-	jmp		107f
-
-104:
-
-	movq	ARG12, %r15  // m1
-	cmpl	$ 6, %r15d
-	jg		105f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_16X6_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nn_16x6_lib8c)
-#endif
-
-	jmp		107f
-
-105:
-
-	movq	ARG12, %r15  // m1
-	cmpl	$ 7, %r15d
-	jg		106f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_16X7_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nn_16x7_lib8c)
-#endif
-
-	jmp		107f
-
-106:
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_16X8_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nn_16x8_lib8c)
-#endif
-
-107:
 
 #if MACRO_LEVEL>=1
 	INNER_TRAN_16X8_LIB8

--- a/kernel/avx512/kernel_dgemm_16x8_lib.S
+++ b/kernel/avx512/kernel_dgemm_16x8_lib.S
@@ -2740,6 +2740,7 @@
 // output arguments:
 // r10d  <- 0
 // r11   <- A+8*k*sizeof(double)
+// r12   <- 4*sda*sizeof(double)
 // r13   <- B+8*k*sizeof(double)
 // r14   <- ldb
 // r15   <- m1

--- a/kernel/avx512/kernel_dgemm_16x8_lib.S
+++ b/kernel/avx512/kernel_dgemm_16x8_lib.S
@@ -61,6 +61,15 @@
 
 	// preload
 
+	prefetcht0		0(%r13)
+	prefetcht0		63(%r13)
+	prefetcht0		0(%r13, %r14)
+	prefetcht0		63(%r13, %r14)
+	prefetcht0		0(%r13, %r14, 2)
+	prefetcht0		63(%r13, %r14, 2)
+	leaq			0(%r14, %r14, 2), %r15
+	prefetcht0		0(%r13, %r15)
+	prefetcht0		63(%r13, %r15)
 
 	cmpl	$ 4, %r10d
 	jle		0f // consider clean-up loop
@@ -70,7 +79,8 @@
 1: // main loop
 
 	// unroll 0
-//	prefetcht0		0(%r13, %r14, 8)
+	prefetcht0		0(%r13, %r14, 4)
+	prefetcht0		63(%r13, %r14, 4)
 	vmovapd			0*64(%r11), %zmm25 // A
 	vmovapd			0*64(%r11, %r12), %zmm26 // A
 	vbroadcastsd	0(%r13), %zmm24 // B
@@ -100,7 +110,8 @@
 	addq	%r14, %r13
 
 	// unroll 1
-//	prefetcht0		0(%r13, %r14, 8)
+	prefetcht0		0(%r13, %r14, 4)
+	prefetcht0		63(%r13, %r14, 4)
 	vmovapd			1*64(%r11), %zmm25 // A
 	vmovapd			1*64(%r11, %r12), %zmm26 // A
 	vbroadcastsd	0(%r13), %zmm24 // B
@@ -130,7 +141,8 @@
 	addq	%r14, %r13
 
 	// unroll 2
-//	prefetcht0		0(%r13, %r14, 8)
+	prefetcht0		0(%r13, %r14, 4)
+	prefetcht0		63(%r13, %r14, 4)
 	vmovapd			2*64(%r11), %zmm25 // A
 	vmovapd			2*64(%r11, %r12), %zmm26 // A
 	vbroadcastsd	0(%r13), %zmm24 // B
@@ -160,7 +172,8 @@
 	addq	%r14, %r13
 
 	// unroll 3
-//	prefetcht0		0(%r13, %r14, 8)
+	prefetcht0		0(%r13, %r14, 4)
+	prefetcht0		63(%r13, %r14, 4)
 	vmovapd			3*64(%r11), %zmm25 // A
 	vmovapd			3*64(%r11, %r12), %zmm26 // A
 	vbroadcastsd	0(%r13), %zmm24 // B

--- a/kernel/avx512/kernel_dgemm_16x8_lib.S
+++ b/kernel/avx512/kernel_dgemm_16x8_lib.S
@@ -6817,14 +6817,14 @@
 
 	// prefetch D
 
-//	movq	ARG10, %r10 // D
-//	movq	ARG11, %r11 // ldd
-//	sall	$ 3, %r11d
+	movq	ARG10, %r10 // D
+	movq	ARG11, %r11 // ldd
+	sall	$ 3, %r11d
 
 #if MACRO_LEVEL>=1
-//	INNER_PREFETCH0_8X4_LIB
+	INNER_PREFETCH0_16X8_LIB
 #else
-//	CALL(inner_prefetch0_8x4_lib)
+	CALL(inner_prefetch0_16x8_lib)
 #endif
 
 

--- a/kernel/avx512/kernel_dgemm_16x8_lib.S
+++ b/kernel/avx512/kernel_dgemm_16x8_lib.S
@@ -6696,7 +6696,7 @@
 
 
 
-//                                 1      2              3          4        5          6             7          8        9          10
+//                                   1      2              3          4        5          6             7          8        9          10
 // void kernel_dgemm_nt_16x8_lib88cc(int k, double *alpha, double *A, int sda, double *B, double *beta, double *C, int ldc, double *D, int ldd);
 
 	.p2align 4,,15
@@ -6712,9 +6712,9 @@
 	// prefetch C
 
 	movq		ARG6, %r10 // beta
-	vmovsd		0(%r10), %xmm14
-	vxorpd		%xmm15, %xmm15, %xmm15 // 0.0
-	vucomisd	%xmm15, %xmm14 // beta==0.0 ?
+	vmovsd		0(%r10), %xmm24
+	vxorpd		%xmm25, %xmm25, %xmm25 // 0.0
+	vucomisd	%xmm25, %xmm24 // beta==0.0 ?
 	je			100f // end
 
 	movq	ARG7, %r10 // C

--- a/kernel/avx512/kernel_dgemm_16x8_lib.S
+++ b/kernel/avx512/kernel_dgemm_16x8_lib.S
@@ -6626,6 +6626,75 @@
 
 
 
+// common inner routine with file scope
+//
+// prefetch
+//
+// input arguments:
+// r10  <- D
+// r11  <- ldd
+//
+// output arguments:
+
+#if MACRO_LEVEL>=1
+	.macro INNER_PREFETCH0_8X16_LIB
+#else
+	.p2align 4,,15
+	FUN_START(inner_prefetch0_8x16_lib)
+#endif
+
+	leaq		0(%r11, %r11, 2), %r12
+	leaq		0(%r10, %r11, 4), %r13
+
+	prefetcht0	0(%r10)
+	prefetcht0	63(%r10)
+	prefetcht0	0(%r10, %r11)
+	prefetcht0	63(%r10, %r11)
+	prefetcht0	0(%r10, %r11, 2)
+	prefetcht0	63(%r10, %r11, 2)
+	prefetcht0	0(%r10, %r12)
+	prefetcht0	63(%r10, %r12)
+	prefetcht0	0(%r13)
+	prefetcht0	63(%r13)
+	prefetcht0	0(%r13, %r11)
+	prefetcht0	63(%r13, %r11)
+	prefetcht0	0(%r13, %r11, 2)
+	prefetcht0	63(%r13, %r11, 2)
+	prefetcht0	0(%r13, %r12)
+	prefetcht0	63(%r13, %r12)
+
+	leaq		0(%r10, %r11, 8), %r10
+	leaq		0(%r13, %r11, 8), %r13
+
+	prefetcht0	0(%r10)
+	prefetcht0	63(%r10)
+	prefetcht0	0(%r10, %r11)
+	prefetcht0	63(%r10, %r11)
+	prefetcht0	0(%r10, %r11, 2)
+	prefetcht0	63(%r10, %r11, 2)
+	prefetcht0	0(%r10, %r12)
+	prefetcht0	63(%r10, %r12)
+	prefetcht0	0(%r13)
+	prefetcht0	63(%r13)
+	prefetcht0	0(%r13, %r11)
+	prefetcht0	63(%r13, %r11)
+	prefetcht0	0(%r13, %r11, 2)
+	prefetcht0	63(%r13, %r11, 2)
+	prefetcht0	0(%r13, %r12)
+	prefetcht0	63(%r13, %r12)
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_prefetch0_8x16_lib)
+#endif
+
+
+
+
+
 //                                 1      2              3          4        5          6             7          8        9          10
 // void kernel_dgemm_nt_16x8_lib88cc(int k, double *alpha, double *A, int sda, double *B, double *beta, double *C, int ldc, double *D, int ldd);
 
@@ -6991,16 +7060,16 @@
 #endif
 
 
-	// prefetch D
+	// prefetch D TODO
 
-//	movq	ARG10, %r10 // D
-//	movq	ARG11, %r11 // ldd
-//	sall	$ 3, %r11d
+	movq	ARG10, %r10 // D
+	movq	ARG11, %r11 // ldd
+	sall	$ 3, %r11d
 
 #if MACRO_LEVEL>=1
-//	INNER_PREFETCH0_8X4_LIB
+	INNER_PREFETCH0_8X16_LIB
 #else
-//	CALL(inner_prefetch0_8x4_lib)
+	CALL(inner_prefetch0_8x16_lib)
 #endif
 
 

--- a/kernel/avx512/kernel_dgemm_16x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_16x8_lib8.S
@@ -8614,23 +8614,21 @@ NAME:
 //
 // input arguments:
 // r10  <- inv_diag_E
-// r11d <- kn
 // zmm0 <- []
 // ...
 // ymm15 <- []
 //
 // output arguments:
 // r10  <- inv_diag_E
-// r11d <- kn
 // zmm0 <- []
 // ...
 // ymm15 <- []
 
 #if MACRO_LEVEL>=1
-	.macro INNER_EDGE_DPOTRF_16X8_VS_LIB8
+	.macro INNER_EDGE_DPOTRF_16X8_LIB8
 #else
 	.p2align 4,,15
-	FUN_START(inner_edge_dpotrf_16x8_vs_lib8)
+	FUN_START(inner_edge_dpotrf_16x8_lib8)
 #endif
 
 	vxorpd	%ymm25, %ymm25, %ymm25 // 0.0
@@ -8651,7 +8649,478 @@ NAME:
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm0, %zmm26, %zmm0
 	vmulpd			%zmm8, %zmm26, %zmm8
-	cmpl			$ 2, %r11d
+	vmovapd			%zmm1, %zmm26
+	vfnmadd231pd	%zmm0, %zmm0, %zmm26
+
+	// 1
+//	vpermilpd		$ 0x3, %xmm1, %xmm26
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm26, %zmm27, %zmm26
+	vucomisd		%xmm25, %xmm26 // d_11 > 0.0 ?
+	jbe				3f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+4:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm1
+	vfnmadd231pd	%zmm8, %zmm27, %zmm9
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm2
+	vfnmadd231pd	%zmm8, %zmm27, %zmm10
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm3
+	vfnmadd231pd	%zmm8, %zmm27, %zmm11
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm4
+	vfnmadd231pd	%zmm8, %zmm27, %zmm12
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm5
+	vfnmadd231pd	%zmm8, %zmm27, %zmm13
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm6
+	vfnmadd231pd	%zmm8, %zmm27, %zmm14
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm7
+	vfnmadd231pd	%zmm8, %zmm27, %zmm15
+	vmovsd			%xmm26, 8(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm1, %zmm26, %zmm1
+	vmulpd			%zmm9, %zmm26, %zmm9
+	vmovapd			%zmm2, %zmm26
+	vfnmadd231pd	%zmm1, %zmm1, %zmm26
+
+	// 2
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm26, %zmm27, %zmm26
+	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
+	jbe				5f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+6:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm2
+	vfnmadd231pd	%zmm9, %zmm27, %zmm10
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm3
+	vfnmadd231pd	%zmm9, %zmm27, %zmm11
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm4
+	vfnmadd231pd	%zmm9, %zmm27, %zmm12
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm5
+	vfnmadd231pd	%zmm9, %zmm27, %zmm13
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm6
+	vfnmadd231pd	%zmm9, %zmm27, %zmm14
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm7
+	vfnmadd231pd	%zmm9, %zmm27, %zmm15
+	vmovsd			%xmm26, 16(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm2, %zmm26, %zmm2
+	vmulpd			%zmm10, %zmm26, %zmm10
+	vmovapd			%zmm3, %zmm26
+	vfnmadd231pd	%zmm2, %zmm2, %zmm26
+
+	// 3
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm26, %zmm27, %zmm26
+	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
+	jbe				7f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+8:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm28
+	vfnmadd231pd	%zmm2, %zmm28, %zmm3
+	vfnmadd231pd	%zmm10, %zmm28, %zmm11
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm28
+	vfnmadd231pd	%zmm2, %zmm28, %zmm4
+	vfnmadd231pd	%zmm10, %zmm28, %zmm12
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm28
+	vfnmadd231pd	%zmm2, %zmm28, %zmm5
+	vfnmadd231pd	%zmm10, %zmm28, %zmm13
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm28
+	vfnmadd231pd	%zmm2, %zmm28, %zmm6
+	vfnmadd231pd	%zmm10, %zmm28, %zmm14
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm28
+	vfnmadd231pd	%zmm2, %zmm28, %zmm7
+	vfnmadd231pd	%zmm10, %zmm28, %zmm15
+	vmovsd			%xmm26, 24(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm3, %zmm26, %zmm3
+	vmulpd			%zmm11, %zmm26, %zmm11
+	vmovapd			%zmm4, %zmm26
+	vfnmadd231pd	%zmm3, %zmm3, %zmm26
+
+	// 4
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm26, %zmm27, %zmm26
+	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
+	jbe				9f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+10:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm3, %zmm27, %zmm27
+	vfnmadd231pd	%zmm3, %zmm27, %zmm4
+	vfnmadd231pd	%zmm11, %zmm27, %zmm12
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm3, %zmm27, %zmm27
+	vfnmadd231pd	%zmm3, %zmm27, %zmm5
+	vfnmadd231pd	%zmm11, %zmm27, %zmm13
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm3, %zmm27, %zmm27
+	vfnmadd231pd	%zmm3, %zmm27, %zmm6
+	vfnmadd231pd	%zmm11, %zmm27, %zmm14
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm3, %zmm27, %zmm27
+	vfnmadd231pd	%zmm3, %zmm27, %zmm7
+	vfnmadd231pd	%zmm11, %zmm27, %zmm15
+	vmovsd			%xmm26, 32(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm4, %zmm26, %zmm4
+	vmulpd			%zmm12, %zmm26, %zmm12
+	vmovapd			%zmm5, %zmm26
+	vfnmadd231pd	%zmm4, %zmm4, %zmm26
+
+	// 5
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm26, %zmm27, %zmm26
+	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
+	jbe				11f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+12:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm4, %zmm27, %zmm27
+	vfnmadd231pd	%zmm4, %zmm27, %zmm5
+	vfnmadd231pd	%zmm12, %zmm27, %zmm13
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm4, %zmm27, %zmm27
+	vfnmadd231pd	%zmm4, %zmm27, %zmm6
+	vfnmadd231pd	%zmm12, %zmm27, %zmm14
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm4, %zmm27, %zmm27
+	vfnmadd231pd	%zmm4, %zmm27, %zmm7
+	vfnmadd231pd	%zmm12, %zmm27, %zmm15
+	vmovsd			%xmm26, 40(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm5, %zmm26, %zmm5
+	vmulpd			%zmm13, %zmm26, %zmm13
+	vmovapd			%zmm6, %zmm26
+	vfnmadd231pd	%zmm5, %zmm5, %zmm26
+
+	// 6
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm26, %zmm27, %zmm26
+	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
+	jbe				13f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+14:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm5, %zmm27, %zmm27
+	vfnmadd231pd	%zmm5, %zmm27, %zmm6
+	vfnmadd231pd	%zmm13, %zmm27, %zmm14
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm5, %zmm27, %zmm27
+	vfnmadd231pd	%zmm5, %zmm27, %zmm7
+	vfnmadd231pd	%zmm13, %zmm27, %zmm15
+	vmovsd			%xmm26, 48(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm6, %zmm26, %zmm6
+	vmulpd			%zmm14, %zmm26, %zmm14
+	vmovapd			%zmm7, %zmm26
+	vfnmadd231pd	%zmm6, %zmm6, %zmm26
+
+	// 7
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm26, %zmm27, %zmm26
+	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
+	jbe				15f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+16:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm6, %zmm27, %zmm27
+	vfnmadd231pd	%zmm6, %zmm27, %zmm7
+	vfnmadd231pd	%zmm14, %zmm27, %zmm15
+	vmovsd			%xmm26, 56(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm7, %zmm26, %zmm7
+	vmulpd			%zmm15, %zmm26, %zmm15
+
+	jmp				0f
+
+1:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				2b
+
+3:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				4b
+
+5:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				6b
+
+7:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				8b
+
+9:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				10b
+
+11:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				12b
+
+13:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				14b
+
+15:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				16b
+
+0:
+	#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_edge_dpotrf_16x8_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// cholesky factorization 
+//
+// input arguments:
+// r10  <- inv_diag_E
+// r11d <- m1
+// r12d <- n1
+// zmm0 <- []
+// ...
+// ymm15 <- []
+//
+// output arguments:
+// r10  <- inv_diag_E
+// r11d <- m1
+// r12d <- n1
+// zmm0 <- []
+// ...
+// ymm15 <- []
+
+#if MACRO_LEVEL>=1
+	.macro INNER_EDGE_DPOTRF_16X8_VS_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_edge_dpotrf_16x8_vs_lib8)
+#endif
+
+	// compute mask for rows
+	vcvtsi2sd	%r11d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC01(%rip), %zmm24
+#elif defined(OS_MAC)
+	vmovupd		LC01(%rip), %zmm24
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm24, %zmm25
+	vpmovq2m	%zmm25, %k1
+
+	vmovapd		%zmm8, %zmm8 {%k1}{z}
+	vmovapd		%zmm9, %zmm9 {%k1}{z}
+	vmovapd		%zmm10, %zmm10 {%k1}{z}
+	vmovapd		%zmm11, %zmm11 {%k1}{z}
+	vmovapd		%zmm12, %zmm12 {%k1}{z}
+	vmovapd		%zmm13, %zmm13 {%k1}{z}
+	vmovapd		%zmm14, %zmm14 {%k1}{z}
+	vmovapd		%zmm15, %zmm15 {%k1}{z}
+
+	vxorpd	%ymm25, %ymm25, %ymm25 // 0.0
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovsd	.LC04(%rip), %xmm24 // 1.0
+#elif defined(OS_MAC)
+	vmovsd	LC04(%rip), %xmm24 // 1.0
+#endif
+
+	// 0
+	vmovsd			%xmm0, %xmm0, %xmm26
+	vucomisd		%xmm25, %xmm26 // d_00 > 0.0 ?
+	jbe				1f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+2:
+	vmovsd			%xmm26, 0(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm0, %zmm26, %zmm0
+	vmulpd			%zmm8, %zmm26, %zmm8
+	cmpl			$ 2, %r12d
 	jl				0f // ret
 	vmovapd			%zmm1, %zmm26
 	vfnmadd231pd	%zmm0, %zmm0, %zmm26
@@ -8729,7 +9198,7 @@ NAME:
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm1, %zmm26, %zmm1
 	vmulpd			%zmm9, %zmm26, %zmm9
-	cmpl			$ 3, %r11d
+	cmpl			$ 3, %r12d
 	jl				0f // ret
 	vmovapd			%zmm2, %zmm26
 	vfnmadd231pd	%zmm1, %zmm1, %zmm26
@@ -8798,7 +9267,7 @@ NAME:
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm2, %zmm26, %zmm2
 	vmulpd			%zmm10, %zmm26, %zmm10
-	cmpl			$ 4, %r11d
+	cmpl			$ 4, %r12d
 	jl				0f // ret
 	vmovapd			%zmm3, %zmm26
 	vfnmadd231pd	%zmm2, %zmm2, %zmm26
@@ -8859,7 +9328,7 @@ NAME:
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm3, %zmm26, %zmm3
 	vmulpd			%zmm11, %zmm26, %zmm11
-	cmpl			$ 5, %r11d
+	cmpl			$ 5, %r12d
 	jl				0f // ret
 	vmovapd			%zmm4, %zmm26
 	vfnmadd231pd	%zmm3, %zmm3, %zmm26
@@ -8912,7 +9381,7 @@ NAME:
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm4, %zmm26, %zmm4
 	vmulpd			%zmm12, %zmm26, %zmm12
-	cmpl			$ 6, %r11d
+	cmpl			$ 6, %r12d
 	jl				0f // ret
 	vmovapd			%zmm5, %zmm26
 	vfnmadd231pd	%zmm4, %zmm4, %zmm26
@@ -8957,7 +9426,7 @@ NAME:
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm5, %zmm26, %zmm5
 	vmulpd			%zmm13, %zmm26, %zmm13
-	cmpl			$ 7, %r11d
+	cmpl			$ 7, %r12d
 	jl				0f // ret
 	vmovapd			%zmm6, %zmm26
 	vfnmadd231pd	%zmm5, %zmm5, %zmm26
@@ -8994,7 +9463,7 @@ NAME:
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm6, %zmm26, %zmm6
 	vmulpd			%zmm14, %zmm26, %zmm14
-	cmpl			$ 8, %r11d
+	cmpl			$ 8, %r12d
 	jl				0f // ret
 	vmovapd			%zmm7, %zmm26
 	vfnmadd231pd	%zmm6, %zmm6, %zmm26
@@ -9288,7 +9757,8 @@ NAME:
 // r11   <- beta
 // r12   <- C
 // r13   <- 8*sdc*sizeof(double)
-// r14   <- n1
+// r14   <- m1
+// r15   <- n1
 // zmm0 <- []
 // ...
 // zmm15 <- []
@@ -9298,7 +9768,8 @@ NAME:
 // r11   <- beta
 // r10   <- C
 // r13   <- 8*sdc*sizeof(double)
-// r14   <- n1
+// r14   <- m1
+// r15   <- n1
 // zmm0 <- []
 // ...
 // zmm15 <- []
@@ -9338,51 +9809,62 @@ NAME:
 	vucomisd	%xmm25, %xmm24 // beta==0.0 ?
 	je			0f // end
 
+	// compute mask for rows
+	vcvtsi2sd	%r14d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC01(%rip), %zmm26
+#elif defined(OS_MAC)
+	vmovupd		LC01(%rip), %zmm26
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm26, %zmm25
+	vpmovq2m	%zmm25, %k1
+
 	vmovapd		0(%r12), %zmm25
 	vfmadd231pd	%zmm24, %zmm25, %zmm0
-	vmovapd		0(%r12, %r13), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm8
-	cmpl	$ 2, %r14d
+	vmovapd		0(%r12, %r13), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm8 {%k1}
+	cmpl	$ 2, %r15d
 	jl		0f // end
 	vmovapd		64(%r12), %zmm25
 	vfmadd231pd	%zmm24, %zmm25, %zmm1
-	vmovapd		64(%r12, %r13), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm9
-	cmpl	$ 3, %r14d
+	vmovapd		64(%r12, %r13), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm9 {%k1}
+	cmpl	$ 3, %r15d
 	jl		0f // end
 	vmovapd		128(%r12), %zmm25
 	vfmadd231pd	%zmm24, %zmm25, %zmm2
-	vmovapd		128(%r12, %r13), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm10
-	cmpl	$ 4, %r14d
+	vmovapd		128(%r12, %r13), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm10 {%k1}
+	cmpl	$ 4, %r15d
 	jl		0f // end
 	vmovapd		192(%r12), %zmm25
 	vfmadd231pd	%zmm24, %zmm25, %zmm3
-	vmovapd		192(%r12, %r13), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm11
-	cmpl	$ 5, %r14d
+	vmovapd		192(%r12, %r13), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm11 {%k1}
+	cmpl	$ 5, %r15d
 	jl		0f // end
 	vmovapd		0+256(%r12), %zmm25
 	vfmadd231pd	%zmm24, %zmm25, %zmm4
-	vmovapd		0+256(%r12, %r13), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm12
-	cmpl	$ 6, %r14d
+	vmovapd		0+256(%r12, %r13), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm12 {%k1}
+	cmpl	$ 6, %r15d
 	jl		0f // end
 	vmovapd		64+256(%r12), %zmm25
 	vfmadd231pd	%zmm24, %zmm25, %zmm5
-	vmovapd		64+256(%r12, %r13), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm13
-	cmpl	$ 7, %r14d
+	vmovapd		64+256(%r12, %r13), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm13 {%k1}
+	cmpl	$ 7, %r15d
 	jl		0f // end
 	vmovapd		128+256(%r12), %zmm25
 	vfmadd231pd	%zmm24, %zmm25, %zmm6
-	vmovapd		128+256(%r12, %r13), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm14
+	vmovapd		128+256(%r12, %r13), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm14 {%k1}
 	je		0f // end
 	vmovapd		192+256(%r12), %zmm25
 	vfmadd231pd	%zmm24, %zmm25, %zmm7
-	vmovapd		192+256(%r12, %r13), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm15
+	vmovapd		192+256(%r12, %r13), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm15 {%k1}
 
 0:
 
@@ -9406,7 +9888,8 @@ NAME:
 // r10   <- alpha
 // r11   <- beta
 // r12   <- C
-// r13d  <- n1
+// r13d  <- m1
+// r14d  <- n1
 // zmm0 <- []
 // ...
 // zmm15 <- []
@@ -9415,7 +9898,8 @@ NAME:
 // r10   <- alpha
 // r11   <- beta
 // r12   <- C
-// r13d  <- n1
+// r13d  <- m1
+// r14d  <- n1
 // zmm0 <- []
 // ...
 // zmm15 <- []
@@ -9455,6 +9939,17 @@ NAME:
 	vucomisd	%xmm25, %xmm24 // beta==0.0 ?
 	je			0f // end
 
+	// compute mask for rows
+	vcvtsi2sd	%r13d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC00(%rip), %zmm26
+#elif defined(OS_MAC)
+	vmovupd		LC00(%rip), %zmm26
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm26, %zmm25
+	vpmovq2m	%zmm25, %k1
+
 	vmovapd		0(%r12), %zmm25
 	vfmadd231pd	%zmm24, %zmm25, %zmm0
 	vmovapd		64(%r12), %zmm25
@@ -9472,35 +9967,35 @@ NAME:
 	vmovapd		192+256(%r12), %zmm25
 	vfmadd231pd	%zmm24, %zmm25, %zmm7
 
-	vmovapd		0+2*256(%r12), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm8
-	cmpl	$ 10, %r13d
+	vmovapd		0+2*256(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm8 {%k1}
+	cmpl	$ 10, %r14d
 	jl		0f // end
-	vmovapd		64+2*256(%r12), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm9
-	cmpl	$ 11, %r13d
+	vmovapd		64+2*256(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm9 {%k1}
+	cmpl	$ 11, %r14d
 	jl		0f // end
-	vmovapd		128+2*256(%r12), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm10
-	cmpl	$ 12, %r13d
+	vmovapd		128+2*256(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm10 {%k1}
+	cmpl	$ 12, %r14d
 	jl		0f // end
-	vmovapd		192+2*256(%r12), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm11
-	cmpl	$ 13, %r13d
+	vmovapd		192+2*256(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm11 {%k1}
+	cmpl	$ 13, %r14d
 	jl		0f // end
-	vmovapd		0+3*256(%r12), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm12
-	cmpl	$ 14, %r13d
+	vmovapd		0+3*256(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm12 {%k1}
+	cmpl	$ 14, %r14d
 	jl		0f // end
-	vmovapd		64+3*256(%r12), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm13
-	cmpl	$ 15, %r13d
+	vmovapd		64+3*256(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm13 {%k1}
+	cmpl	$ 15, %r14d
 	jl		0f // end
-	vmovapd		128+3*256(%r12), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm14
+	vmovapd		128+3*256(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm14 {%k1}
 	je		0f // end
-	vmovapd		192+3*256(%r12), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm15
+	vmovapd		192+3*256(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm15 {%k1}
 
 0:
 
@@ -9543,6 +10038,8 @@ NAME:
 // zmm0 <- []
 // ...
 // ymm15 <- []
+
+// TODO m-mask !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 #if MACRO_LEVEL>=1
 	.macro INNER_SCALE_AB_16X8_GEN_LIB8
@@ -9940,6 +10437,8 @@ NAME:
 // zmm0 <- []
 // ...
 // zmm7 <- []
+
+// TODO m-mask !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 #if MACRO_LEVEL>=1
 	.macro INNER_SCALE_AB_8X16_GEN_LIB8
@@ -10459,7 +10958,8 @@ NAME:
 // r10   <- beta
 // r11   <- C
 // r12   <- sdc
-// r13d  <- n1
+// r13d  <- m1
+// r14d  <- n1
 // zmm0 <- []
 // ...
 // zmm15 <- []
@@ -10467,8 +10967,9 @@ NAME:
 // output arguments:
 // r10   <- beta
 // r11   <- C
-// r13d  <- n1
 // r12   <- sdc
+// r13d  <- m1
+// r14d  <- n1
 // zmm0 <- []
 // ...
 // zmm15 <- []
@@ -10488,51 +10989,62 @@ NAME:
 	vucomisd	%xmm25, %xmm24 // beta==0.0 ?
 	je			0f // end
 
+	// compute mask for rows
+	vcvtsi2sd	%r13d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC01(%rip), %zmm26
+#elif defined(OS_MAC)
+	vmovupd		LC01(%rip), %zmm26
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm26, %zmm25
+	vpmovq2m	%zmm25, %k1
+
 	vmovapd		0(%r11), %zmm25
 	vfmsub231pd	%zmm24, %zmm25, %zmm0
-	vmovapd		0(%r11, %r12), %zmm25
-	vfmsub231pd	%zmm24, %zmm25, %zmm8
-	cmpl	$ 2, %r13d
+	vmovapd		0(%r11, %r12), %zmm25 {%k1}{z}
+	vfmsub231pd	%zmm24, %zmm25, %zmm8 {%k1}
+	cmpl	$ 2, %r14d
 	jl		0f // end
 	vmovapd		1*64(%r11), %zmm25
 	vfmsub231pd	%zmm24, %zmm25, %zmm1
-	vmovapd		1*64(%r11, %r12), %zmm25
-	vfmsub231pd	%zmm24, %zmm25, %zmm9
-	cmpl	$ 3, %r13d
+	vmovapd		1*64(%r11, %r12), %zmm25 {%k1}{z}
+	vfmsub231pd	%zmm24, %zmm25, %zmm9 {%k1}
+	cmpl	$ 3, %r14d
 	jl		0f // end
 	vmovapd		2*64(%r11), %zmm25
 	vfmsub231pd	%zmm24, %zmm25, %zmm2
-	vmovapd		2*64(%r11, %r12), %zmm25
-	vfmsub231pd	%zmm24, %zmm25, %zmm10
-	cmpl	$ 4, %r13d
+	vmovapd		2*64(%r11, %r12), %zmm25 {%k1}{z}
+	vfmsub231pd	%zmm24, %zmm25, %zmm10 {%k1}
+	cmpl	$ 4, %r14d
 	jl		0f // end
 	vmovapd		3*64(%r11), %zmm25
 	vfmsub231pd	%zmm24, %zmm25, %zmm3
-	vmovapd		3*64(%r11, %r12), %zmm25
-	vfmsub231pd	%zmm24, %zmm25, %zmm11
-	cmpl	$ 5, %r13d
+	vmovapd		3*64(%r11, %r12), %zmm25 {%k1}{z}
+	vfmsub231pd	%zmm24, %zmm25, %zmm11 {%k1}
+	cmpl	$ 5, %r14d
 	jl		0f // end
 	vmovapd		4*64(%r11), %zmm25
 	vfmsub231pd	%zmm24, %zmm25, %zmm4
-	vmovapd		4*64(%r11, %r12), %zmm25
-	vfmsub231pd	%zmm24, %zmm25, %zmm12
-	cmpl	$ 6, %r13d
+	vmovapd		4*64(%r11, %r12), %zmm25 {%k1}{z}
+	vfmsub231pd	%zmm24, %zmm25, %zmm12 {%k1}
+	cmpl	$ 6, %r14d
 	jl		0f // end
 	vmovapd		5*64(%r11), %zmm25
 	vfmsub231pd	%zmm24, %zmm25, %zmm5
-	vmovapd		5*64(%r11, %r12), %zmm25
-	vfmsub231pd	%zmm24, %zmm25, %zmm13
-	cmpl	$ 7, %r13d
+	vmovapd		5*64(%r11, %r12), %zmm25 {%k1}{z}
+	vfmsub231pd	%zmm24, %zmm25, %zmm13 {%k1}
+	cmpl	$ 7, %r14d
 	jl		0f // end
 	vmovapd		6*64(%r11), %zmm25
 	vfmsub231pd	%zmm24, %zmm25, %zmm6
-	vmovapd		6*64(%r11, %r12), %zmm25
-	vfmsub231pd	%zmm24, %zmm25, %zmm14
+	vmovapd		6*64(%r11, %r12), %zmm25 {%k1}{z}
+	vfmsub231pd	%zmm24, %zmm25, %zmm14 {%k1}
 	je		0f // end
 	vmovapd		7*64(%r11), %zmm25
 	vfmsub231pd	%zmm24, %zmm25, %zmm7
-	vmovapd		7*64(%r11, %r12), %zmm25
-	vfmsub231pd	%zmm24, %zmm25, %zmm15
+	vmovapd		7*64(%r11, %r12), %zmm25 {%k1}{z}
+	vfmsub231pd	%zmm24, %zmm25, %zmm15 {%k1}
 
 0:
 
@@ -10626,7 +11138,8 @@ NAME:
 // input arguments:
 // r10   <- C
 // r11   <- sdc
-// r12   <- n1
+// r12   <- m1
+// r13   <- n1
 // zmm0 <- []
 // ...
 // zmm15 <- []
@@ -10634,7 +11147,8 @@ NAME:
 // output arguments:
 // r10   <- C
 // r11   <- sdc
-// r12   <- n1
+// r12   <- m1
+// r13   <- n1
 // zmm0 <- []
 // ...
 // zmm15 <- []
@@ -10646,51 +11160,62 @@ NAME:
 	FUN_START(inner_scale_m11_16x8_vs_lib8)
 #endif	
 	
+	// compute mask for rows
+	vcvtsi2sd	%r12d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC01(%rip), %zmm26
+#elif defined(OS_MAC)
+	vmovupd		LC01(%rip), %zmm26
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm26, %zmm25
+	vpmovq2m	%zmm25, %k1
+
 	vmovapd		0(%r10), %zmm24
 	vsubpd		%zmm0, %zmm24, %zmm0
-	vmovapd		0(%r10, %r11), %zmm24
-	vsubpd		%zmm8, %zmm24, %zmm8
-	cmpl	$ 2, %r12d
+	vmovapd		0(%r10, %r11), %zmm24 {%k1}{z}
+	vsubpd		%zmm8, %zmm24, %zmm8 {%k1}
+	cmpl	$ 2, %r13d
 	jl		0f // end
 	vmovapd		1*64(%r10), %zmm24
 	vsubpd		%zmm1, %zmm24, %zmm1
-	vmovapd		1*64(%r10, %r11), %zmm24
-	vsubpd		%zmm9, %zmm24, %zmm9
-	cmpl	$ 3, %r12d
+	vmovapd		1*64(%r10, %r11), %zmm24 {%k1}{z}
+	vsubpd		%zmm9, %zmm24, %zmm9 {%k1}
+	cmpl	$ 3, %r13d
 	jl		0f // end
 	vmovapd		2*64(%r10), %zmm24
 	vsubpd		%zmm2, %zmm24, %zmm2
-	vmovapd		2*64(%r10, %r11), %zmm24
-	vsubpd		%zmm10, %zmm24, %zmm10
-	cmpl	$ 4, %r12d
+	vmovapd		2*64(%r10, %r11), %zmm24 {%k1}{z}
+	vsubpd		%zmm10, %zmm24, %zmm10 {%k1}
+	cmpl	$ 4, %r13d
 	jl		0f // end
 	vmovapd		3*64(%r10), %zmm24
 	vsubpd		%zmm3, %zmm24, %zmm3
-	vmovapd		3*64(%r10, %r11), %zmm24
-	vsubpd		%zmm11, %zmm24, %zmm11
-	cmpl	$ 5, %r12d
+	vmovapd		3*64(%r10, %r11), %zmm24 {%k1}{z}
+	vsubpd		%zmm11, %zmm24, %zmm11 {%k1}
+	cmpl	$ 5, %r13d
 	jl		0f // end
 	vmovapd		4*64(%r10), %zmm24
 	vsubpd		%zmm4, %zmm24, %zmm4
-	vmovapd		4*64(%r10, %r11), %zmm24
-	vsubpd		%zmm12, %zmm24, %zmm12
-	cmpl	$ 6, %r12d
+	vmovapd		4*64(%r10, %r11), %zmm24 {%k1}{z}
+	vsubpd		%zmm12, %zmm24, %zmm12 {%k1}
+	cmpl	$ 6, %r13d
 	jl		0f // end
 	vmovapd		5*64(%r10), %zmm24
 	vsubpd		%zmm5, %zmm24, %zmm5
-	vmovapd		5*64(%r10, %r11), %zmm24
-	vsubpd		%zmm13, %zmm24, %zmm13
-	cmpl	$ 7, %r12d
+	vmovapd		5*64(%r10, %r11), %zmm24 {%k1}{z}
+	vsubpd		%zmm13, %zmm24, %zmm13 {%k1}
+	cmpl	$ 7, %r13d
 	jl		0f // end
 	vmovapd		6*64(%r10), %zmm24
 	vsubpd		%zmm6, %zmm24, %zmm6
-	vmovapd		6*64(%r10, %r11), %zmm24
-	vsubpd		%zmm14, %zmm24, %zmm14
+	vmovapd		6*64(%r10, %r11), %zmm24 {%k1}{z}
+	vsubpd		%zmm14, %zmm24, %zmm14 {%k1}
 	je		0f // end
 	vmovapd		7*64(%r10), %zmm24
 	vsubpd		%zmm7, %zmm24, %zmm7
-	vmovapd		7*64(%r10, %r11), %zmm24
-	vsubpd		%zmm15, %zmm24, %zmm15
+	vmovapd		7*64(%r10, %r11), %zmm24 {%k1}{z}
+	vsubpd		%zmm15, %zmm24, %zmm15 {%k1}
 
 0:
 
@@ -12524,7 +13049,8 @@ NAME:
 	movq	ARG7, %r12 // C
 	movq	ARG8, %r13 // sdc
 	sall	$ 6, %r13d // 8*sdc*sizeof(double)
-	movq	ARG12, %r14 // n1
+	movq	ARG11, %r14 // m1
+	movq	ARG12, %r15 // n1
 
 #if MACRO_LEVEL>=1
 	INNER_SCALE_AB_16X8_VS_LIB8
@@ -12745,7 +13271,8 @@ NAME:
 	movq	ARG2, %r10 // alpha
 	movq	ARG6, %r11 // beta
 	movq	ARG7, %r12 // C
-	movq	ARG10, %r13 // n1
+	movq	ARG9, %r13 // m1
+	movq	ARG10, %r14 // n1
 
 #if MACRO_LEVEL>=1
 	INNER_SCALE_AB_8X16_VS_LIB8
@@ -12901,7 +13428,8 @@ NAME:
 	movq	ARG9, %r12   // C
 	movq	ARG10, %r13 // sdc
 	sall	$ 6, %r13d // 8*sdc*sizeof(double)
-	movq	ARG14, %r14 // n1
+	movq	ARG13, %r14 // m1
+	movq	ARG14, %r15 // n1
 
 #if MACRO_LEVEL>=1
 	INNER_SCALE_AB_16X8_VS_LIB8
@@ -13153,7 +13681,8 @@ NAME:
 	movq	ARG2, %r10 // alpha
 	movq	ARG8, %r11 // beta
 	movq	ARG9, %r12 // C
-	movq	ARG12, %r13 // n1
+	movq	ARG11, %r13 // m1
+	movq	ARG12, %r14 // n1
 
 #if MACRO_LEVEL>=1
 	INNER_SCALE_AB_8X16_VS_LIB8
@@ -13383,7 +13912,8 @@ NAME:
 	movq	ARG7, %r12 // C
 	movq	ARG8, %r13 // sdc
 	sall	$ 6, %r13d // 8*sdc*sizeof(double)
-	movq	ARG12, %r14 // n1
+	movq	ARG11, %r14 // m1
+	movq	ARG12, %r15 // n1
 
 #if MACRO_LEVEL>=1
 	INNER_SCALE_AB_16X8_VS_LIB8
@@ -13858,7 +14388,8 @@ NAME:
 	movq	ARG6, %r11 // C
 	movq	ARG7, %r12 // sdc
 	sall	$ 6, %r12d // 4*sdc*sizeof(double)
-	movq	ARG13, %r13 // n1
+	movq	ARG12, %r13 // m1
+	movq	ARG13, %r14 // n1
 
 #if MACRO_LEVEL>=1
 	INNER_SCALE_M1B_16X8_VS_LIB8
@@ -14056,7 +14587,8 @@ NAME:
 	movq	ARG9, %r10  // C
 	movq	ARG10, %r11 // sdc
 	sall	$ 6, %r11d // 4*sdc*sizeof(double)
-	movq	ARG16, %r12 // n1
+	movq	ARG15, %r12 // m1
+	movq	ARG16, %r13 // n1
 
 #if MACRO_LEVEL>=1
 	INNER_SCALE_M11_16X8_VS_LIB8
@@ -14147,12 +14679,11 @@ NAME:
 	// factorization
 
 	movq	ARG9, %r10  // inv_diag_D 
-	movl	$ 8, %r11d
 
 #if MACRO_LEVEL>=1
-	INNER_EDGE_DPOTRF_16X8_VS_LIB8
+	INNER_EDGE_DPOTRF_16X8_LIB8
 #else
-	CALL(inner_edge_dpotrf_16x8_vs_lib8)
+	CALL(inner_edge_dpotrf_16x8_lib8)
 #endif
 
 
@@ -14214,7 +14745,8 @@ NAME:
 	movq	ARG5, %r10 // C
 	movq	ARG6, %r11 // sdc
 	sall	$ 6, %r11d // 8*sdc*sizeof(double)
-	movq	ARG11, %r12 // n1
+	movq	ARG10, %r12 // m1
+	movq	ARG11, %r13 // n1
 
 #if MACRO_LEVEL>=1
 	INNER_SCALE_M11_16X8_VS_LIB8
@@ -14226,7 +14758,8 @@ NAME:
 	// factorization
 
 	movq	ARG9, %r10  // inv_diag_D 
-	movq	ARG11, %r11 // n1
+	movq	ARG10, %r11 // m1
+	movq	ARG11, %r12 // n1
 
 #if MACRO_LEVEL>=1
 	INNER_EDGE_DPOTRF_16X8_VS_LIB8
@@ -14323,12 +14856,11 @@ NAME:
 	// factorization
 
 	movq	ARG13, %r10  // inv_diag_D 
-	movl	$ 8, %r11d
 
 #if MACRO_LEVEL>=1
-	INNER_EDGE_DPOTRF_16X8_VS_LIB8
+	INNER_EDGE_DPOTRF_16X8_LIB8
 #else
-	CALL(inner_edge_dpotrf_16x8_vs_lib8)
+	CALL(inner_edge_dpotrf_16x8_lib8)
 #endif
 
 
@@ -14411,7 +14943,8 @@ NAME:
 	movq	ARG9, %r10 // C
 	movq	ARG10, %r11 // sdc
 	sall	$ 6, %r11d // 4*sdc*sizeof(double)
-	movq	ARG15, %r12 // n1
+	movq	ARG14, %r12 // m1
+	movq	ARG15, %r13 // n1
 
 #if MACRO_LEVEL>=1
 	INNER_SCALE_M11_16X8_VS_LIB8
@@ -14423,7 +14956,8 @@ NAME:
 	// factorization
 
 	movq	ARG13, %r10  // inv_diag_D 
-	movq	ARG15, %r11 // n1
+	movq	ARG14, %r11 // m1
+	movq	ARG15, %r12 // n1
 
 #if MACRO_LEVEL>=1
 	INNER_EDGE_DPOTRF_16X8_VS_LIB8

--- a/kernel/avx512/kernel_dgemm_16x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_16x8_lib8.S
@@ -3002,7 +3002,7 @@ NAME:
 // r15   <- n1
 // zmm0  <- []
 // ...
-// zmm7  <- []
+// zmm15 <- []
 
 //
 // output arguments:
@@ -3013,7 +3013,7 @@ NAME:
 // r15   <- n1
 // zmm0  <- []
 // ...
-// zmm7  <- []
+// zmm15 <- []
 
 #if MACRO_LEVEL>=2
 	.macro INNER_KERNEL_DGEMM_NT_16X8_VS_LIB8

--- a/kernel/avx512/kernel_dgemm_16x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_16x8_lib8.S
@@ -333,8 +333,10 @@ NAME:
 	jle		2f // return
 
 	// prefetch
-//	prefetcht0	0(%r13) // software prefetch
-//	prefetcht0	0+64(%r13) // software prefetch
+	prefetcht0	0+0*64(%r13) // software prefetch
+	prefetcht0	0+1*64(%r13) // software prefetch
+	prefetcht0	0+2*64(%r13) // software prefetch
+	prefetcht0	0+3*64(%r13) // software prefetch
 
 	// preload
 	vmovapd 		0(%r11), %zmm25 // A0
@@ -356,11 +358,11 @@ NAME:
 	vfmadd231pd		%zmm25, %zmm24, %zmm1
 	vfmadd231pd		%zmm27, %zmm24, %zmm9
 	vmovapd			64(%r11, %r12), %zmm28 // A
-//	prefetcht0	128(%r13) // software prefetch
+	prefetcht0	256+0*64(%r13) // software prefetch
 	vbroadcastsd	16(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm2
 	vfmadd231pd		%zmm27, %zmm24, %zmm10
-//	prefetcht0	128+64(%r13) // software prefetch
+	prefetcht0	256+1*64(%r13) // software prefetch
 	vbroadcastsd	24(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm3
 	vfmadd231pd		%zmm27, %zmm24, %zmm11
@@ -415,11 +417,11 @@ NAME:
 	vfmadd231pd		%zmm25, %zmm24, %zmm1
 	vfmadd231pd		%zmm27, %zmm24, %zmm9
 	vmovapd			192(%r11, %r12), %zmm28 // A
-//	prefetcht0	128(%r13) // software prefetch
+	prefetcht0	256+2*64(%r13) // software prefetch
 	vbroadcastsd	16+128(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm2
 	vfmadd231pd		%zmm27, %zmm24, %zmm10
-//	prefetcht0	128+64(%r13) // software prefetch
+	prefetcht0	256+3*64(%r13) // software prefetch
 	vbroadcastsd	24+128(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm3
 	vfmadd231pd		%zmm27, %zmm24, %zmm11
@@ -484,11 +486,11 @@ NAME:
 	vfmadd231pd		%zmm25, %zmm24, %zmm1
 	vfmadd231pd		%zmm27, %zmm24, %zmm9
 	vmovapd			64(%r11, %r12), %zmm28 // A
-//	prefetcht0	128(%r13) // software prefetch
+//	prefetcht0	256+0*64(%r13) // software prefetch
 	vbroadcastsd	16(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm2
 	vfmadd231pd		%zmm27, %zmm24, %zmm10
-//	prefetcht0	128+64(%r13) // software prefetch
+//	prefetcht0	256+1*64(%r13) // software prefetch
 	vbroadcastsd	24(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm3
 	vfmadd231pd		%zmm27, %zmm24, %zmm11
@@ -543,11 +545,11 @@ NAME:
 	vfmadd231pd		%zmm25, %zmm24, %zmm1
 	vfmadd231pd		%zmm27, %zmm24, %zmm9
 	vmovapd			192(%r11, %r12), %zmm28 // A
-//	prefetcht0	128(%r13) // software prefetch
+//	prefetcht0	256+2*64(%r13) // software prefetch
 	vbroadcastsd	16+128(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm2
 	vfmadd231pd		%zmm27, %zmm24, %zmm10
-//	prefetcht0	128+64(%r13) // software prefetch
+//	prefetcht0	256+3*64(%r13) // software prefetch
 	vbroadcastsd	24+128(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm3
 	vfmadd231pd		%zmm27, %zmm24, %zmm11

--- a/kernel/avx512/kernel_dgemm_16x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_16x8_lib8.S
@@ -661,6 +661,2495 @@ NAME:
 // r10d  <- k
 // r11   <- A
 // r12   <- 4*sda*sizeof(double)
+// r13   <- B
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_2VX8_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_2vx8_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 // A0
+	vmovapd 		0(%r11, %r12), %zmm27 {%k1}{z} // A1
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			128(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	16+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	32+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	40+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vbroadcastsd	48+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+	vbroadcastsd	56+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			192(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	24+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	32+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	40+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vbroadcastsd	48+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+	vbroadcastsd	56+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	16+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	32+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	40+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vbroadcastsd	48+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+	vbroadcastsd	56+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	vfmadd231pd		%zmm28, %zmm24, %zmm15
+	addq	$ 256, %r13
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean4-up
+	
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			128(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	16+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	32+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	40+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vbroadcastsd	48+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+	vbroadcastsd	56+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			192(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	24+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	32+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	40+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vbroadcastsd	48+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+	vbroadcastsd	56+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+//	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+//	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	16+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	32+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	40+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vbroadcastsd	48+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+	vbroadcastsd	56+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	vfmadd231pd		%zmm28, %zmm24, %zmm15
+	addq	$ 256, %r13
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 // A
+	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm27, %zmm24, %zmm15
+
+	addq	$ 64, %r11
+	addq	$ 64, %r13
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_2vx8_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_2VX7_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_2vx7_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 // A0
+	vmovapd 		0(%r11, %r12), %zmm27 {%k1}{z} // A1
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			128(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	16+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	32+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	40+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vbroadcastsd	48+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	56+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			192(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	24+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	32+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	40+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vbroadcastsd	48+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	56+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	16+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	32+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	40+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vbroadcastsd	48+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	56+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+	addq	$ 256, %r13
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean4-up
+	
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			128(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	16+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	32+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	40+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vbroadcastsd	48+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	56+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			192(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	24+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	32+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	40+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vbroadcastsd	48+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	56+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+//	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+//	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	16+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	32+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	40+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vbroadcastsd	48+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	56+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+	addq	$ 256, %r13
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 // A
+	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+
+	addq	$ 64, %r11
+	addq	$ 64, %r13
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_2vx7_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_2VX6_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_2vx6_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 // A0
+	vmovapd 		0(%r11, %r12), %zmm27 {%k1}{z} // A1
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			128(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	16+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	32+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	40+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+//	vbroadcastsd	48+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	56+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			192(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	24+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	32+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	40+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vbroadcastsd	48+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	56+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	16+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	32+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	40+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+//	vbroadcastsd	48+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	56+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+	addq	$ 256, %r13
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean4-up
+	
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			128(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	16+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	32+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	40+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+//	vbroadcastsd	48+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	56+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			192(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	24+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	32+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	40+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vbroadcastsd	48+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	56+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+//	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+//	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	16+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	32+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	40+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+//	vbroadcastsd	48+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	56+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+	addq	$ 256, %r13
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 // A
+	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+
+	addq	$ 64, %r11
+	addq	$ 64, %r13
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_2vx6_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_2VX5_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_2vx5_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 // A0
+	vmovapd 		0(%r11, %r12), %zmm27 {%k1}{z} // A1
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+//	vbroadcastsd	40(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			128(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	16+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	32+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+//	vbroadcastsd	40+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vfmadd231pd		%zmm28, %zmm24, %zmm13
+//	vbroadcastsd	48+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	56+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			192(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	24+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	32+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+//	vbroadcastsd	40+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vbroadcastsd	48+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	56+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	16+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	32+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+//	vbroadcastsd	40+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vfmadd231pd		%zmm28, %zmm24, %zmm13
+//	vbroadcastsd	48+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	56+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+	addq	$ 256, %r13
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean4-up
+	
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+//	vbroadcastsd	40(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			128(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	16+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	32+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+//	vbroadcastsd	40+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vfmadd231pd		%zmm28, %zmm24, %zmm13
+//	vbroadcastsd	48+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	56+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			192(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	24+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	32+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+//	vbroadcastsd	40+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vbroadcastsd	48+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	56+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+//	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+//	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	16+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	32+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+//	vbroadcastsd	40+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vfmadd231pd		%zmm28, %zmm24, %zmm13
+//	vbroadcastsd	48+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	56+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+	addq	$ 256, %r13
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 // A
+	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+//	vbroadcastsd	40(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+
+	addq	$ 64, %r11
+	addq	$ 64, %r13
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_2vx5_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_2VX4_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_2vx4_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 // A0
+	vmovapd 		0(%r11, %r12), %zmm27 {%k1}{z} // A1
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			128(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	16+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			192(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	24+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	16+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	addq	$ 256, %r13
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean4-up
+	
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			128(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	16+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			192(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	24+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+//	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+//	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	16+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	addq	$ 256, %r13
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 // A
+	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+
+	addq	$ 64, %r11
+	addq	$ 64, %r13
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_2vx4_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_2VX3_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_2vx3_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 // A0
+	vmovapd 		0(%r11, %r12), %zmm27 {%k1}{z} // A1
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			128(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	16+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	24+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			192(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	24+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	16+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	24+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	addq	$ 256, %r13
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean4-up
+	
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			128(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	16+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	24+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			192(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	24+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+//	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+//	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	16+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	24+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	addq	$ 256, %r13
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 // A
+	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+
+	addq	$ 64, %r11
+	addq	$ 64, %r13
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_2vx3_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_2VX2_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_2vx2_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 // A0
+	vmovapd 		0(%r11, %r12), %zmm27 {%k1}{z} // A1
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			64(%r11, %r12), %zmm28 {%k1}{z} // A
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			128(%r11, %r12), %zmm27 {%k1}{z} // A
+//	vbroadcastsd	16+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	24+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			192(%r11, %r12), %zmm28 {%k1}{z} // A
+//	vbroadcastsd	16+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	24+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+//	vbroadcastsd	16+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	24+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	addq	$ 256, %r13
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean4-up
+	
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			64(%r11, %r12), %zmm28 {%k1}{z} // A
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			128(%r11, %r12), %zmm27 {%k1}{z} // A
+//	vbroadcastsd	16+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	24+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			192(%r11, %r12), %zmm28 {%k1}{z} // A
+//	vbroadcastsd	16+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	24+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+//	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+//	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+//	vbroadcastsd	16+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	24+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	addq	$ 256, %r13
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 // A
+	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+
+	addq	$ 64, %r11
+	addq	$ 64, %r13
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_2vx2_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_2VX1_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_2vx1_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 // A0
+	vmovapd 		0(%r11, %r12), %zmm27 {%k1}{z} // A1
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			64(%r11), %zmm26 // A
+//	vbroadcastsd	8(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			64(%r11, %r12), %zmm28 {%k1}{z} // A
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			128(%r11), %zmm25 // A
+//	vbroadcastsd	8+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm1
+//	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			128(%r11, %r12), %zmm27 {%k1}{z} // A
+//	vbroadcastsd	16+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	24+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			192(%r11), %zmm26 // A
+//	vbroadcastsd	8+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			192(%r11, %r12), %zmm28 {%k1}{z} // A
+//	vbroadcastsd	16+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	24+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			0(%r11), %zmm25 // A
+//	vbroadcastsd	8+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm1
+//	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+//	vbroadcastsd	16+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	24+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	addq	$ 256, %r13
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean4-up
+	
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			64(%r11), %zmm26 // A
+//	vbroadcastsd	8(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			64(%r11, %r12), %zmm28 {%k1}{z} // A
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			128(%r11), %zmm25 // A
+//	vbroadcastsd	8+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm1
+//	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			128(%r11, %r12), %zmm27 {%k1}{z} // A
+//	vbroadcastsd	16+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	24+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			192(%r11), %zmm26 // A
+//	vbroadcastsd	8+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			192(%r11, %r12), %zmm28 {%k1}{z} // A
+//	vbroadcastsd	16+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	24+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+//	vmovapd			0(%r11), %zmm25 // A
+//	vbroadcastsd	8+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm1
+//	vfmadd231pd		%zmm28, %zmm24, %zmm9
+//	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+//	vbroadcastsd	16+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	24+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	addq	$ 256, %r13
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 // A
+	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+//	vbroadcastsd	8(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm27, %zmm24, %zmm9
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+
+	addq	$ 64, %r11
+	addq	$ 64, %r13
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_2vx1_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B
+// r14   <- m1
+// r15   <- n1
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// r14   <- m1
+// r15   <- n1
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_16X8_VS_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_16x8_vs_lib8)
+#endif
+
+	// compute mask for rows
+	vcvtsi2sd	%r14d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC01(%rip), %zmm24
+#elif defined(OS_MAC)
+	vmovupd		LC01(%rip), %zmm24
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm24, %zmm25
+	vpmovq2m	%zmm25, %k1
+
+	cmpl	$ 1, %r15d
+	jg		100f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_2VX1_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_2vx1_lib8)
+#endif
+	
+	jmp		107f
+
+100:
+
+	cmpl	$ 2, %r15d
+	jg		101f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_2VX2_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_2vx2_lib8)
+#endif
+	
+	jmp		107f
+
+101:
+
+	cmpl	$ 3, %r15d
+	jg		102f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_2VX3_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_2vx3_lib8)
+#endif
+	
+	jmp		107f
+
+102:
+
+	cmpl	$ 4, %r15d
+	jg		103f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_2VX4_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_2vx4_lib8)
+#endif
+	
+	jmp		107f
+
+103:
+
+	cmpl	$ 5, %r15d
+	jg		104f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_2VX5_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_2vx5_lib8)
+#endif
+	
+	jmp		107f
+
+104:
+
+	cmpl	$ 6, %r15d
+	jg		105f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_2VX6_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_2vx6_lib8)
+#endif
+	
+	jmp		107f
+
+105:
+
+	cmpl	$ 7, %r15d
+	jg		106f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_2VX7_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_2vx7_lib8)
+#endif
+	
+	jmp		107f
+
+106:
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_2VX8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_2vx8_lib8)
+#endif
+
+107:
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_16x8_vs_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
 // r12   <- B
 // r14   <- 4*sdb*sizeof(double)
 // zmm0  <- []
@@ -6049,11 +8538,13 @@ NAME:
 	movq	ARG4, %r12 // sda
 	sall	$ 6, %r12d // 8*sda*sizeof(double)
 	movq	ARG5, %r13 // B
+	movq	ARG11, %r14 // m1
+	movq	ARG12, %r15 // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_16X8_LIB8
+	INNER_KERNEL_DGEMM_NT_16X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_16x8_lib8)
+	CALL(inner_kernel_dgemm_nt_16x8_vs_lib8)
 #endif
 
 
@@ -6119,11 +8610,13 @@ NAME:
 	movq	ARG4, %r12 // sda
 	sall	$ 6, %r12d // 8*sda*sizeof(double)
 	movq	ARG5, %r13 // B
+	movq	ARG14, %r14 // m1
+	movq	ARG16, %r15 // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_16X8_LIB8
+	INNER_KERNEL_DGEMM_NT_16X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_16x8_lib8)
+	CALL(inner_kernel_dgemm_nt_16x8_vs_lib8)
 #endif
 
 
@@ -6262,11 +8755,13 @@ NAME:
 	movq	ARG5, %r12 // sdb
 	sall	$ 6, %r12d // 4*sdb*sizeof(double)
 	movq	ARG3, %r13 // A
+	movq	ARG10, %r14 // n1
+	movq	ARG9, %r15 // m1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_16X8_LIB8
+	INNER_KERNEL_DGEMM_NT_16X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_16x8_lib8)
+	CALL(inner_kernel_dgemm_nt_16x8_vs_lib8)
 #endif
 
 #if MACRO_LEVEL>=1
@@ -6882,11 +9377,13 @@ NAME:
 	movq	ARG4, %r12 // sda
 	sall	$ 6, %r12d // 8*sda*sizeof(double)
 	movq	ARG5, %r13 // B
+	movq	ARG11, %r14 // m1
+	movq	ARG12, %r15 // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_16X8_LIB8
+	INNER_KERNEL_DGEMM_NT_16X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_16x8_lib8)
+	CALL(inner_kernel_dgemm_nt_16x8_vs_lib8)
 #endif
 
 
@@ -6952,11 +9449,13 @@ NAME:
 	movq	ARG4, %r12 // sda
 	sall	$ 6, %r12d // 8*sda*sizeof(double)
 	movq	ARG5, %r13 // B
+	movq	ARG14, %r14 // m1
+	movq	ARG16, %r15 // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_16X8_LIB8
+	INNER_KERNEL_DGEMM_NT_16X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_16x8_lib8)
+	CALL(inner_kernel_dgemm_nt_16x8_vs_lib8)
 #endif
 
 
@@ -7348,11 +9847,13 @@ NAME:
 	movq	ARG3, %r12 // sda
 	sall	$ 6, %r12d // 4*sda*sizeof(double)
 	movq	ARG4, %r13 // B
+	movq	ARG12, %r14 // m1
+	movq	ARG13, %r15 // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_16X8_LIB8
+	INNER_KERNEL_DGEMM_NT_16X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_16x8_lib8)
+	CALL(inner_kernel_dgemm_nt_16x8_vs_lib8)
 #endif
 
 
@@ -7524,11 +10025,13 @@ NAME:
 	movq	ARG3, %r12 // sdap
 	sall	$ 6, %r12d   // 4*sdap*sizeof(double)
 	movq	ARG4, %r13  // Bp
+	movq	ARG15, %r14 // m1
+	movq	ARG16, %r15 // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_16X8_LIB8
+	INNER_KERNEL_DGEMM_NT_16X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_16x8_lib8)
+	CALL(inner_kernel_dgemm_nt_16x8_vs_lib8)
 #endif
 
 
@@ -7543,11 +10046,13 @@ NAME:
 	movq	ARG7, %r12 // sdam
 	sall	$ 6, %r12d // 4*sda*sizeof(double)
 	movq	ARG8, %r13  // Bm
+	movq	ARG15, %r14 // m1
+	movq	ARG16, %r15 // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_16X8_LIB8
+	INNER_KERNEL_DGEMM_NT_16X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_16x8_lib8)
+	CALL(inner_kernel_dgemm_nt_16x8_vs_lib8)
 #endif
 
 
@@ -7699,11 +10204,13 @@ NAME:
 	movq	ARG3, %r12
 	sall	$ 6, %r12d // 8*sda*sizeof(double)
 	movq	ARG4, %r13
+	movq	ARG10, %r14 // m1
+	movq	ARG11, %r15 // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_16X8_LIB8
+	INNER_KERNEL_DGEMM_NT_16X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_16x8_lib8)
+	CALL(inner_kernel_dgemm_nt_16x8_vs_lib8)
 #endif
 
 
@@ -7873,11 +10380,13 @@ NAME:
 	movq	ARG3, %r12 // sdap
 	sall	$ 6, %r12d   // 4*sdap*sizeof(double)
 	movq	ARG4, %r13  // Bp
+	movq	ARG14, %r14 // m1
+	movq	ARG15, %r15 // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_16X8_LIB8
+	INNER_KERNEL_DGEMM_NT_16X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_16x8_lib8)
+	CALL(inner_kernel_dgemm_nt_16x8_vs_lib8)
 #endif
 
 
@@ -7892,11 +10401,13 @@ NAME:
 	movq	ARG7, %r12 // sdam
 	sall	$ 6, %r12d // 4*sdam*sizeof(double)
 	movq	ARG8, %r13  // Bm
+	movq	ARG14, %r14 // m1
+	movq	ARG15, %r15 // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_16X8_LIB8
+	INNER_KERNEL_DGEMM_NT_16X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_16x8_lib8)
+	CALL(inner_kernel_dgemm_nt_16x8_vs_lib8)
 #endif
 
 

--- a/kernel/avx512/kernel_dgemm_16x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_16x8_lib8.S
@@ -2200,57 +2200,9 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+1*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm0, %zmm27, %zmm26
-	vfnmadd231pd	%zmm0, %zmm26, %zmm1
-	vfnmadd231pd	%zmm8, %zmm26, %zmm9
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+2*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+2*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm0, %zmm27, %zmm26
-	vfnmadd231pd	%zmm0, %zmm26, %zmm2
-	vfnmadd231pd	%zmm8, %zmm26, %zmm10
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+3*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+3*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm0, %zmm27, %zmm26
-	vfnmadd231pd	%zmm0, %zmm26, %zmm3
-	vfnmadd231pd	%zmm8, %zmm26, %zmm11
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+4*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+4*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm0, %zmm27, %zmm26
-	vfnmadd231pd	%zmm0, %zmm26, %zmm4
-	vfnmadd231pd	%zmm8, %zmm26, %zmm12
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+5*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+5*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm0, %zmm27, %zmm26
-	vfnmadd231pd	%zmm0, %zmm26, %zmm5
-	vfnmadd231pd	%zmm8, %zmm26, %zmm13
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+6*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+6*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm0, %zmm27, %zmm26
-	vfnmadd231pd	%zmm0, %zmm26, %zmm6
-	vfnmadd231pd	%zmm8, %zmm26, %zmm14
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+7*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+7*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm0, %zmm27, %zmm26
-	vfnmadd231pd	%zmm0, %zmm26, %zmm7
-	vfnmadd231pd	%zmm8, %zmm26, %zmm15
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm1
+	vfnmadd231pd	%zmm8, %zmm27, %zmm9
 
 	// 1
 //	vpermilpd		$ 0x3, %xmm1, %xmm26
@@ -2265,6 +2217,54 @@ NAME:
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 4:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm2
+	vfnmadd231pd	%zmm8, %zmm27, %zmm10
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm3
+	vfnmadd231pd	%zmm8, %zmm27, %zmm11
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm4
+	vfnmadd231pd	%zmm8, %zmm27, %zmm12
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm5
+	vfnmadd231pd	%zmm8, %zmm27, %zmm13
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm6
+	vfnmadd231pd	%zmm8, %zmm27, %zmm14
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm7
+	vfnmadd231pd	%zmm8, %zmm27, %zmm15
 	vmovsd			%xmm26, 8(%r10)
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm1, %zmm26, %zmm1
@@ -2276,49 +2276,9 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+2*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm1, %zmm27, %zmm26
-	vfnmadd231pd	%zmm1, %zmm26, %zmm2
-	vfnmadd231pd	%zmm9, %zmm26, %zmm10
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+3*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+3*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm1, %zmm27, %zmm26
-	vfnmadd231pd	%zmm1, %zmm26, %zmm3
-	vfnmadd231pd	%zmm9, %zmm26, %zmm11
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+4*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+4*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm1, %zmm27, %zmm26
-	vfnmadd231pd	%zmm1, %zmm26, %zmm4
-	vfnmadd231pd	%zmm9, %zmm26, %zmm12
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+5*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+5*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm1, %zmm27, %zmm26
-	vfnmadd231pd	%zmm1, %zmm26, %zmm5
-	vfnmadd231pd	%zmm9, %zmm26, %zmm13
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+6*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+6*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm1, %zmm27, %zmm26
-	vfnmadd231pd	%zmm1, %zmm26, %zmm6
-	vfnmadd231pd	%zmm9, %zmm26, %zmm14
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+7*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+7*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm1, %zmm27, %zmm26
-	vfnmadd231pd	%zmm1, %zmm26, %zmm7
-	vfnmadd231pd	%zmm9, %zmm26, %zmm15
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm2
+	vfnmadd231pd	%zmm9, %zmm27, %zmm10
 
 	// 2
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -2332,6 +2292,46 @@ NAME:
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 6:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm3
+	vfnmadd231pd	%zmm9, %zmm27, %zmm11
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm4
+	vfnmadd231pd	%zmm9, %zmm27, %zmm12
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm5
+	vfnmadd231pd	%zmm9, %zmm27, %zmm13
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm6
+	vfnmadd231pd	%zmm9, %zmm27, %zmm14
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm7
+	vfnmadd231pd	%zmm9, %zmm27, %zmm15
 	vmovsd			%xmm26, 16(%r10)
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm2, %zmm26, %zmm2
@@ -2343,41 +2343,9 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+3*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm2, %zmm27, %zmm26
-	vfnmadd231pd	%zmm2, %zmm26, %zmm3
-	vfnmadd231pd	%zmm10, %zmm26, %zmm11
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+4*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+4*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm2, %zmm27, %zmm26
-	vfnmadd231pd	%zmm2, %zmm26, %zmm4
-	vfnmadd231pd	%zmm10, %zmm26, %zmm12
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+5*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+5*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm2, %zmm27, %zmm26
-	vfnmadd231pd	%zmm2, %zmm26, %zmm5
-	vfnmadd231pd	%zmm10, %zmm26, %zmm13
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+6*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+6*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm2, %zmm27, %zmm26
-	vfnmadd231pd	%zmm2, %zmm26, %zmm6
-	vfnmadd231pd	%zmm10, %zmm26, %zmm14
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+7*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+7*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm2, %zmm27, %zmm26
-	vfnmadd231pd	%zmm2, %zmm26, %zmm7
-	vfnmadd231pd	%zmm10, %zmm26, %zmm15
+	vpermpd			%zmm2, %zmm27, %zmm28
+	vfnmadd231pd	%zmm2, %zmm28, %zmm3
+	vfnmadd231pd	%zmm10, %zmm28, %zmm11
 
 	// 3
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -2391,6 +2359,38 @@ NAME:
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 8:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm28
+	vfnmadd231pd	%zmm2, %zmm28, %zmm4
+	vfnmadd231pd	%zmm10, %zmm28, %zmm12
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm28
+	vfnmadd231pd	%zmm2, %zmm28, %zmm5
+	vfnmadd231pd	%zmm10, %zmm28, %zmm13
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm28
+	vfnmadd231pd	%zmm2, %zmm28, %zmm6
+	vfnmadd231pd	%zmm10, %zmm28, %zmm14
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm28
+	vfnmadd231pd	%zmm2, %zmm28, %zmm7
+	vfnmadd231pd	%zmm10, %zmm28, %zmm15
 	vmovsd			%xmm26, 24(%r10)
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm3, %zmm26, %zmm3
@@ -2402,33 +2402,9 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+4*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm3, %zmm27, %zmm26
-	vfnmadd231pd	%zmm3, %zmm26, %zmm4
-	vfnmadd231pd	%zmm11, %zmm26, %zmm12
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+5*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+5*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm3, %zmm27, %zmm26
-	vfnmadd231pd	%zmm3, %zmm26, %zmm5
-	vfnmadd231pd	%zmm11, %zmm26, %zmm13
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+6*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+6*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm3, %zmm27, %zmm26
-	vfnmadd231pd	%zmm3, %zmm26, %zmm6
-	vfnmadd231pd	%zmm11, %zmm26, %zmm14
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+7*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+7*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm3, %zmm27, %zmm26
-	vfnmadd231pd	%zmm3, %zmm26, %zmm7
-	vfnmadd231pd	%zmm11, %zmm26, %zmm15
+	vpermpd			%zmm3, %zmm27, %zmm27
+	vfnmadd231pd	%zmm3, %zmm27, %zmm4
+	vfnmadd231pd	%zmm11, %zmm27, %zmm12
 
 	// 4
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -2442,6 +2418,30 @@ NAME:
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 10:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm3, %zmm27, %zmm27
+	vfnmadd231pd	%zmm3, %zmm27, %zmm5
+	vfnmadd231pd	%zmm11, %zmm27, %zmm13
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm3, %zmm27, %zmm27
+	vfnmadd231pd	%zmm3, %zmm27, %zmm6
+	vfnmadd231pd	%zmm11, %zmm27, %zmm14
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm3, %zmm27, %zmm27
+	vfnmadd231pd	%zmm3, %zmm27, %zmm7
+	vfnmadd231pd	%zmm11, %zmm27, %zmm15
 	vmovsd			%xmm26, 32(%r10)
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm4, %zmm26, %zmm4
@@ -2453,25 +2453,9 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+5*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm4, %zmm27, %zmm26
-	vfnmadd231pd	%zmm4, %zmm26, %zmm5
-	vfnmadd231pd	%zmm12, %zmm26, %zmm13
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+6*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+6*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm4, %zmm27, %zmm26
-	vfnmadd231pd	%zmm4, %zmm26, %zmm6
-	vfnmadd231pd	%zmm12, %zmm26, %zmm14
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+7*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+7*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm4, %zmm27, %zmm26
-	vfnmadd231pd	%zmm4, %zmm26, %zmm7
-	vfnmadd231pd	%zmm12, %zmm26, %zmm15
+	vpermpd			%zmm4, %zmm27, %zmm27
+	vfnmadd231pd	%zmm4, %zmm27, %zmm5
+	vfnmadd231pd	%zmm12, %zmm27, %zmm13
 
 	// 5
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -2485,6 +2469,22 @@ NAME:
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 12:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm4, %zmm27, %zmm27
+	vfnmadd231pd	%zmm4, %zmm27, %zmm6
+	vfnmadd231pd	%zmm12, %zmm27, %zmm14
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm4, %zmm27, %zmm27
+	vfnmadd231pd	%zmm4, %zmm27, %zmm7
+	vfnmadd231pd	%zmm12, %zmm27, %zmm15
 	vmovsd			%xmm26, 40(%r10)
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm5, %zmm26, %zmm5
@@ -2496,17 +2496,9 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+6*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm5, %zmm27, %zmm26
-	vfnmadd231pd	%zmm5, %zmm26, %zmm6
-	vfnmadd231pd	%zmm13, %zmm26, %zmm14
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+7*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+7*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm5, %zmm27, %zmm26
-	vfnmadd231pd	%zmm5, %zmm26, %zmm7
-	vfnmadd231pd	%zmm13, %zmm26, %zmm15
+	vpermpd			%zmm5, %zmm27, %zmm27
+	vfnmadd231pd	%zmm5, %zmm27, %zmm6
+	vfnmadd231pd	%zmm13, %zmm27, %zmm14
 
 	// 6
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -2520,6 +2512,14 @@ NAME:
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 14:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm5, %zmm27, %zmm27
+	vfnmadd231pd	%zmm5, %zmm27, %zmm7
+	vfnmadd231pd	%zmm13, %zmm27, %zmm15
 	vmovsd			%xmm26, 48(%r10)
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm6, %zmm26, %zmm6
@@ -2531,9 +2531,9 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+7*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm6, %zmm27, %zmm26
-	vfnmadd231pd	%zmm6, %zmm26, %zmm7
-	vfnmadd231pd	%zmm14, %zmm26, %zmm15
+	vpermpd			%zmm6, %zmm27, %zmm27
+	vfnmadd231pd	%zmm6, %zmm27, %zmm7
+	vfnmadd231pd	%zmm14, %zmm27, %zmm15
 
 	// 7
 #if defined(OS_LINUX) | defined(OS_WINDOWS)

--- a/kernel/avx512/kernel_dgemm_16x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_16x8_lib8.S
@@ -7314,17 +7314,6 @@ NAME:
 
 
 
-//#if defined(BLAS_API)
-#if ( defined(BLAS_API) | ( defined(LA_HIGH_PERFORMANCE) & defined(MF_COLMAJ) ) )
-
-//#include "kernel_dgemm_16x8_lib.S"
-
-#endif
-
-
-
-
-
 //                                          1      2          3        4          5             6          7        8          9        10         11                  12      13
 // void kernel_dtrsm_nt_rl_inv_16x8_vs_lib8(int k, double *A, int sda, double *B, double *beta, double *C, int sdc, double *D, int sdd, double *E, double *inv_diag_E, int m1, int n1);
 

--- a/kernel/avx512/kernel_dgemm_16x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_16x8_lib8.S
@@ -2195,14 +2195,8 @@ NAME:
 	vmulpd			%zmm8, %zmm26, %zmm8
 	cmpl			$ 2, %r11d
 	jl				0f // ret
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+1*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+1*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm0, %zmm27, %zmm27
-	vfnmadd231pd	%zmm0, %zmm27, %zmm1
-	vfnmadd231pd	%zmm8, %zmm27, %zmm9
+	vmovapd			%zmm1, %zmm26
+	vfnmadd231pd	%zmm0, %zmm0, %zmm26
 
 	// 1
 //	vpermilpd		$ 0x3, %xmm1, %xmm26
@@ -2211,12 +2205,20 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+1*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm1, %zmm27, %zmm26
+	vpermpd			%zmm26, %zmm27, %zmm26
 	vucomisd		%xmm25, %xmm26 // d_11 > 0.0 ?
 	jbe				3f
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 4:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm1
+	vfnmadd231pd	%zmm8, %zmm27, %zmm9
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
 	vbroadcastsd	.LC05+2*8(%rip), %zmm27
 #elif defined(OS_MAC)
@@ -2271,14 +2273,8 @@ NAME:
 	vmulpd			%zmm9, %zmm26, %zmm9
 	cmpl			$ 3, %r11d
 	jl				0f // ret
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+2*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+2*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm1, %zmm27, %zmm27
-	vfnmadd231pd	%zmm1, %zmm27, %zmm2
-	vfnmadd231pd	%zmm9, %zmm27, %zmm10
+	vmovapd			%zmm2, %zmm26
+	vfnmadd231pd	%zmm1, %zmm1, %zmm26
 
 	// 2
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -2286,12 +2282,20 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+2*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm2, %zmm27, %zmm26
+	vpermpd			%zmm26, %zmm27, %zmm26
 	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
 	jbe				5f
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 6:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm2
+	vfnmadd231pd	%zmm9, %zmm27, %zmm10
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
 	vbroadcastsd	.LC05+3*8(%rip), %zmm27
 #elif defined(OS_MAC)
@@ -2338,14 +2342,8 @@ NAME:
 	vmulpd			%zmm10, %zmm26, %zmm10
 	cmpl			$ 4, %r11d
 	jl				0f // ret
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+3*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+3*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm2, %zmm27, %zmm28
-	vfnmadd231pd	%zmm2, %zmm28, %zmm3
-	vfnmadd231pd	%zmm10, %zmm28, %zmm11
+	vmovapd			%zmm3, %zmm26
+	vfnmadd231pd	%zmm2, %zmm2, %zmm26
 
 	// 3
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -2353,12 +2351,20 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+3*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm3, %zmm27, %zmm26
+	vpermpd			%zmm26, %zmm27, %zmm26
 	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
 	jbe				7f
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 8:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm28
+	vfnmadd231pd	%zmm2, %zmm28, %zmm3
+	vfnmadd231pd	%zmm10, %zmm28, %zmm11
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
 	vbroadcastsd	.LC05+4*8(%rip), %zmm27
 #elif defined(OS_MAC)
@@ -2397,14 +2403,8 @@ NAME:
 	vmulpd			%zmm11, %zmm26, %zmm11
 	cmpl			$ 5, %r11d
 	jl				0f // ret
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+4*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+4*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm3, %zmm27, %zmm27
-	vfnmadd231pd	%zmm3, %zmm27, %zmm4
-	vfnmadd231pd	%zmm11, %zmm27, %zmm12
+	vmovapd			%zmm4, %zmm26
+	vfnmadd231pd	%zmm3, %zmm3, %zmm26
 
 	// 4
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -2412,12 +2412,20 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+4*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm4, %zmm27, %zmm26
+	vpermpd			%zmm26, %zmm27, %zmm26
 	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
 	jbe				9f
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 10:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm3, %zmm27, %zmm27
+	vfnmadd231pd	%zmm3, %zmm27, %zmm4
+	vfnmadd231pd	%zmm11, %zmm27, %zmm12
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
 	vbroadcastsd	.LC05+5*8(%rip), %zmm27
 #elif defined(OS_MAC)
@@ -2448,14 +2456,8 @@ NAME:
 	vmulpd			%zmm12, %zmm26, %zmm12
 	cmpl			$ 6, %r11d
 	jl				0f // ret
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+5*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+5*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm4, %zmm27, %zmm27
-	vfnmadd231pd	%zmm4, %zmm27, %zmm5
-	vfnmadd231pd	%zmm12, %zmm27, %zmm13
+	vmovapd			%zmm5, %zmm26
+	vfnmadd231pd	%zmm4, %zmm4, %zmm26
 
 	// 5
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -2463,12 +2465,20 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+5*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm5, %zmm27, %zmm26
+	vpermpd			%zmm26, %zmm27, %zmm26
 	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
 	jbe				11f
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 12:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm4, %zmm27, %zmm27
+	vfnmadd231pd	%zmm4, %zmm27, %zmm5
+	vfnmadd231pd	%zmm12, %zmm27, %zmm13
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
 	vbroadcastsd	.LC05+6*8(%rip), %zmm27
 #elif defined(OS_MAC)
@@ -2491,14 +2501,8 @@ NAME:
 	vmulpd			%zmm13, %zmm26, %zmm13
 	cmpl			$ 7, %r11d
 	jl				0f // ret
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+6*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+6*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm5, %zmm27, %zmm27
-	vfnmadd231pd	%zmm5, %zmm27, %zmm6
-	vfnmadd231pd	%zmm13, %zmm27, %zmm14
+	vmovapd			%zmm6, %zmm26
+	vfnmadd231pd	%zmm5, %zmm5, %zmm26
 
 	// 6
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -2506,12 +2510,20 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+6*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm6, %zmm27, %zmm26
+	vpermpd			%zmm26, %zmm27, %zmm26
 	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
 	jbe				13f
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 14:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm5, %zmm27, %zmm27
+	vfnmadd231pd	%zmm5, %zmm27, %zmm6
+	vfnmadd231pd	%zmm13, %zmm27, %zmm14
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
 	vbroadcastsd	.LC05+7*8(%rip), %zmm27
 #elif defined(OS_MAC)
@@ -2526,14 +2538,8 @@ NAME:
 	vmulpd			%zmm14, %zmm26, %zmm14
 	cmpl			$ 8, %r11d
 	jl				0f // ret
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+7*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+7*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm6, %zmm27, %zmm27
-	vfnmadd231pd	%zmm6, %zmm27, %zmm7
-	vfnmadd231pd	%zmm14, %zmm27, %zmm15
+	vmovapd			%zmm7, %zmm26
+	vfnmadd231pd	%zmm6, %zmm6, %zmm26
 
 	// 7
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -2541,12 +2547,20 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+7*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm7, %zmm27, %zmm26
+	vpermpd			%zmm26, %zmm27, %zmm26
 	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
 	jbe				15f
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 16:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm6, %zmm27, %zmm27
+	vfnmadd231pd	%zmm6, %zmm27, %zmm7
+	vfnmadd231pd	%zmm14, %zmm27, %zmm15
 	vmovsd			%xmm26, 56(%r10)
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm7, %zmm26, %zmm7

--- a/kernel/avx512/kernel_dgemm_16x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_16x8_lib8.S
@@ -8626,6 +8626,590 @@ NAME:
 
 
 
+//                                    1       2       3            4            5           6           7        8           9        10          11
+// void kernel_dlarfb8_rn_lla_16_lib8(int n0, int n1, double *pVL, double *pVA, double *pT, double *pD, int sdd, double *pL, int sdl, double *pA, int sda);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dlarfb8_rn_lla_16_lib8)
+	
+	PROLOGUE
+
+	// zero accumulation registers
+
+//	ZERO_ACC
+
+	movq	ARG6, %r10 // D
+	movq	ARG7, %r11 // sdd
+	sall	$ 6, %r11d
+
+	// D
+	//
+	vmovapd			0*64(%r10), %zmm0
+	vmovapd			0*64(%r10, %r11), %zmm8
+	//
+	vmovapd			1*64(%r10), %zmm1
+	vmovapd			1*64(%r10, %r11), %zmm9
+	//
+	vmovapd			2*64(%r10), %zmm2
+	vmovapd			2*64(%r10, %r11), %zmm10
+	//
+	vmovapd			3*64(%r10), %zmm3
+	vmovapd			3*64(%r10, %r11), %zmm11
+	//
+	vmovapd			4*64(%r10), %zmm4
+	vmovapd			4*64(%r10, %r11), %zmm12
+	//
+	vmovapd			5*64(%r10), %zmm5
+	vmovapd			5*64(%r10, %r11), %zmm13
+	//
+	vmovapd			6*64(%r10), %zmm6
+	vmovapd			6*64(%r10, %r11), %zmm14
+	//
+	vmovapd			7*64(%r10), %zmm7
+	vmovapd			7*64(%r10, %r11), %zmm15
+
+	// L
+	movq	ARG1, %r10 // n0
+	movq	ARG8, %r11 // L
+	movq	ARG9, %r12 // sdl
+	sall	$ 6, %r12d
+	movq	ARG3, %r13 // VL
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_16X8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_16x8_lib8)
+#endif
+	
+	// L final 8x8 lower triangle
+	movq	ARG1, %r10 // n0
+	sall	$ 6, %r10d // n0*ps*sizeof(double)
+	movq	ARG8, %r11 // L
+	addq	%r10, %r11
+	movq	ARG3, %r13 // VL
+	addq	%r10, %r13
+
+	// L 7
+	vmovapd			0+0*64(%r11), %zmm25 // A
+	vmovapd			0+0*64(%r11, %r12), %zmm26 // A
+	vbroadcastsd	0+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vbroadcastsd	8+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vbroadcastsd	16+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vbroadcastsd	24+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vbroadcastsd	32+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vbroadcastsd	40+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vbroadcastsd	48+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vbroadcastsd	56+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	// L 6
+	vmovapd			0+1*64(%r11), %zmm25 // A
+	vmovapd			0+1*64(%r11, %r12), %zmm26 // A
+	vbroadcastsd	8+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vbroadcastsd	16+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vbroadcastsd	24+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vbroadcastsd	32+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vbroadcastsd	40+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vbroadcastsd	48+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vbroadcastsd	56+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	// L 5
+	vmovapd			0+2*64(%r11), %zmm25 // A
+	vmovapd			0+2*64(%r11, %r12), %zmm26 // A
+	vbroadcastsd	16+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vbroadcastsd	24+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vbroadcastsd	32+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vbroadcastsd	40+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vbroadcastsd	48+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vbroadcastsd	56+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	// L 4
+	vmovapd			0+3*64(%r11), %zmm25 // A
+	vmovapd			0+3*64(%r11, %r12), %zmm26 // A
+	vbroadcastsd	24+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vbroadcastsd	32+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vbroadcastsd	40+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vbroadcastsd	48+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vbroadcastsd	56+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	// L 3
+	vmovapd			0+4*64(%r11), %zmm25 // A
+	vmovapd			0+4*64(%r11, %r12), %zmm26 // A
+	vbroadcastsd	32+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vbroadcastsd	40+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vbroadcastsd	48+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vbroadcastsd	56+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	// L 2
+	vmovapd			0+5*64(%r11), %zmm25 // A
+	vmovapd			0+5*64(%r11, %r12), %zmm26 // A
+	vbroadcastsd	40+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vbroadcastsd	48+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vbroadcastsd	56+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	// L 1
+	vmovapd			0+6*64(%r11), %zmm25 // A
+	vmovapd			0+6*64(%r11, %r12), %zmm26 // A
+	vbroadcastsd	48+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vbroadcastsd	56+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	// L 0
+	vmovapd			0+7*64(%r11), %zmm25 // A
+	vmovapd			0+7*64(%r11, %r12), %zmm26 // A
+	vbroadcastsd	56+7*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+
+	// A
+	movq	ARG2, %r10 // n1
+	movq	ARG10, %r11 // A
+	movq	ARG11, %r12 // sda
+	sall	$ 6, %r12d
+	movq	ARG4, %r13 // VA
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_16X8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_16x8_lib8)
+#endif
+
+	// T
+	movq	ARG5, %r10 // T
+
+	//
+	vbroadcastsd	56+7*64(%r10), %zmm24
+	vmulpd			%zmm7, %zmm24, %zmm7
+	vmulpd			%zmm15, %zmm24, %zmm15
+	//
+	vbroadcastsd	48+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm6, %zmm24, %zmm7
+	vfmadd231pd		%zmm14, %zmm24, %zmm15
+	vbroadcastsd	48+6*64(%r10), %zmm24
+	vmulpd			%zmm6, %zmm24, %zmm6
+	vmulpd			%zmm14, %zmm24, %zmm14
+	//
+	vbroadcastsd	40+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm5, %zmm24, %zmm7
+	vfmadd231pd		%zmm13, %zmm24, %zmm15
+	vbroadcastsd	40+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm5, %zmm24, %zmm6
+	vfmadd231pd		%zmm13, %zmm24, %zmm14
+	vbroadcastsd	40+5*64(%r10), %zmm24
+	vmulpd			%zmm5, %zmm24, %zmm5
+	vmulpd			%zmm13, %zmm24, %zmm13
+	//
+	vbroadcastsd	32+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm7
+	vfmadd231pd		%zmm12, %zmm24, %zmm15
+	vbroadcastsd	32+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm6
+	vfmadd231pd		%zmm12, %zmm24, %zmm14
+	vbroadcastsd	32+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm5
+	vfmadd231pd		%zmm12, %zmm24, %zmm13
+	vbroadcastsd	32+4*64(%r10), %zmm24
+	vmulpd			%zmm4, %zmm24, %zmm4
+	vmulpd			%zmm12, %zmm24, %zmm12
+	//
+	vbroadcastsd	24+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm7
+	vfmadd231pd		%zmm11, %zmm24, %zmm15
+	vbroadcastsd	24+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm6
+	vfmadd231pd		%zmm11, %zmm24, %zmm14
+	vbroadcastsd	24+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm5
+	vfmadd231pd		%zmm11, %zmm24, %zmm13
+	vbroadcastsd	24+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm4
+	vfmadd231pd		%zmm11, %zmm24, %zmm12
+	vbroadcastsd	24+3*64(%r10), %zmm24
+	vmulpd			%zmm3, %zmm24, %zmm3
+	vmulpd			%zmm11, %zmm24, %zmm11
+	//
+	vbroadcastsd	16+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm7
+	vfmadd231pd		%zmm10, %zmm24, %zmm15
+	vbroadcastsd	16+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm6
+	vfmadd231pd		%zmm10, %zmm24, %zmm14
+	vbroadcastsd	16+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm5
+	vfmadd231pd		%zmm10, %zmm24, %zmm13
+	vbroadcastsd	16+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm4
+	vfmadd231pd		%zmm10, %zmm24, %zmm12
+	vbroadcastsd	16+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm3
+	vfmadd231pd		%zmm10, %zmm24, %zmm11
+	vbroadcastsd	16+2*64(%r10), %zmm24
+	vmulpd			%zmm2, %zmm24, %zmm2
+	vmulpd			%zmm10, %zmm24, %zmm10
+	//
+	vbroadcastsd	8+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm7
+	vfmadd231pd		%zmm9, %zmm24, %zmm15
+	vbroadcastsd	8+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm6
+	vfmadd231pd		%zmm9, %zmm24, %zmm14
+	vbroadcastsd	8+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm5
+	vfmadd231pd		%zmm9, %zmm24, %zmm13
+	vbroadcastsd	8+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm4
+	vfmadd231pd		%zmm9, %zmm24, %zmm12
+	vbroadcastsd	8+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm3
+	vfmadd231pd		%zmm9, %zmm24, %zmm11
+	vbroadcastsd	8+2*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm2
+	vfmadd231pd		%zmm9, %zmm24, %zmm10
+	vbroadcastsd	8+1*64(%r10), %zmm24
+	vmulpd			%zmm1, %zmm24, %zmm1
+	vmulpd			%zmm9, %zmm24, %zmm9
+	//
+	vbroadcastsd	0+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm7
+	vfmadd231pd		%zmm8, %zmm24, %zmm15
+	vbroadcastsd	0+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm6
+	vfmadd231pd		%zmm8, %zmm24, %zmm14
+	vbroadcastsd	0+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm5
+	vfmadd231pd		%zmm8, %zmm24, %zmm13
+	vbroadcastsd	0+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm4
+	vfmadd231pd		%zmm8, %zmm24, %zmm12
+	vbroadcastsd	0+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm3
+	vfmadd231pd		%zmm8, %zmm24, %zmm11
+	vbroadcastsd	0+2*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm2
+	vfmadd231pd		%zmm8, %zmm24, %zmm10
+	vbroadcastsd	0+1*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm1
+	vfmadd231pd		%zmm8, %zmm24, %zmm9
+	vbroadcastsd	0+0*64(%r10), %zmm24
+	vmulpd			%zmm0, %zmm24, %zmm0
+	vmulpd			%zmm8, %zmm24, %zmm8
+
+	// D
+	movq	ARG6, %r10 // D
+	movq	ARG7, %r11 // sdd
+	sall	$ 6, %r11d
+
+	//
+	vmovapd			0+0*64(%r10), %zmm24
+	vmovapd			0+0*64(%r10, %r11), %zmm26
+	vaddpd			%zmm24, %zmm0, %zmm24
+	vaddpd			%zmm26, %zmm8, %zmm26
+	vmovapd			%zmm24, 0+0*64(%r10)
+	vmovapd			%zmm26, 0+0*64(%r10, %r11)
+	//
+	vmovapd			0+1*64(%r10), %zmm24
+	vmovapd			0+1*64(%r10, %r11), %zmm26
+	vaddpd			%zmm24, %zmm1, %zmm24
+	vaddpd			%zmm26, %zmm9, %zmm26
+	vmovapd			%zmm24, 0+1*64(%r10)
+	vmovapd			%zmm26, 0+1*64(%r10, %r11)
+	//
+	vmovapd			0+2*64(%r10), %zmm24
+	vmovapd			0+2*64(%r10, %r11), %zmm26
+	vaddpd			%zmm24, %zmm2, %zmm24
+	vaddpd			%zmm26, %zmm10, %zmm26
+	vmovapd			%zmm24, 0+2*64(%r10)
+	vmovapd			%zmm26, 0+2*64(%r10, %r11)
+	//
+	vmovapd			0+3*64(%r10), %zmm24
+	vmovapd			0+3*64(%r10, %r11), %zmm26
+	vaddpd			%zmm24, %zmm3, %zmm24
+	vaddpd			%zmm26, %zmm11, %zmm26
+	vmovapd			%zmm24, 0+3*64(%r10)
+	vmovapd			%zmm26, 0+3*64(%r10, %r11)
+	//
+	vmovapd			0+4*64(%r10), %zmm24
+	vmovapd			0+4*64(%r10, %r11), %zmm26
+	vaddpd			%zmm24, %zmm4, %zmm24
+	vaddpd			%zmm26, %zmm12, %zmm26
+	vmovapd			%zmm24, 0+4*64(%r10)
+	vmovapd			%zmm26, 0+4*64(%r10, %r11)
+	//
+	vmovapd			0+5*64(%r10), %zmm24
+	vmovapd			0+5*64(%r10, %r11), %zmm26
+	vaddpd			%zmm24, %zmm5, %zmm24
+	vaddpd			%zmm26, %zmm13, %zmm26
+	vmovapd			%zmm24, 0+5*64(%r10)
+	vmovapd			%zmm26, 0+5*64(%r10, %r11)
+	//
+	vmovapd			0+6*64(%r10), %zmm24
+	vmovapd			0+6*64(%r10, %r11), %zmm26
+	vaddpd			%zmm24, %zmm6, %zmm24
+	vaddpd			%zmm26, %zmm14, %zmm26
+	vmovapd			%zmm24, 0+6*64(%r10)
+	vmovapd			%zmm26, 0+6*64(%r10, %r11)
+	//
+	vmovapd			0+7*64(%r10), %zmm24
+	vmovapd			0+7*64(%r10, %r11), %zmm26
+	vaddpd			%zmm24, %zmm7, %zmm24
+	vaddpd			%zmm26, %zmm15, %zmm26
+	vmovapd			%zmm24, 0+7*64(%r10)
+	vmovapd			%zmm26, 0+7*64(%r10, %r11)
+
+	// L
+	movq	ARG1, %r10 // n0
+	movq	ARG3, %r11 // VL
+	movq	ARG8, %r12 // L
+	movq	ARG9, %r13 // sdl
+	sall	$ 6, %r13d
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEBP_NN_16X8_LIB8
+#else
+	CALL(inner_kernel_dgebp_nn_16x8_lib8)
+#endif
+
+	// L final 8x8 lower triangle
+	movq	ARG1, %r10 // n0
+	sall	$ 6, %r10d // n0*ps*sizeof(double)
+	movq	ARG3, %r11 // VL
+	addq	%r10, %r11
+	movq	ARG8, %r12 // L
+	addq	%r10, %r12
+
+	// L 7
+	vmovapd			0*64(%r12), %zmm28
+	vmovapd			0*64(%r12, %r13), %zmm24
+	vbroadcastsd	0+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm0, %zmm23, %zmm28
+	vfmadd231pd		%zmm8, %zmm23, %zmm24
+	vbroadcastsd	8+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm1, %zmm23, %zmm28
+	vfmadd231pd		%zmm9, %zmm23, %zmm24
+	vbroadcastsd	16+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm2, %zmm23, %zmm28
+	vfmadd231pd		%zmm10, %zmm23, %zmm24
+	vbroadcastsd	24+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm3, %zmm23, %zmm28
+	vfmadd231pd		%zmm11, %zmm23, %zmm24
+	vbroadcastsd	32+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm4, %zmm23, %zmm28
+	vfmadd231pd		%zmm12, %zmm23, %zmm24
+	vbroadcastsd	40+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm5, %zmm23, %zmm28
+	vfmadd231pd		%zmm13, %zmm23, %zmm24
+	vbroadcastsd	48+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm6, %zmm23, %zmm28
+	vfmadd231pd		%zmm14, %zmm23, %zmm24
+	vbroadcastsd	56+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm7, %zmm23, %zmm28
+	vfmadd231pd		%zmm15, %zmm23, %zmm24
+	vmovapd			%zmm28, 0*64(%r12)
+	vmovapd			%zmm24, 0*64(%r12, %r13)
+	// L 6
+	vmovapd			1*64(%r12), %zmm28
+	vmovapd			1*64(%r12, %r13), %zmm24
+	vbroadcastsd	8+1*64(%r11), %zmm23
+	vfmadd231pd		%zmm1, %zmm23, %zmm28
+	vfmadd231pd		%zmm9, %zmm23, %zmm24
+	vbroadcastsd	16+1*64(%r11), %zmm23
+	vfmadd231pd		%zmm2, %zmm23, %zmm28
+	vfmadd231pd		%zmm10, %zmm23, %zmm24
+	vbroadcastsd	24+1*64(%r11), %zmm23
+	vfmadd231pd		%zmm3, %zmm23, %zmm28
+	vfmadd231pd		%zmm11, %zmm23, %zmm24
+	vbroadcastsd	32+1*64(%r11), %zmm23
+	vfmadd231pd		%zmm4, %zmm23, %zmm28
+	vfmadd231pd		%zmm12, %zmm23, %zmm24
+	vbroadcastsd	40+1*64(%r11), %zmm23
+	vfmadd231pd		%zmm5, %zmm23, %zmm28
+	vfmadd231pd		%zmm13, %zmm23, %zmm24
+	vbroadcastsd	48+1*64(%r11), %zmm23
+	vfmadd231pd		%zmm6, %zmm23, %zmm28
+	vfmadd231pd		%zmm14, %zmm23, %zmm24
+	vbroadcastsd	56+1*64(%r11), %zmm23
+	vfmadd231pd		%zmm7, %zmm23, %zmm28
+	vfmadd231pd		%zmm15, %zmm23, %zmm24
+	vmovapd			%zmm28, 1*64(%r12)
+	vmovapd			%zmm24, 1*64(%r12, %r13)
+	// L 5
+	vmovapd			2*64(%r12), %zmm28
+	vmovapd			2*64(%r12, %r13), %zmm24
+	vbroadcastsd	16+2*64(%r11), %zmm23
+	vfmadd231pd		%zmm2, %zmm23, %zmm28
+	vfmadd231pd		%zmm10, %zmm23, %zmm24
+	vbroadcastsd	24+2*64(%r11), %zmm23
+	vfmadd231pd		%zmm3, %zmm23, %zmm28
+	vfmadd231pd		%zmm11, %zmm23, %zmm24
+	vbroadcastsd	32+2*64(%r11), %zmm23
+	vfmadd231pd		%zmm4, %zmm23, %zmm28
+	vfmadd231pd		%zmm12, %zmm23, %zmm24
+	vbroadcastsd	40+2*64(%r11), %zmm23
+	vfmadd231pd		%zmm5, %zmm23, %zmm28
+	vfmadd231pd		%zmm13, %zmm23, %zmm24
+	vbroadcastsd	48+2*64(%r11), %zmm23
+	vfmadd231pd		%zmm6, %zmm23, %zmm28
+	vfmadd231pd		%zmm14, %zmm23, %zmm24
+	vbroadcastsd	56+2*64(%r11), %zmm23
+	vfmadd231pd		%zmm7, %zmm23, %zmm28
+	vfmadd231pd		%zmm15, %zmm23, %zmm24
+	vmovapd			%zmm28, 2*64(%r12)
+	vmovapd			%zmm24, 2*64(%r12, %r13)
+	// L 4
+	vmovapd			3*64(%r12), %zmm28
+	vmovapd			3*64(%r12, %r13), %zmm24
+	vbroadcastsd	24+3*64(%r11), %zmm23
+	vfmadd231pd		%zmm3, %zmm23, %zmm28
+	vfmadd231pd		%zmm11, %zmm23, %zmm24
+	vbroadcastsd	32+3*64(%r11), %zmm23
+	vfmadd231pd		%zmm4, %zmm23, %zmm28
+	vfmadd231pd		%zmm12, %zmm23, %zmm24
+	vbroadcastsd	40+3*64(%r11), %zmm23
+	vfmadd231pd		%zmm5, %zmm23, %zmm28
+	vfmadd231pd		%zmm13, %zmm23, %zmm24
+	vbroadcastsd	48+3*64(%r11), %zmm23
+	vfmadd231pd		%zmm6, %zmm23, %zmm28
+	vfmadd231pd		%zmm14, %zmm23, %zmm24
+	vbroadcastsd	56+3*64(%r11), %zmm23
+	vfmadd231pd		%zmm7, %zmm23, %zmm28
+	vfmadd231pd		%zmm15, %zmm23, %zmm24
+	vmovapd			%zmm28, 3*64(%r12)
+	vmovapd			%zmm24, 3*64(%r12, %r13)
+	// L 3
+	vmovapd			4*64(%r12), %zmm28
+	vmovapd			4*64(%r12, %r13), %zmm24
+	vbroadcastsd	32+4*64(%r11), %zmm23
+	vfmadd231pd		%zmm4, %zmm23, %zmm28
+	vfmadd231pd		%zmm12, %zmm23, %zmm24
+	vbroadcastsd	40+4*64(%r11), %zmm23
+	vfmadd231pd		%zmm5, %zmm23, %zmm28
+	vfmadd231pd		%zmm13, %zmm23, %zmm24
+	vbroadcastsd	48+4*64(%r11), %zmm23
+	vfmadd231pd		%zmm6, %zmm23, %zmm28
+	vfmadd231pd		%zmm14, %zmm23, %zmm24
+	vbroadcastsd	56+4*64(%r11), %zmm23
+	vfmadd231pd		%zmm7, %zmm23, %zmm28
+	vfmadd231pd		%zmm15, %zmm23, %zmm24
+	vmovapd			%zmm28, 4*64(%r12)
+	vmovapd			%zmm24, 4*64(%r12, %r13)
+	// L 2
+	vmovapd			5*64(%r12), %zmm28
+	vmovapd			5*64(%r12, %r13), %zmm24
+	vbroadcastsd	40+5*64(%r11), %zmm23
+	vfmadd231pd		%zmm5, %zmm23, %zmm28
+	vfmadd231pd		%zmm13, %zmm23, %zmm24
+	vbroadcastsd	48+5*64(%r11), %zmm23
+	vfmadd231pd		%zmm6, %zmm23, %zmm28
+	vfmadd231pd		%zmm14, %zmm23, %zmm24
+	vbroadcastsd	56+5*64(%r11), %zmm23
+	vfmadd231pd		%zmm7, %zmm23, %zmm28
+	vfmadd231pd		%zmm15, %zmm23, %zmm24
+	vmovapd			%zmm28, 5*64(%r12)
+	vmovapd			%zmm24, 5*64(%r12, %r13)
+	// L 1
+	vmovapd			6*64(%r12), %zmm28
+	vmovapd			6*64(%r12, %r13), %zmm24
+	vbroadcastsd	48+6*64(%r11), %zmm23
+	vfmadd231pd		%zmm6, %zmm23, %zmm28
+	vfmadd231pd		%zmm14, %zmm23, %zmm24
+	vbroadcastsd	56+6*64(%r11), %zmm23
+	vfmadd231pd		%zmm7, %zmm23, %zmm28
+	vfmadd231pd		%zmm15, %zmm23, %zmm24
+	vmovapd			%zmm28, 6*64(%r12)
+	vmovapd			%zmm24, 6*64(%r12, %r13)
+	// L 0
+	vmovapd			7*64(%r12), %zmm28
+	vmovapd			7*64(%r12, %r13), %zmm24
+	vbroadcastsd	56+7*64(%r11), %zmm23
+	vfmadd231pd		%zmm7, %zmm23, %zmm28
+	vfmadd231pd		%zmm15, %zmm23, %zmm24
+	vmovapd			%zmm28, 7*64(%r12)
+	vmovapd			%zmm24, 7*64(%r12, %r13)
+
+	// A
+	movq	ARG2, %r10 // n1
+	movq	ARG4, %r11 // VA
+	movq	ARG10, %r12 // A
+	movq	ARG11, %r13 // sda
+	sall	$ 6, %r13d
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEBP_NN_16X8_LIB8
+#else
+	CALL(inner_kernel_dgebp_nn_16x8_lib8)
+#endif
+
+	EPILOGUE
+
+	ret
+
+	FUN_END(kernel_dlarfb8_rn_lla_16_lib8)
+
+
+
+
+
 //#if defined(BLAS_API)
 #if ( defined(BLAS_API) | ( defined(LA_HIGH_PERFORMANCE) & defined(MF_COLMAJ) ) )
 

--- a/kernel/avx512/kernel_dgemm_16x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_16x8_lib8.S
@@ -8371,6 +8371,261 @@ NAME:
 
 
 
+//                                   1         2            3           4           5        6           7
+// void kernel_dlarfb8_rn_la_16_lib8(int kmax, double *pVA, double *pT, double *pD, int sdd, double *pA, int sda);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dlarfb8_rn_la_16_lib8)
+	
+	PROLOGUE
+
+	// zero accumulation registers
+
+//	ZERO_ACC
+
+	movq	ARG4, %r10 // D
+	movq	ARG5, %r11 // sdd
+	sall	$ 6, %r11d
+
+	//
+	vmovapd			0*64(%r10), %zmm0
+	vmovapd			0*64(%r10, %r11), %zmm8
+	//
+	vmovapd			1*64(%r10), %zmm1
+	vmovapd			1*64(%r10, %r11), %zmm9
+	//
+	vmovapd			2*64(%r10), %zmm2
+	vmovapd			2*64(%r10, %r11), %zmm10
+	//
+	vmovapd			3*64(%r10), %zmm3
+	vmovapd			3*64(%r10, %r11), %zmm11
+	//
+	vmovapd			4*64(%r10), %zmm4
+	vmovapd			4*64(%r10, %r11), %zmm12
+	//
+	vmovapd			5*64(%r10), %zmm5
+	vmovapd			5*64(%r10, %r11), %zmm13
+	//
+	vmovapd			6*64(%r10), %zmm6
+	vmovapd			6*64(%r10, %r11), %zmm14
+	//
+	vmovapd			7*64(%r10), %zmm7
+	vmovapd			7*64(%r10, %r11), %zmm15
+
+	movq	ARG1, %r10 // k
+	movq	ARG6, %r11 // A
+	movq	ARG7, %r12 // sda
+	sall	$ 6, %r12d
+	movq	ARG2, %r13 // VA
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_16X8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_16x8_lib8)
+#endif
+
+	movq	ARG3, %r10 // T
+
+	//
+	vbroadcastsd	56+7*64(%r10), %zmm24
+	vmulpd			%zmm7, %zmm24, %zmm7
+	vmulpd			%zmm15, %zmm24, %zmm15
+	//
+	vbroadcastsd	48+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm6, %zmm24, %zmm7
+	vfmadd231pd		%zmm14, %zmm24, %zmm15
+	vbroadcastsd	48+6*64(%r10), %zmm24
+	vmulpd			%zmm6, %zmm24, %zmm6
+	vmulpd			%zmm14, %zmm24, %zmm14
+	//
+	vbroadcastsd	40+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm5, %zmm24, %zmm7
+	vfmadd231pd		%zmm13, %zmm24, %zmm15
+	vbroadcastsd	40+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm5, %zmm24, %zmm6
+	vfmadd231pd		%zmm13, %zmm24, %zmm14
+	vbroadcastsd	40+5*64(%r10), %zmm24
+	vmulpd			%zmm5, %zmm24, %zmm5
+	vmulpd			%zmm13, %zmm24, %zmm13
+	//
+	vbroadcastsd	32+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm7
+	vfmadd231pd		%zmm12, %zmm24, %zmm15
+	vbroadcastsd	32+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm6
+	vfmadd231pd		%zmm12, %zmm24, %zmm14
+	vbroadcastsd	32+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm5
+	vfmadd231pd		%zmm12, %zmm24, %zmm13
+	vbroadcastsd	32+4*64(%r10), %zmm24
+	vmulpd			%zmm4, %zmm24, %zmm4
+	vmulpd			%zmm12, %zmm24, %zmm12
+	//
+	vbroadcastsd	24+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm7
+	vfmadd231pd		%zmm11, %zmm24, %zmm15
+	vbroadcastsd	24+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm6
+	vfmadd231pd		%zmm11, %zmm24, %zmm14
+	vbroadcastsd	24+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm5
+	vfmadd231pd		%zmm11, %zmm24, %zmm13
+	vbroadcastsd	24+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm4
+	vfmadd231pd		%zmm11, %zmm24, %zmm12
+	vbroadcastsd	24+3*64(%r10), %zmm24
+	vmulpd			%zmm3, %zmm24, %zmm3
+	vmulpd			%zmm11, %zmm24, %zmm11
+	//
+	vbroadcastsd	16+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm7
+	vfmadd231pd		%zmm10, %zmm24, %zmm15
+	vbroadcastsd	16+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm6
+	vfmadd231pd		%zmm10, %zmm24, %zmm14
+	vbroadcastsd	16+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm5
+	vfmadd231pd		%zmm10, %zmm24, %zmm13
+	vbroadcastsd	16+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm4
+	vfmadd231pd		%zmm10, %zmm24, %zmm12
+	vbroadcastsd	16+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm3
+	vfmadd231pd		%zmm10, %zmm24, %zmm11
+	vbroadcastsd	16+2*64(%r10), %zmm24
+	vmulpd			%zmm2, %zmm24, %zmm2
+	vmulpd			%zmm10, %zmm24, %zmm10
+	//
+	vbroadcastsd	8+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm7
+	vfmadd231pd		%zmm9, %zmm24, %zmm15
+	vbroadcastsd	8+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm6
+	vfmadd231pd		%zmm9, %zmm24, %zmm14
+	vbroadcastsd	8+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm5
+	vfmadd231pd		%zmm9, %zmm24, %zmm13
+	vbroadcastsd	8+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm4
+	vfmadd231pd		%zmm9, %zmm24, %zmm12
+	vbroadcastsd	8+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm3
+	vfmadd231pd		%zmm9, %zmm24, %zmm11
+	vbroadcastsd	8+2*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm2
+	vfmadd231pd		%zmm9, %zmm24, %zmm10
+	vbroadcastsd	8+1*64(%r10), %zmm24
+	vmulpd			%zmm1, %zmm24, %zmm1
+	vmulpd			%zmm9, %zmm24, %zmm9
+	//
+	vbroadcastsd	0+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm7
+	vfmadd231pd		%zmm8, %zmm24, %zmm15
+	vbroadcastsd	0+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm6
+	vfmadd231pd		%zmm8, %zmm24, %zmm14
+	vbroadcastsd	0+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm5
+	vfmadd231pd		%zmm8, %zmm24, %zmm13
+	vbroadcastsd	0+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm4
+	vfmadd231pd		%zmm8, %zmm24, %zmm12
+	vbroadcastsd	0+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm3
+	vfmadd231pd		%zmm8, %zmm24, %zmm11
+	vbroadcastsd	0+2*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm2
+	vfmadd231pd		%zmm8, %zmm24, %zmm10
+	vbroadcastsd	0+1*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm1
+	vfmadd231pd		%zmm8, %zmm24, %zmm9
+	vbroadcastsd	0+0*64(%r10), %zmm24
+	vmulpd			%zmm0, %zmm24, %zmm0
+	vmulpd			%zmm8, %zmm24, %zmm8
+
+	movq	ARG4, %r10 // D
+	movq	ARG5, %r11 // sdd
+	sall	$ 6, %r11d
+
+	//
+	vmovapd			0+0*64(%r10), %zmm24
+	vmovapd			0+0*64(%r10, %r11), %zmm26
+	vaddpd			%zmm24, %zmm0, %zmm24
+	vaddpd			%zmm26, %zmm8, %zmm26
+	vmovapd			%zmm24, 0+0*64(%r10)
+	vmovapd			%zmm26, 0+0*64(%r10, %r11)
+	//
+	vmovapd			0+1*64(%r10), %zmm24
+	vmovapd			0+1*64(%r10, %r11), %zmm26
+	vaddpd			%zmm24, %zmm1, %zmm24
+	vaddpd			%zmm26, %zmm9, %zmm26
+	vmovapd			%zmm24, 0+1*64(%r10)
+	vmovapd			%zmm26, 0+1*64(%r10, %r11)
+	//
+	vmovapd			0+2*64(%r10), %zmm24
+	vmovapd			0+2*64(%r10, %r11), %zmm26
+	vaddpd			%zmm24, %zmm2, %zmm24
+	vaddpd			%zmm26, %zmm10, %zmm26
+	vmovapd			%zmm24, 0+2*64(%r10)
+	vmovapd			%zmm26, 0+2*64(%r10, %r11)
+	//
+	vmovapd			0+3*64(%r10), %zmm24
+	vmovapd			0+3*64(%r10, %r11), %zmm26
+	vaddpd			%zmm24, %zmm3, %zmm24
+	vaddpd			%zmm26, %zmm11, %zmm26
+	vmovapd			%zmm24, 0+3*64(%r10)
+	vmovapd			%zmm26, 0+3*64(%r10, %r11)
+	//
+	vmovapd			0+4*64(%r10), %zmm24
+	vmovapd			0+4*64(%r10, %r11), %zmm26
+	vaddpd			%zmm24, %zmm4, %zmm24
+	vaddpd			%zmm26, %zmm12, %zmm26
+	vmovapd			%zmm24, 0+4*64(%r10)
+	vmovapd			%zmm26, 0+4*64(%r10, %r11)
+	//
+	vmovapd			0+5*64(%r10), %zmm24
+	vmovapd			0+5*64(%r10, %r11), %zmm26
+	vaddpd			%zmm24, %zmm5, %zmm24
+	vaddpd			%zmm26, %zmm13, %zmm26
+	vmovapd			%zmm24, 0+5*64(%r10)
+	vmovapd			%zmm26, 0+5*64(%r10, %r11)
+	//
+	vmovapd			0+6*64(%r10), %zmm24
+	vmovapd			0+6*64(%r10, %r11), %zmm26
+	vaddpd			%zmm24, %zmm6, %zmm24
+	vaddpd			%zmm26, %zmm14, %zmm26
+	vmovapd			%zmm24, 0+6*64(%r10)
+	vmovapd			%zmm26, 0+6*64(%r10, %r11)
+	//
+	vmovapd			0+7*64(%r10), %zmm24
+	vmovapd			0+7*64(%r10, %r11), %zmm26
+	vaddpd			%zmm24, %zmm7, %zmm24
+	vaddpd			%zmm26, %zmm15, %zmm26
+	vmovapd			%zmm24, 0+7*64(%r10)
+	vmovapd			%zmm26, 0+7*64(%r10, %r11)
+
+	movq	ARG1, %r10 // k
+	movq	ARG2, %r11 // VA
+	movq	ARG6, %r12 // A
+	movq	ARG7, %r13 // sda
+	sall	$ 6, %r13d
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEBP_NN_16X8_LIB8
+#else
+	CALL(inner_kernel_dgebp_nn_16x8_lib8)
+#endif
+
+	EPILOGUE
+
+	ret
+
+	FUN_END(kernel_dlarfb8_rn_la_16_lib8)
+
+
+
+
+
 //#if defined(BLAS_API)
 #if ( defined(BLAS_API) | ( defined(LA_HIGH_PERFORMANCE) & defined(MF_COLMAJ) ) )
 

--- a/kernel/avx512/kernel_dgemm_16x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_16x8_lib8.S
@@ -3180,8 +3180,14 @@ NAME:
 	jle		2f // return
 
 	// prefetch
-//	prefetcht0	0(%r13) // software prefetch
-//	prefetcht0	0+64(%r13) // software prefetch
+	prefetcht0	0*64(%r13) // software prefetch
+	prefetcht0	1*64(%r13) // software prefetch
+	prefetcht0	2*64(%r13) // software prefetch
+	prefetcht0	3*64(%r13) // software prefetch
+	prefetcht0	4*64(%r13) // software prefetch
+	prefetcht0	5*64(%r13) // software prefetch
+	prefetcht0	6*64(%r13) // software prefetch
+	prefetcht0	7*64(%r13) // software prefetch
 
 	// preload
 	vmovapd 		0(%r11), %zmm25 // A0
@@ -3194,35 +3200,40 @@ NAME:
 	.p2align 3
 1: // main loop
 
-//	prefetcht0	128(%r13) // software prefetch
-//	prefetcht0	128+64(%r13) // software prefetch
-
 	// unroll 0
 	vbroadcastsd	0*64(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	prefetcht0	0*64(%r13, %r14) // software prefetch
 	vfmadd231pd		%zmm27, %zmm24, %zmm8
 	vmovapd			1*64(%r11), %zmm26 // A
 	vbroadcastsd	1*64(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	prefetcht0	1*64(%r13, %r14) // software prefetch
 	vfmadd231pd		%zmm27, %zmm24, %zmm9
 	vmovapd			1*64(%r11, %r12), %zmm28 // A
 	vbroadcastsd	2*64(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	prefetcht0	2*64(%r13, %r14) // software prefetch
 	vfmadd231pd		%zmm27, %zmm24, %zmm10
 	vbroadcastsd	3*64(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	prefetcht0	3*64(%r13, %r14) // software prefetch
 	vfmadd231pd		%zmm27, %zmm24, %zmm11
 	vbroadcastsd	4*64(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	prefetcht0	4*64(%r13, %r14) // software prefetch
 	vfmadd231pd		%zmm27, %zmm24, %zmm12
 	vbroadcastsd	5*64(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	prefetcht0	5*64(%r13, %r14) // software prefetch
 	vfmadd231pd		%zmm27, %zmm24, %zmm13
 	vbroadcastsd	6*64(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	prefetcht0	6*64(%r13, %r14) // software prefetch
 	vfmadd231pd		%zmm27, %zmm24, %zmm14
 	vbroadcastsd	7*64(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	prefetcht0	7*64(%r13, %r14) // software prefetch
 	vfmadd231pd		%zmm27, %zmm24, %zmm15
 	subl	$ 8, %r10d
 

--- a/kernel/avx512/kernel_dgemm_16x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_16x8_lib8.S
@@ -1232,6 +1232,233 @@ NAME:
 
 // common inner routine with file scope
 //
+// input arguments:
+// r10d  <- k
+// r11   <- B
+// r12   <- C
+// r13   <- 64*sdc
+// zmm0  <- [a00 ... a70]
+// ...
+// zmm7  <- [a07 ... a77]
+// zmm8  <- [a87 ... af7]
+// ...
+// zmm15 <- [a87 ... af7]
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- ?
+// r12   <- ?
+// r13   <- 64*sdc
+// zmm0  <- [a00 ... a70]
+// ...
+// zmm7  <- [a07 ... a77]
+// zmm8  <- [a87 ... af7]
+// ...
+// zmm15 <- [a87 ... af7]
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEBP_NN_16X8_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgebp_nn_16x8_lib8)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		0f // return
+
+	cmpl	$ 3, %r10d
+	jle		2f // cleanup loop
+
+	// main loop
+	.p2align 
+1:
+	// merged k-iter 0-3 to have more independent acc
+	vmovapd			0*64(%r12), %zmm28
+	vmovapd			0*64(%r12, %r13), %zmm24
+	vbroadcastsd	0+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm0, %zmm23, %zmm28
+	vfmadd231pd		%zmm8, %zmm23, %zmm24
+	vmovapd			1*64(%r12), %zmm29
+	vmovapd			1*64(%r12, %r13), %zmm25
+	vbroadcastsd	0+1*64(%r11), %zmm23
+	vfmadd231pd		%zmm0, %zmm23, %zmm29
+	vfmadd231pd		%zmm8, %zmm23, %zmm25
+	vmovapd			2*64(%r12), %zmm30
+	vmovapd			2*64(%r12, %r13), %zmm26
+	vbroadcastsd	0+2*64(%r11), %zmm23
+	vfmadd231pd		%zmm0, %zmm23, %zmm30
+	vfmadd231pd		%zmm8, %zmm23, %zmm26
+	vmovapd			3*64(%r12), %zmm31
+	vmovapd			3*64(%r12, %r13), %zmm27
+	vbroadcastsd	0+3*64(%r11), %zmm23
+	vfmadd231pd		%zmm0, %zmm23, %zmm31
+	vfmadd231pd		%zmm8, %zmm23, %zmm27
+
+	vbroadcastsd	8+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm1, %zmm23, %zmm28
+	vfmadd231pd		%zmm9, %zmm23, %zmm24
+	vbroadcastsd	8+1*64(%r11), %zmm23
+	vfmadd231pd		%zmm1, %zmm23, %zmm29
+	vfmadd231pd		%zmm9, %zmm23, %zmm25
+	vbroadcastsd	8+2*64(%r11), %zmm23
+	vfmadd231pd		%zmm1, %zmm23, %zmm30
+	vfmadd231pd		%zmm9, %zmm23, %zmm26
+	vbroadcastsd	8+3*64(%r11), %zmm23
+	vfmadd231pd		%zmm1, %zmm23, %zmm31
+	vfmadd231pd		%zmm9, %zmm23, %zmm27
+
+	vbroadcastsd	16+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm2, %zmm23, %zmm28
+	vfmadd231pd		%zmm10, %zmm23, %zmm24
+	vbroadcastsd	16+1*64(%r11), %zmm23
+	vfmadd231pd		%zmm2, %zmm23, %zmm29
+	vfmadd231pd		%zmm10, %zmm23, %zmm25
+	vbroadcastsd	16+2*64(%r11), %zmm23
+	vfmadd231pd		%zmm2, %zmm23, %zmm30
+	vfmadd231pd		%zmm10, %zmm23, %zmm26
+	vbroadcastsd	16+3*64(%r11), %zmm23
+	vfmadd231pd		%zmm2, %zmm23, %zmm31
+	vfmadd231pd		%zmm10, %zmm23, %zmm27
+
+	vbroadcastsd	24+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm3, %zmm23, %zmm28
+	vfmadd231pd		%zmm11, %zmm23, %zmm24
+	vbroadcastsd	24+1*64(%r11), %zmm23
+	vfmadd231pd		%zmm3, %zmm23, %zmm29
+	vfmadd231pd		%zmm11, %zmm23, %zmm25
+	vbroadcastsd	24+2*64(%r11), %zmm23
+	vfmadd231pd		%zmm3, %zmm23, %zmm30
+	vfmadd231pd		%zmm11, %zmm23, %zmm26
+	vbroadcastsd	24+3*64(%r11), %zmm23
+	vfmadd231pd		%zmm3, %zmm23, %zmm31
+	vfmadd231pd		%zmm11, %zmm23, %zmm27
+
+	vbroadcastsd	32+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm4, %zmm23, %zmm28
+	vfmadd231pd		%zmm12, %zmm23, %zmm24
+	vbroadcastsd	32+1*64(%r11), %zmm23
+	vfmadd231pd		%zmm4, %zmm23, %zmm29
+	vfmadd231pd		%zmm12, %zmm23, %zmm25
+	vbroadcastsd	32+2*64(%r11), %zmm23
+	vfmadd231pd		%zmm4, %zmm23, %zmm30
+	vfmadd231pd		%zmm12, %zmm23, %zmm26
+	vbroadcastsd	32+3*64(%r11), %zmm23
+	vfmadd231pd		%zmm4, %zmm23, %zmm31
+	vfmadd231pd		%zmm12, %zmm23, %zmm27
+
+	vbroadcastsd	40+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm5, %zmm23, %zmm28
+	vfmadd231pd		%zmm13, %zmm23, %zmm24
+	vbroadcastsd	40+1*64(%r11), %zmm23
+	vfmadd231pd		%zmm5, %zmm23, %zmm29
+	vfmadd231pd		%zmm13, %zmm23, %zmm25
+	vbroadcastsd	40+2*64(%r11), %zmm23
+	vfmadd231pd		%zmm5, %zmm23, %zmm30
+	vfmadd231pd		%zmm13, %zmm23, %zmm26
+	vbroadcastsd	40+3*64(%r11), %zmm23
+	vfmadd231pd		%zmm5, %zmm23, %zmm31
+	vfmadd231pd		%zmm13, %zmm23, %zmm27
+
+	vbroadcastsd	48+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm6, %zmm23, %zmm28
+	vfmadd231pd		%zmm14, %zmm23, %zmm24
+	vbroadcastsd	48+1*64(%r11), %zmm23
+	vfmadd231pd		%zmm6, %zmm23, %zmm29
+	vfmadd231pd		%zmm14, %zmm23, %zmm25
+	vbroadcastsd	48+2*64(%r11), %zmm23
+	vfmadd231pd		%zmm6, %zmm23, %zmm30
+	vfmadd231pd		%zmm14, %zmm23, %zmm26
+	vbroadcastsd	48+3*64(%r11), %zmm23
+	vfmadd231pd		%zmm6, %zmm23, %zmm31
+	vfmadd231pd		%zmm14, %zmm23, %zmm27
+
+	vbroadcastsd	56+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm7, %zmm23, %zmm28
+	vfmadd231pd		%zmm15, %zmm23, %zmm24
+	vmovapd			%zmm28, 0*64(%r12)
+	vmovapd			%zmm24, 0*64(%r12, %r13)
+	vbroadcastsd	56+1*64(%r11), %zmm23
+	vfmadd231pd		%zmm7, %zmm23, %zmm29
+	vfmadd231pd		%zmm15, %zmm23, %zmm25
+	vmovapd			%zmm29, 1*64(%r12)
+	vmovapd			%zmm25, 1*64(%r12, %r13)
+	vbroadcastsd	56+2*64(%r11), %zmm23
+	vfmadd231pd		%zmm7, %zmm23, %zmm30
+	vfmadd231pd		%zmm15, %zmm23, %zmm26
+	vmovapd			%zmm30, 2*64(%r12)
+	vmovapd			%zmm26, 2*64(%r12, %r13)
+	vbroadcastsd	56+3*64(%r11), %zmm23
+	vfmadd231pd		%zmm7, %zmm23, %zmm31
+	vfmadd231pd		%zmm15, %zmm23, %zmm27
+	vmovapd			%zmm31, 3*64(%r12)
+	vmovapd			%zmm27, 3*64(%r12, %r13)
+
+	addq	$ 256, %r11
+	addq	$ 256, %r12
+	subl	$ 4, %r10d
+
+	cmpl	$ 3, %r10d
+	jg		1b // main loop
+
+	cmpl	$ 0, %r10d
+	jle		0f // return
+
+	// cleanup loop
+2:
+	vmovapd			0*64(%r12), %zmm28
+	vmovapd			0*64(%r12, %r13), %zmm24
+	vbroadcastsd	0+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm0, %zmm23, %zmm28
+	vfmadd231pd		%zmm8, %zmm23, %zmm24
+	vbroadcastsd	8+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm1, %zmm23, %zmm28
+	vfmadd231pd		%zmm9, %zmm23, %zmm24
+	vbroadcastsd	16+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm2, %zmm23, %zmm28
+	vfmadd231pd		%zmm10, %zmm23, %zmm24
+	vbroadcastsd	24+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm3, %zmm23, %zmm28
+	vfmadd231pd		%zmm11, %zmm23, %zmm24
+	vbroadcastsd	32+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm4, %zmm23, %zmm28
+	vfmadd231pd		%zmm12, %zmm23, %zmm24
+	vbroadcastsd	40+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm5, %zmm23, %zmm28
+	vfmadd231pd		%zmm13, %zmm23, %zmm24
+	vbroadcastsd	48+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm6, %zmm23, %zmm28
+	vfmadd231pd		%zmm14, %zmm23, %zmm24
+	vbroadcastsd	56+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm7, %zmm23, %zmm28
+	vfmadd231pd		%zmm15, %zmm23, %zmm24
+	vmovapd			%zmm28, 0*64(%r12)
+	vmovapd			%zmm24, 0*64(%r12, %r13)
+
+	subl	$ 1, %r10d
+	addq	$ 64, %r11
+	addq	$ 64, %r12
+
+	cmpl	$ 0, %r10d
+	jg		2b // main loop
+
+	// return
+0:
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgebp_nn_16x8_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
 // edge for B unaligned
 //
 // input arguments:
@@ -7716,6 +7943,429 @@ NAME:
 	ret
 
 	FUN_END(kernel_dsyrk_dpotrf_nt_l_16x8_vs_lib8)
+
+
+
+
+
+//                                1         2           3           4           5
+// void kernel_dlarfb8_rn_16_lib8(int kmax, double *pV, double *pT, double *pD, int sdd);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dlarfb8_rn_16_lib8)
+	
+	PROLOGUE
+
+	// zero accumulation registers
+
+//	ZERO_ACC
+
+	movq	ARG1, %r10 // k
+	movq	ARG4, %r11 // D
+	movq	ARG5, %r12 // sdd
+	sall	$ 6, %r12d
+	movq	ARG2, %r13 // V
+
+	//
+	vmovapd			0*64(%r11), %zmm0
+	vmovapd			0*64(%r11, %r12), %zmm8
+	//
+	vmovapd			1*64(%r11), %zmm1
+	vmovapd			1*64(%r11, %r12), %zmm9
+	vbroadcastsd	1*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm1, %zmm0
+	vfmadd231pd		%zmm24, %zmm9, %zmm8
+	//
+	vmovapd			2*64(%r11), %zmm2
+	vmovapd			2*64(%r11, %r12), %zmm10
+	vbroadcastsd	0+2*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm2, %zmm0
+	vfmadd231pd		%zmm24, %zmm10, %zmm8
+	vbroadcastsd	8+2*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm2, %zmm1
+	vfmadd231pd		%zmm24, %zmm10, %zmm9
+	//
+	vmovapd			3*64(%r11), %zmm3
+	vmovapd			3*64(%r11, %r12), %zmm11
+	vbroadcastsd	0+3*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm3, %zmm0
+	vfmadd231pd		%zmm24, %zmm11, %zmm8
+	vbroadcastsd	8+3*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm3, %zmm1
+	vfmadd231pd		%zmm24, %zmm11, %zmm9
+	vbroadcastsd	16+3*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm3, %zmm2
+	vfmadd231pd		%zmm24, %zmm11, %zmm10
+	//
+	vmovapd			4*64(%r11), %zmm4
+	vmovapd			4*64(%r11, %r12), %zmm12
+	vbroadcastsd	0+4*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm4, %zmm0
+	vfmadd231pd		%zmm24, %zmm12, %zmm8
+	vbroadcastsd	8+4*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm4, %zmm1
+	vfmadd231pd		%zmm24, %zmm12, %zmm9
+	vbroadcastsd	16+4*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm4, %zmm2
+	vfmadd231pd		%zmm24, %zmm12, %zmm10
+	vbroadcastsd	24+4*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm4, %zmm3
+	vfmadd231pd		%zmm24, %zmm12, %zmm11
+	//
+	vmovapd			5*64(%r11), %zmm5
+	vmovapd			5*64(%r11, %r12), %zmm13
+	vbroadcastsd	0+5*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm5, %zmm0
+	vfmadd231pd		%zmm24, %zmm13, %zmm8
+	vbroadcastsd	8+5*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm5, %zmm1
+	vfmadd231pd		%zmm24, %zmm13, %zmm9
+	vbroadcastsd	16+5*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm5, %zmm2
+	vfmadd231pd		%zmm24, %zmm13, %zmm10
+	vbroadcastsd	24+5*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm5, %zmm3
+	vfmadd231pd		%zmm24, %zmm13, %zmm11
+	vbroadcastsd	32+5*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm5, %zmm4
+	vfmadd231pd		%zmm24, %zmm13, %zmm12
+	//
+	vmovapd			6*64(%r11), %zmm6
+	vmovapd			6*64(%r11, %r12), %zmm14
+	vbroadcastsd	0+6*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm6, %zmm0
+	vfmadd231pd		%zmm24, %zmm14, %zmm8
+	vbroadcastsd	8+6*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm6, %zmm1
+	vfmadd231pd		%zmm24, %zmm14, %zmm9
+	vbroadcastsd	16+6*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm6, %zmm2
+	vfmadd231pd		%zmm24, %zmm14, %zmm10
+	vbroadcastsd	24+6*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm6, %zmm3
+	vfmadd231pd		%zmm24, %zmm14, %zmm11
+	vbroadcastsd	32+6*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm6, %zmm4
+	vfmadd231pd		%zmm24, %zmm14, %zmm12
+	vbroadcastsd	40+6*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm6, %zmm5
+	vfmadd231pd		%zmm24, %zmm14, %zmm13
+	//
+	vmovapd			7*64(%r11), %zmm7
+	vmovapd			7*64(%r11, %r12), %zmm15
+	vbroadcastsd	0+7*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm7, %zmm0
+	vfmadd231pd		%zmm24, %zmm15, %zmm8
+	vbroadcastsd	8+7*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm7, %zmm1
+	vfmadd231pd		%zmm24, %zmm15, %zmm9
+	vbroadcastsd	16+7*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm7, %zmm2
+	vfmadd231pd		%zmm24, %zmm15, %zmm10
+	vbroadcastsd	24+7*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm7, %zmm3
+	vfmadd231pd		%zmm24, %zmm15, %zmm11
+	vbroadcastsd	32+7*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm7, %zmm4
+	vfmadd231pd		%zmm24, %zmm15, %zmm12
+	vbroadcastsd	40+7*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm7, %zmm5
+	vfmadd231pd		%zmm24, %zmm15, %zmm13
+	vbroadcastsd	48+7*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm7, %zmm6
+	vfmadd231pd		%zmm24, %zmm15, %zmm14
+
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+	addq	$ 512, %r13
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_16X8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_16x8_lib8)
+#endif
+
+	movq	ARG3, %r10 // T
+
+	//
+	vbroadcastsd	56+7*64(%r10), %zmm24
+	vmulpd			%zmm7, %zmm24, %zmm7
+	vmulpd			%zmm15, %zmm24, %zmm15
+	//
+	vbroadcastsd	48+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm6, %zmm24, %zmm7
+	vfmadd231pd		%zmm14, %zmm24, %zmm15
+	vbroadcastsd	48+6*64(%r10), %zmm24
+	vmulpd			%zmm6, %zmm24, %zmm6
+	vmulpd			%zmm14, %zmm24, %zmm14
+	//
+	vbroadcastsd	40+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm5, %zmm24, %zmm7
+	vfmadd231pd		%zmm13, %zmm24, %zmm15
+	vbroadcastsd	40+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm5, %zmm24, %zmm6
+	vfmadd231pd		%zmm13, %zmm24, %zmm14
+	vbroadcastsd	40+5*64(%r10), %zmm24
+	vmulpd			%zmm5, %zmm24, %zmm5
+	vmulpd			%zmm13, %zmm24, %zmm13
+	//
+	vbroadcastsd	32+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm7
+	vfmadd231pd		%zmm12, %zmm24, %zmm15
+	vbroadcastsd	32+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm6
+	vfmadd231pd		%zmm12, %zmm24, %zmm14
+	vbroadcastsd	32+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm5
+	vfmadd231pd		%zmm12, %zmm24, %zmm13
+	vbroadcastsd	32+4*64(%r10), %zmm24
+	vmulpd			%zmm4, %zmm24, %zmm4
+	vmulpd			%zmm12, %zmm24, %zmm12
+	//
+	vbroadcastsd	24+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm7
+	vfmadd231pd		%zmm11, %zmm24, %zmm15
+	vbroadcastsd	24+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm6
+	vfmadd231pd		%zmm11, %zmm24, %zmm14
+	vbroadcastsd	24+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm5
+	vfmadd231pd		%zmm11, %zmm24, %zmm13
+	vbroadcastsd	24+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm4
+	vfmadd231pd		%zmm11, %zmm24, %zmm12
+	vbroadcastsd	24+3*64(%r10), %zmm24
+	vmulpd			%zmm3, %zmm24, %zmm3
+	vmulpd			%zmm11, %zmm24, %zmm11
+	//
+	vbroadcastsd	16+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm7
+	vfmadd231pd		%zmm10, %zmm24, %zmm15
+	vbroadcastsd	16+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm6
+	vfmadd231pd		%zmm10, %zmm24, %zmm14
+	vbroadcastsd	16+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm5
+	vfmadd231pd		%zmm10, %zmm24, %zmm13
+	vbroadcastsd	16+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm4
+	vfmadd231pd		%zmm10, %zmm24, %zmm12
+	vbroadcastsd	16+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm3
+	vfmadd231pd		%zmm10, %zmm24, %zmm11
+	vbroadcastsd	16+2*64(%r10), %zmm24
+	vmulpd			%zmm2, %zmm24, %zmm2
+	vmulpd			%zmm10, %zmm24, %zmm10
+	//
+	vbroadcastsd	8+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm7
+	vfmadd231pd		%zmm9, %zmm24, %zmm15
+	vbroadcastsd	8+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm6
+	vfmadd231pd		%zmm9, %zmm24, %zmm14
+	vbroadcastsd	8+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm5
+	vfmadd231pd		%zmm9, %zmm24, %zmm13
+	vbroadcastsd	8+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm4
+	vfmadd231pd		%zmm9, %zmm24, %zmm12
+	vbroadcastsd	8+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm3
+	vfmadd231pd		%zmm9, %zmm24, %zmm11
+	vbroadcastsd	8+2*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm2
+	vfmadd231pd		%zmm9, %zmm24, %zmm10
+	vbroadcastsd	8+1*64(%r10), %zmm24
+	vmulpd			%zmm1, %zmm24, %zmm1
+	vmulpd			%zmm9, %zmm24, %zmm9
+	//
+	vbroadcastsd	0+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm7
+	vfmadd231pd		%zmm8, %zmm24, %zmm15
+	vbroadcastsd	0+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm6
+	vfmadd231pd		%zmm8, %zmm24, %zmm14
+	vbroadcastsd	0+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm5
+	vfmadd231pd		%zmm8, %zmm24, %zmm13
+	vbroadcastsd	0+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm4
+	vfmadd231pd		%zmm8, %zmm24, %zmm12
+	vbroadcastsd	0+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm3
+	vfmadd231pd		%zmm8, %zmm24, %zmm11
+	vbroadcastsd	0+2*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm2
+	vfmadd231pd		%zmm8, %zmm24, %zmm10
+	vbroadcastsd	0+1*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm1
+	vfmadd231pd		%zmm8, %zmm24, %zmm9
+	vbroadcastsd	0+0*64(%r10), %zmm24
+	vmulpd			%zmm0, %zmm24, %zmm0
+	vmulpd			%zmm8, %zmm24, %zmm8
+
+	movq	ARG1, %r10 // k
+	movq	ARG2, %r11 // V
+	movq	ARG4, %r12 // D
+	movq	ARG5, %r13 // sdd
+	sall	$ 6, %r13d
+
+	//
+	vmovapd			0+0*64(%r12), %zmm24
+	vmovapd			0+0*64(%r12, %r13), %zmm26
+	vaddpd			%zmm24, %zmm0, %zmm24
+	vaddpd			%zmm26, %zmm8, %zmm26
+	vmovapd			%zmm24, 0+0*64(%r12)
+	vmovapd			%zmm26, 0+0*64(%r12, %r13)
+	//
+	vmovapd			0+1*64(%r12), %zmm24
+	vmovapd			0+1*64(%r12, %r13), %zmm26
+	vbroadcastsd	0+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm24
+	vfmadd231pd		%zmm8, %zmm25, %zmm26
+	vaddpd			%zmm24, %zmm1, %zmm24
+	vaddpd			%zmm26, %zmm9, %zmm26
+	vmovapd			%zmm24, 0+1*64(%r12)
+	vmovapd			%zmm26, 0+1*64(%r12, %r13)
+	//
+	vmovapd			0+2*64(%r12), %zmm24
+	vmovapd			0+2*64(%r12, %r13), %zmm26
+	vbroadcastsd	0+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm24
+	vfmadd231pd		%zmm8, %zmm25, %zmm26
+	vbroadcastsd	8+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm24
+	vfmadd231pd		%zmm9, %zmm25, %zmm26
+	vaddpd			%zmm24, %zmm2, %zmm24
+	vaddpd			%zmm26, %zmm10, %zmm26
+	vmovapd			%zmm24, 0+2*64(%r12)
+	vmovapd			%zmm26, 0+2*64(%r12, %r13)
+	//
+	vmovapd			0+3*64(%r12), %zmm24
+	vmovapd			0+3*64(%r12, %r13), %zmm26
+	vbroadcastsd	0+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm24
+	vfmadd231pd		%zmm8, %zmm25, %zmm26
+	vbroadcastsd	8+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm24
+	vfmadd231pd		%zmm9, %zmm25, %zmm26
+	vbroadcastsd	16+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm24
+	vfmadd231pd		%zmm10, %zmm25, %zmm26
+	vaddpd			%zmm24, %zmm3, %zmm24
+	vaddpd			%zmm26, %zmm11, %zmm26
+	vmovapd			%zmm24, 0+3*64(%r12)
+	vmovapd			%zmm26, 0+3*64(%r12, %r13)
+	//
+	vmovapd			0+4*64(%r12), %zmm24
+	vmovapd			0+4*64(%r12, %r13), %zmm26
+	vbroadcastsd	0+4*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm24
+	vfmadd231pd		%zmm8, %zmm25, %zmm26
+	vbroadcastsd	8+4*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm24
+	vfmadd231pd		%zmm9, %zmm25, %zmm26
+	vbroadcastsd	16+4*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm24
+	vfmadd231pd		%zmm10, %zmm25, %zmm26
+	vbroadcastsd	24+4*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm24
+	vfmadd231pd		%zmm11, %zmm25, %zmm26
+	vaddpd			%zmm24, %zmm4, %zmm24
+	vaddpd			%zmm26, %zmm12, %zmm26
+	vmovapd			%zmm24, 0+4*64(%r12)
+	vmovapd			%zmm26, 0+4*64(%r12, %r13)
+	//
+	vmovapd			0+5*64(%r12), %zmm24
+	vmovapd			0+5*64(%r12, %r13), %zmm26
+	vbroadcastsd	0+5*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm24
+	vfmadd231pd		%zmm8, %zmm25, %zmm26
+	vbroadcastsd	8+5*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm24
+	vfmadd231pd		%zmm9, %zmm25, %zmm26
+	vbroadcastsd	16+5*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm24
+	vfmadd231pd		%zmm10, %zmm25, %zmm26
+	vbroadcastsd	24+5*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm24
+	vfmadd231pd		%zmm11, %zmm25, %zmm26
+	vbroadcastsd	32+5*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm24
+	vfmadd231pd		%zmm12, %zmm25, %zmm26
+	vaddpd			%zmm24, %zmm5, %zmm24
+	vaddpd			%zmm26, %zmm13, %zmm26
+	vmovapd			%zmm24, 0+5*64(%r12)
+	vmovapd			%zmm26, 0+5*64(%r12, %r13)
+	//
+	vmovapd			0+6*64(%r12), %zmm24
+	vmovapd			0+6*64(%r12, %r13), %zmm26
+	vbroadcastsd	0+6*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm24
+	vfmadd231pd		%zmm8, %zmm25, %zmm26
+	vbroadcastsd	8+6*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm24
+	vfmadd231pd		%zmm9, %zmm25, %zmm26
+	vbroadcastsd	16+6*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm24
+	vfmadd231pd		%zmm10, %zmm25, %zmm26
+	vbroadcastsd	24+6*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm24
+	vfmadd231pd		%zmm11, %zmm25, %zmm26
+	vbroadcastsd	32+6*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm24
+	vfmadd231pd		%zmm12, %zmm25, %zmm26
+	vbroadcastsd	40+6*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm24
+	vfmadd231pd		%zmm13, %zmm25, %zmm26
+	vaddpd			%zmm24, %zmm6, %zmm24
+	vaddpd			%zmm26, %zmm14, %zmm26
+	vmovapd			%zmm24, 0+6*64(%r12)
+	vmovapd			%zmm26, 0+6*64(%r12, %r13)
+	//
+	vmovapd			0+7*64(%r12), %zmm24
+	vmovapd			0+7*64(%r12, %r13), %zmm26
+	vbroadcastsd	0+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm24
+	vfmadd231pd		%zmm8, %zmm25, %zmm26
+	vbroadcastsd	8+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm24
+	vfmadd231pd		%zmm9, %zmm25, %zmm26
+	vbroadcastsd	16+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm24
+	vfmadd231pd		%zmm10, %zmm25, %zmm26
+	vbroadcastsd	24+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm24
+	vfmadd231pd		%zmm11, %zmm25, %zmm26
+	vbroadcastsd	32+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm24
+	vfmadd231pd		%zmm12, %zmm25, %zmm26
+	vbroadcastsd	40+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm24
+	vfmadd231pd		%zmm13, %zmm25, %zmm26
+	vbroadcastsd	48+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm6, %zmm25, %zmm24
+	vfmadd231pd		%zmm14, %zmm25, %zmm26
+	vaddpd			%zmm24, %zmm7, %zmm24
+	vaddpd			%zmm26, %zmm15, %zmm26
+	vmovapd			%zmm24, 0+7*64(%r12)
+	vmovapd			%zmm26, 0+7*64(%r12, %r13)
+
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+	addq	$ 512, %r12
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEBP_NN_16X8_LIB8
+#else
+	CALL(inner_kernel_dgebp_nn_16x8_lib8)
+#endif
+
+	EPILOGUE
+
+	ret
+
+	FUN_END(kernel_dlarfb8_rn_16_lib8)
 
 
 

--- a/kernel/avx512/kernel_dgemm_16x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_16x8_lib8.S
@@ -3154,7 +3154,7 @@ NAME:
 // r14   <- 4*sdb*sizeof(double)
 // zmm0  <- []
 // ...
-// zmm7  <- []
+// zmm15 <- []
 
 //
 // output arguments:
@@ -3165,7 +3165,7 @@ NAME:
 // r14   <- 4*sdb*sizeof(double)
 // zmm0  <- []
 // ...
-// zmm7  <- []
+// zmm15 <- []
 
 #if MACRO_LEVEL>=2
 	.macro INNER_KERNEL_DGEMM_NN_16X8_LIB8
@@ -3713,6 +3713,3962 @@ NAME:
 	ret
 
 	FUN_END(inner_kernel_dgemm_nn_16x8_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r12   <- B
+// r14   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15 <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// r14   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15 <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_2VX8_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_2vx8_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+//	prefetcht0	0(%r13) // software prefetch
+//	prefetcht0	0+64(%r13) // software prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 // A0
+	vmovapd 		0(%r11, %r12), %zmm27 {%k1}{z} // A1
+
+	cmpl	$ 8, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+//	prefetcht0	128(%r13) // software prefetch
+//	prefetcht0	128+64(%r13) // software prefetch
+
+	// unroll 0
+	vbroadcastsd	0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			1*64(%r11), %zmm26 // A
+	vbroadcastsd	1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			1*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vbroadcastsd	6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+	vbroadcastsd	7*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			2*64(%r11), %zmm25 // A
+	vbroadcastsd	8+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			2*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	8+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	8+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	8+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	8+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vbroadcastsd	8+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+	vbroadcastsd	8+7*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			3*64(%r11), %zmm26 // A
+	vbroadcastsd	16+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			3*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	16+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	16+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	16+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vbroadcastsd	16+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+	vbroadcastsd	16+7*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm27, %zmm24, %zmm15
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			4*64(%r11), %zmm25 // A
+	vbroadcastsd	24+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			4*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	24+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	24+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	24+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vbroadcastsd	24+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+	vbroadcastsd	24+7*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			5*64(%r11), %zmm26 // A
+	vbroadcastsd	32+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			5*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	32+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	32+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	32+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	32+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vbroadcastsd	32+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+	vbroadcastsd	32+7*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm27, %zmm24, %zmm15
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			6*64(%r11), %zmm25 // A
+	vbroadcastsd	40+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			6*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	40+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	40+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	40+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	40+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vbroadcastsd	40+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+	vbroadcastsd	40+7*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			7*64(%r11), %zmm26 // A
+	vbroadcastsd	48+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			7*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	48+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	48+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	48+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	48+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vbroadcastsd	48+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+	vbroadcastsd	48+7*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			0*64(%r11), %zmm25 // A
+	vbroadcastsd	56+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			0*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	56+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	56+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	56+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	56+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vbroadcastsd	56+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+	vbroadcastsd	56+7*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	vfmadd231pd		%zmm28, %zmm24, %zmm15
+	addq	%r14, %r13
+
+	cmpl	$ 8, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean8-up
+	
+	cmpl	$ 7, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			1*64(%r11), %zmm26 // A
+	vbroadcastsd	1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			1*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vbroadcastsd	6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+	vbroadcastsd	7*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			2*64(%r11), %zmm25 // A
+	vbroadcastsd	8+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			2*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	8+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	8+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	8+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	8+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vbroadcastsd	8+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+	vbroadcastsd	8+7*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			3*64(%r11), %zmm26 // A
+	vbroadcastsd	16+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			3*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	16+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	16+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	16+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vbroadcastsd	16+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+	vbroadcastsd	16+7*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm27, %zmm24, %zmm15
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			4*64(%r11), %zmm25 // A
+	vbroadcastsd	24+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			4*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	24+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	24+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	24+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vbroadcastsd	24+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+	vbroadcastsd	24+7*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			5*64(%r11), %zmm26 // A
+	vbroadcastsd	32+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			5*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	32+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	32+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	32+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	32+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vbroadcastsd	32+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+	vbroadcastsd	32+7*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm27, %zmm24, %zmm15
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			6*64(%r11), %zmm25 // A
+	vbroadcastsd	40+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			6*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	40+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	40+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	40+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	40+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vbroadcastsd	40+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+	vbroadcastsd	40+7*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			7*64(%r11), %zmm26 // A
+	vbroadcastsd	48+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			7*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	48+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	48+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	48+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	48+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vbroadcastsd	48+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+	vbroadcastsd	48+7*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+//	vmovapd			0*64(%r11), %zmm25 // A
+	vbroadcastsd	56+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+//	vmovapd			0*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	56+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	56+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	56+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	56+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vbroadcastsd	56+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+	vbroadcastsd	56+7*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	vfmadd231pd		%zmm28, %zmm24, %zmm15
+	addq	%r14, %r13
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 // A
+	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vbroadcastsd	1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vbroadcastsd	2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vbroadcastsd	6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+	vbroadcastsd	7*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm27, %zmm24, %zmm15
+
+	addq	$ 64, %r11
+	addq	$ 8, %r13
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_2vx8_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r12   <- B
+// r14   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15 <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// r14   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15 <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_2VX7_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_2vx7_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+//	prefetcht0	0(%r13) // software prefetch
+//	prefetcht0	0+64(%r13) // software prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 // A0
+	vmovapd 		0(%r11, %r12), %zmm27 {%k1}{z} // A1
+
+	cmpl	$ 8, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+//	prefetcht0	128(%r13) // software prefetch
+//	prefetcht0	128+64(%r13) // software prefetch
+
+	// unroll 0
+	vbroadcastsd	0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			1*64(%r11), %zmm26 // A
+	vbroadcastsd	1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			1*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vbroadcastsd	6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			2*64(%r11), %zmm25 // A
+	vbroadcastsd	8+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			2*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	8+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	8+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	8+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	8+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vbroadcastsd	8+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	8+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			3*64(%r11), %zmm26 // A
+	vbroadcastsd	16+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			3*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	16+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	16+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	16+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vbroadcastsd	16+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	16+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			4*64(%r11), %zmm25 // A
+	vbroadcastsd	24+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			4*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	24+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	24+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	24+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vbroadcastsd	24+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	24+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			5*64(%r11), %zmm26 // A
+	vbroadcastsd	32+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			5*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	32+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	32+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	32+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	32+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vbroadcastsd	32+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	32+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			6*64(%r11), %zmm25 // A
+	vbroadcastsd	40+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			6*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	40+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	40+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	40+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	40+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vbroadcastsd	40+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	40+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			7*64(%r11), %zmm26 // A
+	vbroadcastsd	48+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			7*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	48+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	48+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	48+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	48+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vbroadcastsd	48+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	48+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			0*64(%r11), %zmm25 // A
+	vbroadcastsd	56+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			0*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	56+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	56+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	56+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	56+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vbroadcastsd	56+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	56+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+	addq	%r14, %r13
+
+	cmpl	$ 8, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean8-up
+	
+	cmpl	$ 7, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			1*64(%r11), %zmm26 // A
+	vbroadcastsd	1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			1*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vbroadcastsd	6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			2*64(%r11), %zmm25 // A
+	vbroadcastsd	8+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			2*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	8+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	8+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	8+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	8+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vbroadcastsd	8+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	8+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			3*64(%r11), %zmm26 // A
+	vbroadcastsd	16+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			3*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	16+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	16+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	16+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vbroadcastsd	16+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	16+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			4*64(%r11), %zmm25 // A
+	vbroadcastsd	24+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			4*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	24+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	24+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	24+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vbroadcastsd	24+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	24+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			5*64(%r11), %zmm26 // A
+	vbroadcastsd	32+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			5*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	32+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	32+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	32+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	32+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vbroadcastsd	32+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	32+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			6*64(%r11), %zmm25 // A
+	vbroadcastsd	40+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			6*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	40+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	40+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	40+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	40+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vbroadcastsd	40+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	40+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			7*64(%r11), %zmm26 // A
+	vbroadcastsd	48+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			7*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	48+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	48+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	48+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	48+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vbroadcastsd	48+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	48+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+//	vmovapd			0*64(%r11), %zmm25 // A
+	vbroadcastsd	56+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+//	vmovapd			0*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	56+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	56+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	56+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	56+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vbroadcastsd	56+6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	56+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+	addq	%r14, %r13
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 // A
+	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vbroadcastsd	1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vbroadcastsd	2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vbroadcastsd	6*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+
+	addq	$ 64, %r11
+	addq	$ 8, %r13
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_2vx7_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r12   <- B
+// r14   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15 <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// r14   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15 <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_2VX6_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_2vx6_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+//	prefetcht0	0(%r13) // software prefetch
+//	prefetcht0	0+64(%r13) // software prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 // A0
+	vmovapd 		0(%r11, %r12), %zmm27 {%k1}{z} // A1
+
+	cmpl	$ 8, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+//	prefetcht0	128(%r13) // software prefetch
+//	prefetcht0	128+64(%r13) // software prefetch
+
+	// unroll 0
+	vbroadcastsd	0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			1*64(%r11), %zmm26 // A
+	vbroadcastsd	1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			1*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vbroadcastsd	6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			2*64(%r11), %zmm25 // A
+	vbroadcastsd	8+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			2*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	8+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	8+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	8+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	8+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+//	vbroadcastsd	8+6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	8+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			3*64(%r11), %zmm26 // A
+	vbroadcastsd	16+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			3*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	16+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	16+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	16+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vbroadcastsd	16+6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	16+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			4*64(%r11), %zmm25 // A
+	vbroadcastsd	24+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			4*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	24+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	24+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	24+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+//	vbroadcastsd	24+6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	24+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			5*64(%r11), %zmm26 // A
+	vbroadcastsd	32+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			5*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	32+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	32+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	32+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	32+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vbroadcastsd	32+6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	32+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			6*64(%r11), %zmm25 // A
+	vbroadcastsd	40+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			6*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	40+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	40+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	40+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	40+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+//	vbroadcastsd	40+6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	40+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			7*64(%r11), %zmm26 // A
+	vbroadcastsd	48+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			7*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	48+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	48+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	48+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	48+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vbroadcastsd	48+6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	48+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			0*64(%r11), %zmm25 // A
+	vbroadcastsd	56+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			0*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	56+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	56+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	56+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	56+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+//	vbroadcastsd	56+6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	56+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+	addq	%r14, %r13
+
+	cmpl	$ 8, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean8-up
+	
+	cmpl	$ 7, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			1*64(%r11), %zmm26 // A
+	vbroadcastsd	1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			1*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vbroadcastsd	6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			2*64(%r11), %zmm25 // A
+	vbroadcastsd	8+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			2*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	8+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	8+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	8+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	8+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+//	vbroadcastsd	8+6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	8+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			3*64(%r11), %zmm26 // A
+	vbroadcastsd	16+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			3*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	16+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	16+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	16+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vbroadcastsd	16+6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	16+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			4*64(%r11), %zmm25 // A
+	vbroadcastsd	24+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			4*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	24+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	24+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	24+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+//	vbroadcastsd	24+6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	24+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			5*64(%r11), %zmm26 // A
+	vbroadcastsd	32+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			5*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	32+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	32+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	32+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	32+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vbroadcastsd	32+6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	32+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			6*64(%r11), %zmm25 // A
+	vbroadcastsd	40+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			6*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	40+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	40+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	40+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	40+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+//	vbroadcastsd	40+6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	40+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			7*64(%r11), %zmm26 // A
+	vbroadcastsd	48+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			7*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	48+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	48+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	48+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	48+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vbroadcastsd	48+6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	48+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+//	vmovapd			0*64(%r11), %zmm25 // A
+	vbroadcastsd	56+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+//	vmovapd			0*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	56+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	56+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	56+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vbroadcastsd	56+5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+//	vbroadcastsd	56+6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	56+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+	addq	%r14, %r13
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 // A
+	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vbroadcastsd	1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vbroadcastsd	2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vbroadcastsd	5*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vbroadcastsd	6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+
+	addq	$ 64, %r11
+	addq	$ 8, %r13
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_2vx6_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r12   <- B
+// r14   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15 <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// r14   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15 <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_2VX5_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_2vx5_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+//	prefetcht0	0(%r13) // software prefetch
+//	prefetcht0	0+64(%r13) // software prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 // A0
+	vmovapd 		0(%r11, %r12), %zmm27 {%k1}{z} // A1
+
+	cmpl	$ 8, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+//	prefetcht0	128(%r13) // software prefetch
+//	prefetcht0	128+64(%r13) // software prefetch
+
+	// unroll 0
+	vbroadcastsd	0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			1*64(%r11), %zmm26 // A
+	vbroadcastsd	1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			1*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+//	vbroadcastsd	5*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vbroadcastsd	6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			2*64(%r11), %zmm25 // A
+	vbroadcastsd	8+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			2*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	8+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	8+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	8+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+//	vbroadcastsd	8+5*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vfmadd231pd		%zmm28, %zmm24, %zmm13
+//	vbroadcastsd	8+6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	8+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			3*64(%r11), %zmm26 // A
+	vbroadcastsd	16+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			3*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	16+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	16+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+//	vbroadcastsd	16+5*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vbroadcastsd	16+6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	16+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			4*64(%r11), %zmm25 // A
+	vbroadcastsd	24+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			4*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	24+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	24+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+//	vbroadcastsd	24+5*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vfmadd231pd		%zmm28, %zmm24, %zmm13
+//	vbroadcastsd	24+6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	24+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			5*64(%r11), %zmm26 // A
+	vbroadcastsd	32+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			5*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	32+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	32+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	32+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+//	vbroadcastsd	32+5*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vbroadcastsd	32+6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	32+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			6*64(%r11), %zmm25 // A
+	vbroadcastsd	40+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			6*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	40+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	40+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	40+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+//	vbroadcastsd	40+5*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vfmadd231pd		%zmm28, %zmm24, %zmm13
+//	vbroadcastsd	40+6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	40+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			7*64(%r11), %zmm26 // A
+	vbroadcastsd	48+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			7*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	48+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	48+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	48+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+//	vbroadcastsd	48+5*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vbroadcastsd	48+6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	48+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			0*64(%r11), %zmm25 // A
+	vbroadcastsd	56+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			0*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	56+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	56+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	56+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+//	vbroadcastsd	56+5*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vfmadd231pd		%zmm28, %zmm24, %zmm13
+//	vbroadcastsd	56+6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	56+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+	addq	%r14, %r13
+
+	cmpl	$ 8, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean8-up
+	
+	cmpl	$ 7, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			1*64(%r11), %zmm26 // A
+	vbroadcastsd	1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			1*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+//	vbroadcastsd	5*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vbroadcastsd	6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			2*64(%r11), %zmm25 // A
+	vbroadcastsd	8+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			2*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	8+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	8+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	8+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+//	vbroadcastsd	8+5*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vfmadd231pd		%zmm28, %zmm24, %zmm13
+//	vbroadcastsd	8+6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	8+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			3*64(%r11), %zmm26 // A
+	vbroadcastsd	16+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			3*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	16+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	16+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+//	vbroadcastsd	16+5*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vbroadcastsd	16+6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	16+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			4*64(%r11), %zmm25 // A
+	vbroadcastsd	24+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			4*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	24+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	24+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+//	vbroadcastsd	24+5*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vfmadd231pd		%zmm28, %zmm24, %zmm13
+//	vbroadcastsd	24+6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	24+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			5*64(%r11), %zmm26 // A
+	vbroadcastsd	32+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			5*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	32+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	32+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	32+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+//	vbroadcastsd	32+5*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vbroadcastsd	32+6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	32+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			6*64(%r11), %zmm25 // A
+	vbroadcastsd	40+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			6*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	40+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	40+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	40+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+//	vbroadcastsd	40+5*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vfmadd231pd		%zmm28, %zmm24, %zmm13
+//	vbroadcastsd	40+6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	40+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			7*64(%r11), %zmm26 // A
+	vbroadcastsd	48+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			7*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	48+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	48+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	48+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+//	vbroadcastsd	48+5*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vbroadcastsd	48+6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	48+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+//	vmovapd			0*64(%r11), %zmm25 // A
+	vbroadcastsd	56+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+//	vmovapd			0*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	56+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	56+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vbroadcastsd	56+4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+//	vbroadcastsd	56+5*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vfmadd231pd		%zmm28, %zmm24, %zmm13
+//	vbroadcastsd	56+6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vbroadcastsd	56+7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+	addq	%r14, %r13
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 // A
+	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vbroadcastsd	1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vbroadcastsd	2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vbroadcastsd	4*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+//	vbroadcastsd	5*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vbroadcastsd	6*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vbroadcastsd	7*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+
+	addq	$ 64, %r11
+	addq	$ 8, %r13
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_2vx5_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r12   <- B
+// r14   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15 <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// r14   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15 <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_2VX4_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_2vx4_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+//	prefetcht0	0(%r13) // software prefetch
+//	prefetcht0	0+64(%r13) // software prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 // A0
+	vmovapd 		0(%r11, %r12), %zmm27 {%k1}{z} // A1
+
+	cmpl	$ 8, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+//	prefetcht0	128(%r13) // software prefetch
+//	prefetcht0	128+64(%r13) // software prefetch
+
+	// unroll 0
+	vbroadcastsd	0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			1*64(%r11), %zmm26 // A
+	vbroadcastsd	1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			1*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			2*64(%r11), %zmm25 // A
+	vbroadcastsd	8+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			2*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	8+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	8+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			3*64(%r11), %zmm26 // A
+	vbroadcastsd	16+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			3*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	16+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			4*64(%r11), %zmm25 // A
+	vbroadcastsd	24+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			4*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	24+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			5*64(%r11), %zmm26 // A
+	vbroadcastsd	32+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			5*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	32+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	32+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			6*64(%r11), %zmm25 // A
+	vbroadcastsd	40+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			6*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	40+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	40+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			7*64(%r11), %zmm26 // A
+	vbroadcastsd	48+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			7*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	48+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	48+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			0*64(%r11), %zmm25 // A
+	vbroadcastsd	56+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			0*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	56+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	56+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	addq	%r14, %r13
+
+	cmpl	$ 8, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean8-up
+	
+	cmpl	$ 7, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			1*64(%r11), %zmm26 // A
+	vbroadcastsd	1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			1*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			2*64(%r11), %zmm25 // A
+	vbroadcastsd	8+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			2*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	8+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	8+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			3*64(%r11), %zmm26 // A
+	vbroadcastsd	16+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			3*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	16+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			4*64(%r11), %zmm25 // A
+	vbroadcastsd	24+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			4*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	24+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	24+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			5*64(%r11), %zmm26 // A
+	vbroadcastsd	32+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			5*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	32+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	32+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			6*64(%r11), %zmm25 // A
+	vbroadcastsd	40+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			6*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	40+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	40+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			7*64(%r11), %zmm26 // A
+	vbroadcastsd	48+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			7*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	48+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	48+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+//	vmovapd			0*64(%r11), %zmm25 // A
+	vbroadcastsd	56+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+//	vmovapd			0*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	56+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vbroadcastsd	56+3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	addq	%r14, %r13
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 // A
+	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vbroadcastsd	1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vbroadcastsd	2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vbroadcastsd	3*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+
+	addq	$ 64, %r11
+	addq	$ 8, %r13
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_2vx4_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r12   <- B
+// r14   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15 <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// r14   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15 <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_2VX3_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_2vx3_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+//	prefetcht0	0(%r13) // software prefetch
+//	prefetcht0	0+64(%r13) // software prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 // A0
+	vmovapd 		0(%r11, %r12), %zmm27 {%k1}{z} // A1
+
+	cmpl	$ 8, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+//	prefetcht0	128(%r13) // software prefetch
+//	prefetcht0	128+64(%r13) // software prefetch
+
+	// unroll 0
+	vbroadcastsd	0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			1*64(%r11), %zmm26 // A
+	vbroadcastsd	1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			1*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			2*64(%r11), %zmm25 // A
+	vbroadcastsd	8+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			2*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	8+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	8+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			3*64(%r11), %zmm26 // A
+	vbroadcastsd	16+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			3*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	16+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			4*64(%r11), %zmm25 // A
+	vbroadcastsd	24+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			4*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	24+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	24+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			5*64(%r11), %zmm26 // A
+	vbroadcastsd	32+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			5*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	32+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	32+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			6*64(%r11), %zmm25 // A
+	vbroadcastsd	40+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			6*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	40+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	40+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			7*64(%r11), %zmm26 // A
+	vbroadcastsd	48+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			7*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	48+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	48+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			0*64(%r11), %zmm25 // A
+	vbroadcastsd	56+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			0*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	56+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	56+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	addq	%r14, %r13
+
+	cmpl	$ 8, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean8-up
+	
+	cmpl	$ 7, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			1*64(%r11), %zmm26 // A
+	vbroadcastsd	1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			1*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			2*64(%r11), %zmm25 // A
+	vbroadcastsd	8+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			2*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	8+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	8+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			3*64(%r11), %zmm26 // A
+	vbroadcastsd	16+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			3*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	16+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	16+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			4*64(%r11), %zmm25 // A
+	vbroadcastsd	24+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			4*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	24+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	24+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			5*64(%r11), %zmm26 // A
+	vbroadcastsd	32+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			5*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	32+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	32+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			6*64(%r11), %zmm25 // A
+	vbroadcastsd	40+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			6*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	40+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	40+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			7*64(%r11), %zmm26 // A
+	vbroadcastsd	48+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			7*64(%r11, %r12), %zmm28 {%k1}{z} // A
+	vbroadcastsd	48+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	48+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+//	vmovapd			0*64(%r11), %zmm25 // A
+	vbroadcastsd	56+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+//	vmovapd			0*64(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	56+2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	56+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	addq	%r14, %r13
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 // A
+	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vbroadcastsd	1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vbroadcastsd	2*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+
+	addq	$ 64, %r11
+	addq	$ 8, %r13
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_2vx3_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r12   <- B
+// r14   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15 <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// r14   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15 <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_2VX2_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_2vx2_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+//	prefetcht0	0(%r13) // software prefetch
+//	prefetcht0	0+64(%r13) // software prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 // A0
+	vmovapd 		0(%r11, %r12), %zmm27 {%k1}{z} // A1
+
+	cmpl	$ 8, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+//	prefetcht0	128(%r13) // software prefetch
+//	prefetcht0	128+64(%r13) // software prefetch
+
+	// unroll 0
+	vbroadcastsd	0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			1*64(%r11), %zmm26 // A
+	vbroadcastsd	1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			1*64(%r11, %r12), %zmm28 {%k1}{z} // A
+//	vbroadcastsd	2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			2*64(%r11), %zmm25 // A
+	vbroadcastsd	8+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			2*64(%r11, %r12), %zmm27 {%k1}{z} // A
+//	vbroadcastsd	8+2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	8+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			3*64(%r11), %zmm26 // A
+	vbroadcastsd	16+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			3*64(%r11, %r12), %zmm28 {%k1}{z} // A
+//	vbroadcastsd	16+2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	16+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			4*64(%r11), %zmm25 // A
+	vbroadcastsd	24+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			4*64(%r11, %r12), %zmm27 {%k1}{z} // A
+//	vbroadcastsd	24+2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	24+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			5*64(%r11), %zmm26 // A
+	vbroadcastsd	32+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			5*64(%r11, %r12), %zmm28 {%k1}{z} // A
+//	vbroadcastsd	32+2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	32+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			6*64(%r11), %zmm25 // A
+	vbroadcastsd	40+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			6*64(%r11, %r12), %zmm27 {%k1}{z} // A
+//	vbroadcastsd	40+2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	40+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			7*64(%r11), %zmm26 // A
+	vbroadcastsd	48+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			7*64(%r11, %r12), %zmm28 {%k1}{z} // A
+//	vbroadcastsd	48+2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	48+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			0*64(%r11), %zmm25 // A
+	vbroadcastsd	56+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			0*64(%r11, %r12), %zmm27 {%k1}{z} // A
+//	vbroadcastsd	56+2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	56+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	addq	%r14, %r13
+
+	cmpl	$ 8, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean8-up
+	
+	cmpl	$ 7, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			1*64(%r11), %zmm26 // A
+	vbroadcastsd	1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			1*64(%r11, %r12), %zmm28 {%k1}{z} // A
+//	vbroadcastsd	2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			2*64(%r11), %zmm25 // A
+	vbroadcastsd	8+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			2*64(%r11, %r12), %zmm27 {%k1}{z} // A
+//	vbroadcastsd	8+2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	8+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			3*64(%r11), %zmm26 // A
+	vbroadcastsd	16+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			3*64(%r11, %r12), %zmm28 {%k1}{z} // A
+//	vbroadcastsd	16+2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	16+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			4*64(%r11), %zmm25 // A
+	vbroadcastsd	24+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			4*64(%r11, %r12), %zmm27 {%k1}{z} // A
+//	vbroadcastsd	24+2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	24+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			5*64(%r11), %zmm26 // A
+	vbroadcastsd	32+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			5*64(%r11, %r12), %zmm28 {%k1}{z} // A
+//	vbroadcastsd	32+2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	32+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			6*64(%r11), %zmm25 // A
+	vbroadcastsd	40+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			6*64(%r11, %r12), %zmm27 {%k1}{z} // A
+//	vbroadcastsd	40+2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	40+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			7*64(%r11), %zmm26 // A
+	vbroadcastsd	48+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			7*64(%r11, %r12), %zmm28 {%k1}{z} // A
+//	vbroadcastsd	48+2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	48+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+//	vmovapd			0*64(%r11), %zmm25 // A
+	vbroadcastsd	56+1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+//	vmovapd			0*64(%r11, %r12), %zmm27 {%k1}{z} // A
+//	vbroadcastsd	56+2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	56+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	addq	%r14, %r13
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 // A
+	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vbroadcastsd	1*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+//	vbroadcastsd	2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+
+	addq	$ 64, %r11
+	addq	$ 8, %r13
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_2vx2_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r12   <- B
+// r14   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15 <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// r14   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm15 <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_2VX1_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_2vx1_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+//	prefetcht0	0(%r13) // software prefetch
+//	prefetcht0	0+64(%r13) // software prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 // A0
+	vmovapd 		0(%r11, %r12), %zmm27 {%k1}{z} // A1
+
+	cmpl	$ 8, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+//	prefetcht0	128(%r13) // software prefetch
+//	prefetcht0	128+64(%r13) // software prefetch
+
+	// unroll 0
+	vbroadcastsd	0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			1*64(%r11), %zmm26 // A
+//	vbroadcastsd	1*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			1*64(%r11, %r12), %zmm28 {%k1}{z} // A
+//	vbroadcastsd	2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			2*64(%r11), %zmm25 // A
+//	vbroadcastsd	8+1*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm1
+//	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			2*64(%r11, %r12), %zmm27 {%k1}{z} // A
+//	vbroadcastsd	8+2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	8+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			3*64(%r11), %zmm26 // A
+//	vbroadcastsd	16+1*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			3*64(%r11, %r12), %zmm28 {%k1}{z} // A
+//	vbroadcastsd	16+2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	16+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			4*64(%r11), %zmm25 // A
+//	vbroadcastsd	24+1*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm1
+//	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			4*64(%r11, %r12), %zmm27 {%k1}{z} // A
+//	vbroadcastsd	24+2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	24+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			5*64(%r11), %zmm26 // A
+//	vbroadcastsd	32+1*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			5*64(%r11, %r12), %zmm28 {%k1}{z} // A
+//	vbroadcastsd	32+2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	32+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			6*64(%r11), %zmm25 // A
+//	vbroadcastsd	40+1*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm1
+//	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			6*64(%r11, %r12), %zmm27 {%k1}{z} // A
+//	vbroadcastsd	40+2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	40+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			7*64(%r11), %zmm26 // A
+//	vbroadcastsd	48+1*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			7*64(%r11, %r12), %zmm28 {%k1}{z} // A
+//	vbroadcastsd	48+2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	48+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			0*64(%r11), %zmm25 // A
+//	vbroadcastsd	56+1*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm1
+//	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			0*64(%r11, %r12), %zmm27 {%k1}{z} // A
+//	vbroadcastsd	56+2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	56+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	addq	%r14, %r13
+
+	cmpl	$ 8, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean8-up
+	
+	cmpl	$ 7, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			1*64(%r11), %zmm26 // A
+//	vbroadcastsd	1*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			1*64(%r11, %r12), %zmm28 {%k1}{z} // A
+//	vbroadcastsd	2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			2*64(%r11), %zmm25 // A
+//	vbroadcastsd	8+1*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm1
+//	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			2*64(%r11, %r12), %zmm27 {%k1}{z} // A
+//	vbroadcastsd	8+2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	8+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			3*64(%r11), %zmm26 // A
+//	vbroadcastsd	16+1*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			3*64(%r11, %r12), %zmm28 {%k1}{z} // A
+//	vbroadcastsd	16+2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	16+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			4*64(%r11), %zmm25 // A
+//	vbroadcastsd	24+1*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm1
+//	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			4*64(%r11, %r12), %zmm27 {%k1}{z} // A
+//	vbroadcastsd	24+2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	24+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			5*64(%r11), %zmm26 // A
+//	vbroadcastsd	32+1*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			5*64(%r11, %r12), %zmm28 {%k1}{z} // A
+//	vbroadcastsd	32+2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	32+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vmovapd			6*64(%r11), %zmm25 // A
+//	vbroadcastsd	40+1*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm1
+//	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vmovapd			6*64(%r11, %r12), %zmm27 {%k1}{z} // A
+//	vbroadcastsd	40+2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	40+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vmovapd			7*64(%r11), %zmm26 // A
+//	vbroadcastsd	48+1*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vmovapd			7*64(%r11, %r12), %zmm28 {%k1}{z} // A
+//	vbroadcastsd	48+2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	48+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+//	vmovapd			0*64(%r11), %zmm25 // A
+//	vbroadcastsd	56+1*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm1
+//	vfmadd231pd		%zmm28, %zmm24, %zmm9
+//	vmovapd			0*64(%r11, %r12), %zmm27 {%k1}{z} // A
+//	vbroadcastsd	56+2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vbroadcastsd	56+3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	addq	%r14, %r13
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 // A
+	vmovapd			0(%r11, %r12), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+//	vbroadcastsd	1*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm27, %zmm24, %zmm9
+//	vbroadcastsd	2*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vbroadcastsd	3*64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+
+	addq	$ 64, %r11
+	addq	$ 8, %r13
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_2vx1_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B
+// r14   <- 4*sdb*sizeof(double)
+// r15   <- m1
+// rax   <- n1
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// r14   <- 4*sdb*sizeof(double)
+// r15   <- m1
+// rax   <- n1
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_16X8_VS_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_16x8_vs_lib8)
+#endif
+
+	// compute mask for rows
+	vcvtsi2sd	%r15d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC01(%rip), %zmm24
+#elif defined(OS_MAC)
+	vmovupd		LC01(%rip), %zmm24
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm24, %zmm25
+	vpmovq2m	%zmm25, %k1
+
+	cmpl	$ 1, %eax
+	jg		100f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_2VX1_LIB8
+#else
+	CALL(inner_kernel_dgemm_nn_2vx1_lib8)
+#endif
+	
+	jmp		107f
+
+100:
+
+	cmpl	$ 2, %eax
+	jg		101f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_2VX2_LIB8
+#else
+	CALL(inner_kernel_dgemm_nn_2vx2_lib8)
+#endif
+	
+	jmp		107f
+
+101:
+
+	cmpl	$ 3, %eax
+	jg		102f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_2VX3_LIB8
+#else
+	CALL(inner_kernel_dgemm_nn_2vx3_lib8)
+#endif
+	
+	jmp		107f
+
+102:
+
+	cmpl	$ 4, %eax
+	jg		103f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_2VX4_LIB8
+#else
+	CALL(inner_kernel_dgemm_nn_2vx4_lib8)
+#endif
+	
+	jmp		107f
+
+103:
+
+	cmpl	$ 5, %eax
+	jg		104f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_2VX5_LIB8
+#else
+	CALL(inner_kernel_dgemm_nn_2vx5_lib8)
+#endif
+	
+	jmp		107f
+
+104:
+
+	cmpl	$ 6, %eax
+	jg		105f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_2VX6_LIB8
+#else
+	CALL(inner_kernel_dgemm_nn_2vx6_lib8)
+#endif
+	
+	jmp		107f
+
+105:
+
+	cmpl	$ 7, %eax
+	jg		106f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_2VX7_LIB8
+#else
+	CALL(inner_kernel_dgemm_nn_2vx7_lib8)
+#endif
+	
+	jmp		107f
+
+106:
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_2VX8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nn_2vx8_lib8)
+#endif
+
+107:
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_16x8_vs_lib8)
 #endif
 
 
@@ -8905,18 +12861,23 @@ NAME:
 	movq	ARG6, %r13  // B
 	movq	ARG7, %r14 // sdb
 	sall	$ 6, %r14d // 8*sdb*sizeof(double)
+
 	movq	ARG5, %r15 // offsetB
 
+	// TODO vs
 #if MACRO_LEVEL>=1
 	INNER_EDGE_DGEMM_NN_16X8_LIB8
 #else
 	CALL(inner_edge_dgemm_nn_16x8_lib8)
 #endif
 
+	movq	ARG13, %r15 // m1
+	movq	ARG14, %rax // n1
+
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_16X8_LIB8
+	INNER_KERNEL_DGEMM_NN_16X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nn_16x8_lib8)
+	CALL(inner_kernel_dgemm_nn_16x8_vs_lib8)
 #endif
 
 
@@ -8983,18 +12944,23 @@ NAME:
 	movq	ARG6, %r13  // B
 	movq	ARG7, %r14 // sdb
 	sall	$ 6, %r14d // 4*sdb*sizeof(double)
+
 	movq	ARG5, %r15 // offsetB
 
+	// TODO vs
 #if MACRO_LEVEL>=1
 	INNER_EDGE_DGEMM_NN_16X8_LIB8
 #else
 	CALL(inner_edge_dgemm_nn_16x8_lib8)
 #endif
 
+	movq	ARG16, %r15 // m1
+	movq	ARG18, %rax // n1
+
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_16X8_LIB8
+	INNER_KERNEL_DGEMM_NN_16X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nn_16x8_lib8)
+	CALL(inner_kernel_dgemm_nn_16x8_vs_lib8)
 #endif
 
 
@@ -9143,18 +13109,23 @@ NAME:
 	movq	ARG4, %r13 // A
 	movq	ARG5, %r14 // sda
 	sall	$ 6, %r14d // 4*sda*sizeof(double)
+
 	movq	ARG3, %r15 // offsetA
 
+	// TODO vs
 #if MACRO_LEVEL>=1
 	INNER_EDGE_DGEMM_NN_16X8_LIB8
 #else
 	CALL(inner_edge_dgemm_nn_16x8_lib8)
 #endif
 
+	movq	ARG12, %r15 // n1
+	movq	ARG11, %rax // m1
+
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_16X8_LIB8
+	INNER_KERNEL_DGEMM_NN_16X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nn_16x8_lib8)
+	CALL(inner_kernel_dgemm_nn_16x8_vs_lib8)
 #endif
 
 #if MACRO_LEVEL>=1
@@ -9223,18 +13194,23 @@ NAME:
 	movq	ARG4, %r13  // A
 	movq	ARG5, %r14 // sda
 	sall	$ 6, %r14d // 4*sda*sizeof(double)
+
 	movq	ARG3, %r15 // offsetA
 
+	// TODO vs
 #if MACRO_LEVEL>=1
 	INNER_EDGE_DGEMM_NN_16X8_LIB8
 #else
 	CALL(inner_edge_dgemm_nn_16x8_lib8)
 #endif
 
+	movq	ARG18, %r15 // n1
+	movq	ARG16, %rax // m1
+
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_16X8_LIB8
+	INNER_KERNEL_DGEMM_NN_16X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nn_16x8_lib8)
+	CALL(inner_kernel_dgemm_nn_16x8_vs_lib8)
 #endif
 
 #if MACRO_LEVEL>=1
@@ -9607,14 +13583,17 @@ NAME:
 	movq	ARG6, %r13 // B
 	movq	ARG7, %r14 // sdb
 	sall	$ 6, %r14d // 4*sdb*sizeof(double)
+
 	movq	ARG5, %r15 // offsetB
 
+	// TODO vs
 #if MACRO_LEVEL>=1
 	INNER_EDGE_DTRMM_NN_RL_16X8_LIB8
 #else
 	CALL(inner_edge_dtrmm_nn_rl_16x8_lib8)
 #endif
 
+	// TODO vs
 #if MACRO_LEVEL>=1
 	INNER_EDGE_DGEMM_NN_16X8_LIB8
 #else
@@ -9623,10 +13602,13 @@ NAME:
 
 	// call inner dgemm kernel nt after initial triangle
 
+	movq	ARG10, %r14 // m1
+	movq	ARG11, %r15 // n1
+
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_16X8_LIB8
+	INNER_KERNEL_DGEMM_NN_16X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nn_16x8_lib8)
+	CALL(inner_kernel_dgemm_nn_16x8_vs_lib8)
 #endif
 
 

--- a/kernel/avx512/kernel_dgemm_24x8_lib.S
+++ b/kernel/avx512/kernel_dgemm_24x8_lib.S
@@ -1,0 +1,669 @@
+/**************************************************************************************************
+*                                                                                                 *
+* This file is part of BLASFEO.                                                                   *
+*                                                                                                 *
+* BLASFEO -- BLAS For Embedded Optimization.                                                      *
+* Copyright (C) 2021 by Gianluca Frison.                                                          *
+* Developed at IMTEK (University of Freiburg) under the supervision of Moritz Diehl.              *
+* All rights reserved.                                                                            *
+*                                                                                                 *
+* The 2-Clause BSD License                                                                        *
+*                                                                                                 *
+* Redistribution and use in source and binary forms, with or without                              *
+* modification, are permitted provided that the following conditions are met:                     *
+*                                                                                                 *
+* 1. Redistributions of source code must retain the above copyright notice, this                  *
+*    list of conditions and the following disclaimer.                                             *
+* 2. Redistributions in binary form must reproduce the above copyright notice,                    *
+*    this list of conditions and the following disclaimer in the documentation                    *
+*    and/or other materials provided with the distribution.                                       *
+*                                                                                                 *
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND                 *
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED                   *
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE                          *
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR                 *
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES                  *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;                    *
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND                     *
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT                      *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS                   *
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                                    *
+*                                                                                                 *
+* Author: Gianluca Frison, gianluca.frison (at) imtek.uni-freiburg.de                             *
+*                                                                                                 *
+**************************************************************************************************/
+
+
+
+// common inner routine with file scope
+//
+// scale for generic alpha and beta
+//
+// input arguments:
+// r10   <- alpha
+// r11   <- beta
+// r12   <- C
+// r13   <- ldc
+// zmm0 <- []
+// ...
+// zmm15 <- []
+//
+// output arguments:
+// r10   <- alpha
+// r11   <- beta
+// r10   <- C
+// r13   <- ldc
+// zmm0 <- []
+// ...
+// zmm15 <- []
+
+#if MACRO_LEVEL>=1
+	.macro INNER_SCALE_AB_24X8_LIB
+#else
+	.p2align 4,,15
+	FUN_START(inner_scale_ab_24x8_lib)
+#endif
+	
+	// alpha
+	vbroadcastsd	0(%r10), %zmm25
+
+	vmulpd		%zmm0, %zmm25, %zmm0
+	vmulpd		%zmm1, %zmm25, %zmm1
+	vmulpd		%zmm2, %zmm25, %zmm2
+	vmulpd		%zmm3, %zmm25, %zmm3
+	vmulpd		%zmm4, %zmm25, %zmm4
+	vmulpd		%zmm5, %zmm25, %zmm5
+	vmulpd		%zmm6, %zmm25, %zmm6
+	vmulpd		%zmm7, %zmm25, %zmm7
+	vmulpd		%zmm8, %zmm25, %zmm8
+	vmulpd		%zmm9, %zmm25, %zmm9
+	vmulpd		%zmm10, %zmm25, %zmm10
+	vmulpd		%zmm11, %zmm25, %zmm11
+	vmulpd		%zmm12, %zmm25, %zmm12
+	vmulpd		%zmm13, %zmm25, %zmm13
+	vmulpd		%zmm14, %zmm25, %zmm14
+	vmulpd		%zmm15, %zmm25, %zmm15
+	vmulpd		%zmm16, %zmm25, %zmm16
+	vmulpd		%zmm17, %zmm25, %zmm17
+	vmulpd		%zmm18, %zmm25, %zmm18
+	vmulpd		%zmm19, %zmm25, %zmm19
+	vmulpd		%zmm20, %zmm25, %zmm20
+	vmulpd		%zmm21, %zmm25, %zmm21
+	vmulpd		%zmm22, %zmm25, %zmm22
+	vmulpd		%zmm23, %zmm25, %zmm23
+
+	// beta
+	vbroadcastsd	0(%r11), %zmm24
+
+	vxorpd		%zmm25, %zmm25, %zmm25 // 0.0
+
+	vucomisd	%xmm25, %xmm24 // beta==0.0 ?
+	je			0f // end
+
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm0
+	vmovupd		64(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm8
+	vmovupd		128(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm16
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm1
+	vmovupd		64(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm9
+	vmovupd		128(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm17
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm2
+	vmovupd		64(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm10
+	vmovupd		128(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm18
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm3
+	vmovupd		64(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm11
+	vmovupd		128(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm19
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm4
+	vmovupd		64(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm12
+	vmovupd		128(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm20
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm5
+	vmovupd		64(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm13
+	vmovupd		128(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm21
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm6
+	vmovupd		64(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm14
+	vmovupd		128(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm22
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm7
+	vmovupd		64(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm15
+	vmovupd		128(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm23
+//	addq		%r13, %r12
+
+0:
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_scale_ab_24x8_lib)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// scale for generic alpha and beta
+//
+// input arguments:
+// r10   <- alpha
+// r11   <- beta
+// r12   <- C
+// r13   <- ldc
+// r14   <- m1
+// r15   <- n1
+// zmm0 <- []
+// ...
+// zmm15 <- []
+//
+// output arguments:
+// r10   <- alpha
+// r11   <- beta
+// r10   <- C
+// r13   <- ldc
+// r14   <- m1
+// r15   <- n1
+// zmm0 <- []
+// ...
+// zmm15 <- []
+
+#if MACRO_LEVEL>=1
+	.macro INNER_SCALE_AB_24X8_VS_LIB
+#else
+	.p2align 4,,15
+	FUN_START(inner_scale_ab_24x8_vs_lib)
+#endif
+	
+	// alpha
+	vbroadcastsd	0(%r10), %zmm25
+
+	vmulpd		%zmm0, %zmm25, %zmm0
+	vmulpd		%zmm1, %zmm25, %zmm1
+	vmulpd		%zmm2, %zmm25, %zmm2
+	vmulpd		%zmm3, %zmm25, %zmm3
+	vmulpd		%zmm4, %zmm25, %zmm4
+	vmulpd		%zmm5, %zmm25, %zmm5
+	vmulpd		%zmm6, %zmm25, %zmm6
+	vmulpd		%zmm7, %zmm25, %zmm7
+	vmulpd		%zmm8, %zmm25, %zmm8
+	vmulpd		%zmm9, %zmm25, %zmm9
+	vmulpd		%zmm10, %zmm25, %zmm10
+	vmulpd		%zmm11, %zmm25, %zmm11
+	vmulpd		%zmm12, %zmm25, %zmm12
+	vmulpd		%zmm13, %zmm25, %zmm13
+	vmulpd		%zmm14, %zmm25, %zmm14
+	vmulpd		%zmm15, %zmm25, %zmm15
+	vmulpd		%zmm16, %zmm25, %zmm16
+	vmulpd		%zmm17, %zmm25, %zmm17
+	vmulpd		%zmm18, %zmm25, %zmm18
+	vmulpd		%zmm19, %zmm25, %zmm19
+	vmulpd		%zmm20, %zmm25, %zmm20
+	vmulpd		%zmm21, %zmm25, %zmm21
+	vmulpd		%zmm22, %zmm25, %zmm22
+	vmulpd		%zmm23, %zmm25, %zmm23
+
+	// beta
+	vbroadcastsd	0(%r11), %zmm24
+
+	vxorpd		%zmm25, %zmm25, %zmm25 // 0.0
+
+	vucomisd	%xmm25, %xmm24 // beta==0.0 ?
+	je			0f // end
+
+	// compute mask for rows
+	vcvtsi2sd	%r14d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC02(%rip), %zmm26
+#elif defined(OS_MAC)
+	vmovupd		LC02(%rip), %zmm26
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm26, %zmm25
+	vpmovq2m	%zmm25, %k1
+
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm0
+	vmovupd		64(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm8
+	vmovupd		128(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm16
+	addq		%r13, %r12
+	cmpl		$ 2, %r15d
+	jl			0f // end
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm1
+	vmovupd		64(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm9
+	vmovupd		128(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm17
+	addq		%r13, %r12
+	cmpl		$ 3, %r15d
+	jl			0f // end
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm2
+	vmovupd		64(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm10
+	vmovupd		128(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm18
+	addq		%r13, %r12
+	cmpl		$ 4, %r15d
+	jl			0f // end
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm3
+	vmovupd		64(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm11
+	vmovupd		128(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm19
+	addq		%r13, %r12
+	cmpl		$ 5, %r15d
+	jl			0f // end
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm4
+	vmovupd		64(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm12
+	vmovupd		128(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm20
+	addq		%r13, %r12
+	cmpl		$ 6, %r15d
+	jl			0f // end
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm5
+	vmovupd		64(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm13
+	vmovupd		128(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm21
+	addq		%r13, %r12
+	cmpl		$ 7, %r15d
+	jl			0f // end
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm6
+	vmovupd		64(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm14
+	vmovupd		128(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm22
+	addq		%r13, %r12
+	cmpl		$ 7, %r15d
+	je			0f // end
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm7
+	vmovupd		64(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm15
+	vmovupd		128(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm23
+//	addq		%r13, %r12
+
+0:
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_scale_ab_24x8_vs_lib)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// store n
+//
+// input arguments:
+// r10  <- D
+// r11  <- ldd
+// zmm0 <- []
+// ...
+// zmm15 <- []
+//
+// output arguments:
+// r10  <- D
+// r11  <- ldd
+// zmm0 <- []
+// ...
+// zmm15 <- []
+
+#if MACRO_LEVEL>=1
+	.macro INNER_STORE_24X8_LIB
+#else
+	.p2align 4,,15
+	FUN_START(inner_store_24x8_lib)
+#endif
+	
+	vmovupd %zmm0, 0(%r10)
+	vmovupd %zmm8, 64(%r10)
+	vmovupd %zmm16, 128(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm1, 0(%r10)
+	vmovupd %zmm9, 64(%r10)
+	vmovupd %zmm17, 128(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm2, 0(%r10)
+	vmovupd %zmm10, 64(%r10)
+	vmovupd %zmm18, 128(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm3, 0(%r10)
+	vmovupd %zmm11, 64(%r10)
+	vmovupd %zmm19, 128(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm4, 0(%r10)
+	vmovupd %zmm12, 64(%r10)
+	vmovupd %zmm20, 128(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm5, 0(%r10)
+	vmovupd %zmm13, 64(%r10)
+	vmovupd %zmm21, 128(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm6, 0(%r10)
+	vmovupd %zmm14, 64(%r10)
+	vmovupd %zmm22, 128(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm7, 0(%r10)
+	vmovupd %zmm15, 64(%r10)
+	vmovupd %zmm23, 128(%r10)
+//	addq		%r11, %r10
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_store_24x8_lib)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// store n
+//
+// input arguments:
+// r10  <- D
+// r11  <- ldd
+// r12  <- m1
+// r13  <- n1
+// zmm0 <- []
+// ...
+// zmm15 <- []
+//
+// output arguments:
+// r10  <- D
+// r11  <- ldd
+// r12  <- m1
+// r13  <- n1
+// zmm0 <- []
+// ...
+// zmm15 <- []
+
+#if MACRO_LEVEL>=1
+	.macro INNER_STORE_24X8_VS_LIB
+#else
+	.p2align 4,,15
+	FUN_START(inner_store_24x8_vs_lib)
+#endif
+	
+	// compute mask for rows
+	vcvtsi2sd	%r12d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC02(%rip), %zmm24
+#elif defined(OS_MAC)
+	vmovupd		LC02(%rip), %zmm24
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm24, %zmm25
+	vpmovq2m	%zmm25, %k1
+
+	vmovupd %zmm0, 0(%r10)
+	vmovupd %zmm8, 64(%r10)
+	vmovupd %zmm16, 128(%r10) {%k1}
+	addq		%r11, %r10
+	cmpl		$ 2, %r13d
+	jl			0f // end
+	vmovupd %zmm1, 0(%r10)
+	vmovupd %zmm9, 64(%r10)
+	vmovupd %zmm17, 128(%r10) {%k1}
+	addq		%r11, %r10
+	cmpl		$ 3, %r13d
+	jl			0f // end
+	vmovupd %zmm2, 0(%r10)
+	vmovupd %zmm10, 64(%r10)
+	vmovupd %zmm18, 128(%r10) {%k1}
+	addq		%r11, %r10
+	cmpl		$ 4, %r13d
+	jl			0f // end
+	vmovupd %zmm3, 0(%r10)
+	vmovupd %zmm11, 64(%r10)
+	vmovupd %zmm19, 128(%r10) {%k1}
+	addq		%r11, %r10
+	cmpl		$ 5, %r13d
+	jl			0f // end
+	vmovupd %zmm4, 0(%r10)
+	vmovupd %zmm12, 64(%r10)
+	vmovupd %zmm20, 128(%r10) {%k1}
+	addq		%r11, %r10
+	cmpl		$ 6, %r13d
+	jl			0f // end
+	vmovupd %zmm5, 0(%r10)
+	vmovupd %zmm13, 64(%r10)
+	vmovupd %zmm21, 128(%r10) {%k1}
+	addq		%r11, %r10
+	cmpl		$ 7, %r13d
+	jl			0f // end
+	vmovupd %zmm6, 0(%r10)
+	vmovupd %zmm14, 64(%r10)
+	vmovupd %zmm22, 128(%r10) {%k1}
+	addq		%r11, %r10
+	cmpl		$ 7, %r13d
+	je			0f // end
+	vmovupd %zmm7, 0(%r10)
+	vmovupd %zmm15, 64(%r10)
+	vmovupd %zmm23, 128(%r10) {%k1}
+//	addq		%r11, %r10
+
+0:
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_store_24x8_vs_lib)
+#endif
+
+
+
+
+
+//                                 1      2              3          4        5          6             7          8        9          10
+// void kernel_dgemm_nt_24x8_lib88cc(int k, double *alpha, double *A, int sda, double *B, double *beta, double *C, int ldc, double *D, int ldd);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dgemm_nt_24x8_lib88cc)
+
+	PROLOGUE
+
+	// zero accumulation registers
+
+	ZERO_ACC
+
+
+	// prefetch C
+
+//	movq		ARG6, %r10 // beta
+//	vmovsd		0(%r10), %xmm14
+//	vxorpd		%xmm15, %xmm15, %xmm15 // 0.0
+//	vucomisd	%xmm15, %xmm14 // beta==0.0 ?
+//	je			100f // end
+
+//	movq	ARG7, %r10 // C
+//	movq	ARG8, %r11 // ldc
+//	sall	$ 3, %r11d
+
+#if MACRO_LEVEL>=1
+//	INNER_PREFETCH0_8X4_LIB
+#else
+//	CALL(inner_prefetch0_8x4_lib)
+#endif
+
+//100:
+
+
+	// call inner dgemm kernel nn
+
+	movq	ARG1, %r10 // k
+	movq	ARG3, %r11  // A
+	movq	ARG4, %r12 // sda
+	sall	$ 6, %r12d // 8*sda*sizeof(double)
+	movq	ARG5, %r13  // B
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_24X8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_24x8_lib8)
+#endif
+
+
+	// call inner blend
+
+	movq	ARG2, %r10 // alpha
+	movq	ARG6, %r11 // beta
+	movq	ARG7, %r12   // C
+	movq	ARG8, %r13   // ldc
+	sall	$ 3, %r13d
+
+#if MACRO_LEVEL>=1
+	INNER_SCALE_AB_24X8_LIB
+#else
+	CALL(inner_scale_ab_24x8_lib)
+#endif
+
+
+	// store n
+
+	movq	ARG9, %r10 // D
+	movq	ARG10, %r11 // ldd
+	sall	$ 3, %r11d
+
+#if MACRO_LEVEL>=1
+	INNER_STORE_24X8_LIB
+#else
+	CALL(inner_store_24x8_lib)
+#endif
+
+
+	EPILOGUE
+
+	ret
+
+	FUN_END(kernel_dgemm_nt_24x8_lib88cc)
+
+
+
+
+
+//                                      1      2              3          4        5          6             7          8        9          10       11      12
+// void kernel_dgemm_nt_24x8_vs_lib88cc(int k, double *alpha, double *A, int sda, double *B, double *beta, double *C, int ldc, double *D, int ldd, int m1, int n1);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dgemm_nt_24x8_vs_lib88cc)
+
+	PROLOGUE
+
+	// zero accumulation registers
+
+	ZERO_ACC
+
+
+	// call inner dgemm kernel nn
+
+	movq	ARG1, %r10 // k
+	movq	ARG3, %r11  // A
+	movq	ARG4, %r12 // sda
+	sall	$ 6, %r12d // 8*sda*sizeof(double)
+	movq	ARG5, %r13  // B
+	movq	ARG11, %r14 // m1
+	movq	ARG12, %r15 // n1
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_24X8_VS_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_24x8_vs_lib8)
+#endif
+
+
+	// call inner blend
+
+	movq	ARG2, %r10 // alpha
+	movq	ARG6, %r11 // beta
+	movq	ARG7, %r12   // C
+	movq	ARG8, %r13   // ldc
+	sall	$ 3, %r13d
+	movq	ARG11, %r14 // m1
+	movq	ARG12, %r15 // n1
+
+#if MACRO_LEVEL>=1
+	INNER_SCALE_AB_24X8_VS_LIB
+#else
+	CALL(inner_scale_ab_24x8_vs_lib)
+#endif
+
+
+	// store n
+
+	movq	ARG9, %r10 // D
+	movq	ARG10, %r11 // ldd
+	sall	$ 3, %r11d
+	movq	ARG11, %r12 // m1
+	movq	ARG12, %r13 // n1
+
+#if MACRO_LEVEL>=1
+	INNER_STORE_24X8_VS_LIB
+#else
+	CALL(inner_store_24x8_vs_lib)
+#endif
+
+
+	EPILOGUE
+
+	ret
+
+	FUN_END(kernel_dgemm_nt_24x8_vs_lib88cc)
+
+
+
+
+
+

--- a/kernel/avx512/kernel_dgemm_24x8_lib.S
+++ b/kernel/avx512/kernel_dgemm_24x8_lib.S
@@ -3624,6 +3624,158 @@
 // r11   <- beta
 // r12   <- C
 // r13   <- ldc
+// zmm0 <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+// r10   <- alpha
+// r11   <- beta
+// r10   <- C
+// r13   <- ldc
+// zmm0 <- []
+// ...
+// zmm23 <- []
+
+#if MACRO_LEVEL>=1
+	.macro INNER_SCALE_AB_8X24_LIB
+#else
+	.p2align 4,,15
+	FUN_START(inner_scale_ab_8x24_lib)
+#endif
+	
+	// alpha
+	vbroadcastsd	0(%r10), %zmm25
+
+	vmulpd		%zmm0, %zmm25, %zmm0
+	vmulpd		%zmm1, %zmm25, %zmm1
+	vmulpd		%zmm2, %zmm25, %zmm2
+	vmulpd		%zmm3, %zmm25, %zmm3
+	vmulpd		%zmm4, %zmm25, %zmm4
+	vmulpd		%zmm5, %zmm25, %zmm5
+	vmulpd		%zmm6, %zmm25, %zmm6
+	vmulpd		%zmm7, %zmm25, %zmm7
+	vmulpd		%zmm8, %zmm25, %zmm8
+	vmulpd		%zmm9, %zmm25, %zmm9
+	vmulpd		%zmm10, %zmm25, %zmm10
+	vmulpd		%zmm11, %zmm25, %zmm11
+	vmulpd		%zmm12, %zmm25, %zmm12
+	vmulpd		%zmm13, %zmm25, %zmm13
+	vmulpd		%zmm14, %zmm25, %zmm14
+	vmulpd		%zmm15, %zmm25, %zmm15
+	vmulpd		%zmm16, %zmm25, %zmm16
+	vmulpd		%zmm17, %zmm25, %zmm17
+	vmulpd		%zmm18, %zmm25, %zmm18
+	vmulpd		%zmm19, %zmm25, %zmm19
+	vmulpd		%zmm20, %zmm25, %zmm20
+	vmulpd		%zmm21, %zmm25, %zmm21
+	vmulpd		%zmm22, %zmm25, %zmm22
+	vmulpd		%zmm23, %zmm25, %zmm23
+
+	// beta
+	vbroadcastsd	0(%r11), %zmm24
+
+	vxorpd		%zmm25, %zmm25, %zmm25 // 0.0
+
+	vucomisd	%xmm25, %xmm24 // beta==0.0 ?
+	je			0f // end
+
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm0
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm1
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm2
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm3
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm4
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm5
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm6
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm7
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm8
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm9
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm10
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm11
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm12
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm13
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm14
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm15
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm16
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm17
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm18
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm19
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm20
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm21
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm22
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm23
+//	addq		%r13, %r12
+
+0:
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_scale_ab_8x24_lib)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// scale for generic alpha and beta
+//
+// input arguments:
+// r10   <- alpha
+// r11   <- beta
+// r12   <- C
+// r13   <- ldc
 // r14   <- m1
 // r15   <- n1
 // zmm0 <- []
@@ -3782,6 +3934,189 @@
 
 // common inner routine with file scope
 //
+// scale for generic alpha and beta
+//
+// input arguments:
+// r10   <- alpha
+// r11   <- beta
+// r12   <- C
+// r13   <- ldc
+// r14   <- m1
+// r15   <- n1
+// zmm0 <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+// r10   <- alpha
+// r11   <- beta
+// r10   <- C
+// r13   <- ldc
+// r14   <- m1
+// r15   <- n1
+// zmm0 <- []
+// ...
+// zmm23 <- []
+
+#if MACRO_LEVEL>=1
+	.macro INNER_SCALE_AB_8X24_VS_LIB
+#else
+	.p2align 4,,15
+	FUN_START(inner_scale_ab_8x24_vs_lib)
+#endif
+	
+	// alpha
+	vbroadcastsd	0(%r10), %zmm25
+
+	vmulpd		%zmm0, %zmm25, %zmm0
+	vmulpd		%zmm1, %zmm25, %zmm1
+	vmulpd		%zmm2, %zmm25, %zmm2
+	vmulpd		%zmm3, %zmm25, %zmm3
+	vmulpd		%zmm4, %zmm25, %zmm4
+	vmulpd		%zmm5, %zmm25, %zmm5
+	vmulpd		%zmm6, %zmm25, %zmm6
+	vmulpd		%zmm7, %zmm25, %zmm7
+	vmulpd		%zmm8, %zmm25, %zmm8
+	vmulpd		%zmm9, %zmm25, %zmm9
+	vmulpd		%zmm10, %zmm25, %zmm10
+	vmulpd		%zmm11, %zmm25, %zmm11
+	vmulpd		%zmm12, %zmm25, %zmm12
+	vmulpd		%zmm13, %zmm25, %zmm13
+	vmulpd		%zmm14, %zmm25, %zmm14
+	vmulpd		%zmm15, %zmm25, %zmm15
+	vmulpd		%zmm16, %zmm25, %zmm16
+	vmulpd		%zmm17, %zmm25, %zmm17
+	vmulpd		%zmm18, %zmm25, %zmm18
+	vmulpd		%zmm19, %zmm25, %zmm19
+	vmulpd		%zmm20, %zmm25, %zmm20
+	vmulpd		%zmm21, %zmm25, %zmm21
+	vmulpd		%zmm22, %zmm25, %zmm22
+	vmulpd		%zmm23, %zmm25, %zmm23
+
+	// beta
+	vbroadcastsd	0(%r11), %zmm24
+
+	vxorpd		%zmm25, %zmm25, %zmm25 // 0.0
+
+	vucomisd	%xmm25, %xmm24 // beta==0.0 ?
+	je			0f // end
+
+	// compute mask for rows
+	vcvtsi2sd	%r14d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC00(%rip), %zmm26
+#elif defined(OS_MAC)
+	vmovupd		LC00(%rip), %zmm26
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm26, %zmm25
+	vpmovq2m	%zmm25, %k1
+
+	vmovupd		0(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm0
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm1
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm2
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm3
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm4
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm5
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm6
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm7
+	addq		%r13, %r12
+
+	vmovupd		0(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm8
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm9
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm10
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm11
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm12
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm13
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm14
+	addq		%r13, %r12
+	vmovupd		0(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm15
+	addq		%r13, %r12
+
+	vmovupd		0(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm16
+	addq		%r13, %r12
+	cmpl		$ 18, %r15d
+	jl			0f // end
+	vmovupd		0(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm17
+	addq		%r13, %r12
+	cmpl		$ 19, %r15d
+	jl			0f // end
+	vmovupd		0(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm18
+	addq		%r13, %r12
+	cmpl		$ 20, %r15d
+	jl			0f // end
+	vmovupd		0(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm19
+	addq		%r13, %r12
+	cmpl		$ 21, %r15d
+	jl			0f // end
+	vmovupd		0(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm20
+	addq		%r13, %r12
+	cmpl		$ 22, %r15d
+	jl			0f // end
+	vmovupd		0(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm21
+	addq		%r13, %r12
+	cmpl		$ 23, %r15d
+	jl			0f // end
+	vmovupd		0(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm22
+	addq		%r13, %r12
+	cmpl		$ 23, %r15d
+	je			0f // end
+	vmovupd		0(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm23
+//	addq		%r13, %r12
+
+0:
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_scale_ab_8x24_vs_lib)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
 // store n
 //
 // input arguments:
@@ -3844,6 +4179,92 @@
 	ret
 
 	FUN_END(inner_store_24x8_lib)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// store n
+//
+// input arguments:
+// r10  <- D
+// r11  <- ldd
+// zmm0 <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+// r10  <- D
+// r11  <- ldd
+// zmm0 <- []
+// ...
+// zmm23 <- []
+
+#if MACRO_LEVEL>=1
+	.macro INNER_STORE_8X24_LIB
+#else
+	.p2align 4,,15
+	FUN_START(inner_store_8x24_lib)
+#endif
+	
+	vmovupd %zmm0, 0(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm1, 0(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm2, 0(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm3, 0(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm4, 0(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm5, 0(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm6, 0(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm7, 0(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm8, 0(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm9, 0(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm10, 0(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm11, 0(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm12, 0(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm13, 0(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm14, 0(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm15, 0(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm16, 0(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm17, 0(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm18, 0(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm19, 0(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm20, 0(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm21, 0(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm22, 0(%r10)
+	addq		%r11, %r10
+	vmovupd %zmm23, 0(%r10)
+//	addq		%r11, %r10
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_store_8x24_lib)
 #endif
 
 
@@ -3953,6 +4374,125 @@
 
 // common inner routine with file scope
 //
+// store n
+//
+// input arguments:
+// r10  <- D
+// r11  <- ldd
+// r12  <- m1
+// r13  <- n1
+// zmm0 <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+// r10  <- D
+// r11  <- ldd
+// r12  <- m1
+// r13  <- n1
+// zmm0 <- []
+// ...
+// zmm23 <- []
+
+#if MACRO_LEVEL>=1
+	.macro INNER_STORE_8X24_VS_LIB
+#else
+	.p2align 4,,15
+	FUN_START(inner_store_8x24_vs_lib)
+#endif
+	
+	// compute mask for rows
+	vcvtsi2sd	%r12d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC00(%rip), %zmm24
+#elif defined(OS_MAC)
+	vmovupd		LC00(%rip), %zmm24
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm24, %zmm25
+	vpmovq2m	%zmm25, %k1
+
+	vmovupd %zmm0, 0(%r10) {%k1}
+	addq		%r11, %r10
+	vmovupd %zmm1, 0(%r10) {%k1}
+	addq		%r11, %r10
+	vmovupd %zmm2, 0(%r10) {%k1}
+	addq		%r11, %r10
+	vmovupd %zmm3, 0(%r10) {%k1}
+	addq		%r11, %r10
+	vmovupd %zmm4, 0(%r10) {%k1}
+	addq		%r11, %r10
+	vmovupd %zmm5, 0(%r10) {%k1}
+	addq		%r11, %r10
+	vmovupd %zmm6, 0(%r10) {%k1}
+	addq		%r11, %r10
+	vmovupd %zmm7, 0(%r10) {%k1}
+	addq		%r11, %r10
+
+	vmovupd %zmm8, 0(%r10) {%k1}
+	addq		%r11, %r10
+	vmovupd %zmm9, 0(%r10) {%k1}
+	addq		%r11, %r10
+	vmovupd %zmm10, 0(%r10) {%k1}
+	addq		%r11, %r10
+	vmovupd %zmm11, 0(%r10) {%k1}
+	addq		%r11, %r10
+	vmovupd %zmm12, 0(%r10) {%k1}
+	addq		%r11, %r10
+	vmovupd %zmm13, 0(%r10) {%k1}
+	addq		%r11, %r10
+	vmovupd %zmm14, 0(%r10) {%k1}
+	addq		%r11, %r10
+	vmovupd %zmm15, 0(%r10) {%k1}
+	addq		%r11, %r10
+
+	vmovupd %zmm16, 0(%r10) {%k1}
+	addq		%r11, %r10
+	cmpl		$ 18, %r13d
+	jl			0f // end
+	vmovupd %zmm17, 0(%r10) {%k1}
+	addq		%r11, %r10
+	cmpl		$ 19, %r13d
+	jl			0f // end
+	vmovupd %zmm18, 0(%r10) {%k1}
+	addq		%r11, %r10
+	cmpl		$ 20, %r13d
+	jl			0f // end
+	vmovupd %zmm19, 0(%r10) {%k1}
+	addq		%r11, %r10
+	cmpl		$ 21, %r13d
+	jl			0f // end
+	vmovupd %zmm20, 0(%r10) {%k1}
+	addq		%r11, %r10
+	cmpl		$ 22, %r13d
+	jl			0f // end
+	vmovupd %zmm21, 0(%r10) {%k1}
+	addq		%r11, %r10
+	cmpl		$ 23, %r13d
+	jl			0f // end
+	vmovupd %zmm22, 0(%r10) {%k1}
+	addq		%r11, %r10
+	cmpl		$ 23, %r13d
+	je			0f // end
+	vmovupd %zmm23, 0(%r10) {%k1}
+//	addq		%r11, %r10
+
+0:
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_store_8x24_vs_lib)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
 // prefetch
 //
 // input arguments:
@@ -4010,6 +4550,95 @@
 	ret
 
 	FUN_END(inner_prefetch0_24x8_lib)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// prefetch
+//
+// input arguments:
+// r10  <- D
+// r11  <- ldd
+//
+// output arguments:
+
+#if MACRO_LEVEL>=1
+	.macro INNER_PREFETCH0_8X24_LIB
+#else
+	.p2align 4,,15
+	FUN_START(inner_prefetch0_8x24_lib)
+#endif
+
+	leaq		0(%r11, %r11, 2), %r12
+	leaq		0(%r10, %r11, 4), %r13
+
+	prefetcht0	0(%r10)
+	prefetcht0	63(%r10)
+	prefetcht0	0(%r10, %r11)
+	prefetcht0	63(%r10, %r11)
+	prefetcht0	0(%r10, %r11, 2)
+	prefetcht0	63(%r10, %r11, 2)
+	prefetcht0	0(%r10, %r12)
+	prefetcht0	63(%r10, %r12)
+	prefetcht0	0(%r13)
+	prefetcht0	63(%r13)
+	prefetcht0	0(%r13, %r11)
+	prefetcht0	63(%r13, %r11)
+	prefetcht0	0(%r13, %r11, 2)
+	prefetcht0	63(%r13, %r11, 2)
+	prefetcht0	0(%r13, %r12)
+	prefetcht0	63(%r13, %r12)
+
+	leaq		0(%r10, %r11, 8), %r10
+	leaq		0(%r13, %r11, 8), %r13
+
+	prefetcht0	0(%r10)
+	prefetcht0	63(%r10)
+	prefetcht0	0(%r10, %r11)
+	prefetcht0	63(%r10, %r11)
+	prefetcht0	0(%r10, %r11, 2)
+	prefetcht0	63(%r10, %r11, 2)
+	prefetcht0	0(%r10, %r12)
+	prefetcht0	63(%r10, %r12)
+	prefetcht0	0(%r13)
+	prefetcht0	63(%r13)
+	prefetcht0	0(%r13, %r11)
+	prefetcht0	63(%r13, %r11)
+	prefetcht0	0(%r13, %r11, 2)
+	prefetcht0	63(%r13, %r11, 2)
+	prefetcht0	0(%r13, %r12)
+	prefetcht0	63(%r13, %r12)
+
+	leaq		0(%r10, %r11, 8), %r10
+	leaq		0(%r13, %r11, 8), %r13
+
+	prefetcht0	0(%r10)
+	prefetcht0	63(%r10)
+	prefetcht0	0(%r10, %r11)
+	prefetcht0	63(%r10, %r11)
+	prefetcht0	0(%r10, %r11, 2)
+	prefetcht0	63(%r10, %r11, 2)
+	prefetcht0	0(%r10, %r12)
+	prefetcht0	63(%r10, %r12)
+	prefetcht0	0(%r13)
+	prefetcht0	63(%r13)
+	prefetcht0	0(%r13, %r11)
+	prefetcht0	63(%r13, %r11)
+	prefetcht0	0(%r13, %r11, 2)
+	prefetcht0	63(%r13, %r11, 2)
+	prefetcht0	0(%r13, %r12)
+	prefetcht0	63(%r13, %r12)
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_prefetch0_8x24_lib)
 #endif
 
 
@@ -4340,6 +4969,188 @@
 	ret
 
 	FUN_END(kernel_dgemm_nt_24x8_vs_lib8ccc)
+
+
+
+
+
+//                                  1      2              3          4        5          6        7             8          9        10         11
+// void kernel_dgemm_nt_8x24_libc8cc(int k, double *alpha, double *A, int lda, double *B, int sdb, double *beta, double *C, int ldc, double *D, int ldd);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dgemm_nt_8x24_libc8cc)
+
+	PROLOGUE
+
+	// zero accumulation registers
+
+	ZERO_ACC
+
+
+	// call inner dgemm kernel nn
+
+	movq	ARG1, %r10 // k
+	movq	ARG5, %r11  // B
+	movq	ARG6, %r12 // sdb
+	sall	$ 6, %r12d // 8*sdb*sizeof(double)
+	movq	ARG3, %r13  // A
+	movq	ARG4, %r14  // lda
+	sall	$ 3, %r14d
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_24X8_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nt_24x8_lib8c)
+#endif
+
+#if MACRO_LEVEL>=1
+	INNER_TRAN_24X8_LIB8
+#else
+	CALL(inner_tran_24x8_lib8)
+#endif
+
+
+	// prefetch D TODO
+
+	movq	ARG10, %r10 // D
+	movq	ARG11, %r11 // ldd
+	sall	$ 3, %r11d
+
+#if MACRO_LEVEL>=1
+	INNER_PREFETCH0_8X24_LIB
+#else
+	CALL(inner_prefetch0_8x24_lib)
+#endif
+
+
+	// call inner blend
+
+	movq	ARG2, %r10 // alpha
+	movq	ARG7, %r11 // beta
+	movq	ARG8, %r12   // C
+	movq	ARG9, %r13   // ldc
+	sall	$ 3, %r13d
+
+#if MACRO_LEVEL>=1
+	INNER_SCALE_AB_8X24_LIB
+#else
+	CALL(inner_scale_ab_8x24_lib)
+#endif
+
+
+	// store n
+
+	movq	ARG10, %r10 // D
+	movq	ARG11, %r11 // ldd
+	sall	$ 3, %r11d
+
+#if MACRO_LEVEL>=1
+	INNER_STORE_8X24_LIB
+#else
+	CALL(inner_store_8x24_lib)
+#endif
+
+
+	EPILOGUE
+
+	ret
+
+	FUN_END(kernel_dgemm_nt_8x24_libc8cc)
+
+
+
+
+
+
+//                                      1      2              3          4        5          6        7             8          9        10         11       12      13
+// void kernel_dgemm_nt_8x24_vs_libc8cc(int k, double *alpha, double *A, int lda, double *B, int sdb, double *beta, double *C, int ldc, double *D, int ldd, int m1, int n1);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dgemm_nt_8x24_vs_libc8cc)
+
+	PROLOGUE
+
+	// zero accumulation registers
+
+	ZERO_ACC
+
+
+	// call inner dgemm kernel nn
+
+	movq	ARG1, %r10 // k
+	movq	ARG5, %r11  // B
+	movq	ARG6, %r12 // sdb
+	sall	$ 6, %r12d // 8*sdb*sizeof(double)
+	movq	ARG3, %r13  // A
+	movq	ARG4, %r14  // lda
+	sall	$ 3, %r14d
+	movq	ARG13, %r15 // n1
+	movq	ARG12, %rax // m1
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_24X8_VS_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nt_24x8_vs_lib8c)
+#endif
+
+#if MACRO_LEVEL>=1
+	INNER_TRAN_24X8_LIB8
+#else
+	CALL(inner_tran_24x8_lib8)
+#endif
+
+
+	// prefetch D
+	// TODO prefetch vs !!!
+
+//	movq	ARG9, %r10 // D
+//	movq	ARG10, %r11 // ldd
+//	sall	$ 3, %r11d
+
+#if MACRO_LEVEL>=1
+//	INNER_PREFETCH0_24X8_LIB
+#else
+//	CALL(inner_prefetch0_24x8_lib)
+#endif
+
+
+	// call inner blend
+
+	movq	ARG2, %r10 // alpha
+	movq	ARG7, %r11 // beta
+	movq	ARG8, %r12   // C
+	movq	ARG9, %r13   // ldc
+	sall	$ 3, %r13d
+	movq	ARG12, %r14 // m1
+	movq	ARG13, %r15 // n1
+
+#if MACRO_LEVEL>=1
+	INNER_SCALE_AB_8X24_VS_LIB
+#else
+	CALL(inner_scale_ab_8x24_vs_lib)
+#endif
+
+
+	// store n
+
+	movq	ARG10, %r10 // D
+	movq	ARG11, %r11 // ldd
+	sall	$ 3, %r11d
+	movq	ARG12, %r12 // m1
+	movq	ARG13, %r13 // n1
+
+#if MACRO_LEVEL>=1
+	INNER_STORE_8X24_VS_LIB
+#else
+	CALL(inner_store_8x24_vs_lib)
+#endif
+
+
+	EPILOGUE
+
+	ret
+
+	FUN_END(kernel_dgemm_nt_8x24_vs_libc8cc)
 
 
 

--- a/kernel/avx512/kernel_dgemm_24x8_lib.S
+++ b/kernel/avx512/kernel_dgemm_24x8_lib.S
@@ -3481,6 +3481,3428 @@
 
 // common inner routine with file scope
 //
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- sda
+// r13   <- B
+// r14   <- ldb
+// zmm0  <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_24X8_LIB8C
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_24x8_lib8c)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	leaq	0(%r13, %r14, 4), %r15
+	leaq	0(%r14, %r14, 2), %rax
+
+	// preload
+
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+//	prefetcht0		32(%r13)
+//	...
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	0*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	0*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	0*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	0*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 // A
+	vbroadcastsd	1*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	1*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	1*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	1*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	1*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	1*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	1*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	1*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 // A
+	vbroadcastsd	2*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	2*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	2*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	2*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	2*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	2*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	2*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	2*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 // A
+	vbroadcastsd	3*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	3*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	3*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	3*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	3*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	3*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	3*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	3*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+	addq	$ 4*8, %r13
+	addq	$ 4*8, %r15
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean4-up
+
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	0*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	0*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	0*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	0*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 // A
+	vbroadcastsd	1*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	1*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	1*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	1*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	1*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	1*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	1*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	1*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 // A
+	vbroadcastsd	2*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	2*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	2*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	2*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	2*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	2*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	2*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	2*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 // A
+	vbroadcastsd	3*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	3*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	3*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	3*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	3*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	3*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	3*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	3*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+	addq	$ 4*8, %r13
+	addq	$ 4*8, %r15
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	0*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	0*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	0*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	0*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	subl	$ 1, %r10d
+	addq	$ 1*64, %r11
+	addq	$ 1*8, %r13
+	addq	$ 1*8, %r15
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_24x8_lib8c)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- sda
+// r13   <- B
+// r14   <- ldb
+// k1    <- m_mask
+// zmm0  <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_3VX8_LIB8C
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_3vx8_lib8c)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	leaq	0(%r13, %r14, 4), %r15
+	leaq	0(%r14, %r14, 2), %rax
+
+	// preload
+
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+//	prefetcht0		32(%r13)
+//	...
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	0*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	0*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	0*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	0*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	1*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	1*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	1*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	1*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	1*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	1*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	1*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	1*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	2*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	2*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	2*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	2*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	2*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	2*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	2*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	2*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	3*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	3*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	3*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	3*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	3*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	3*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	3*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	3*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+	addq	$ 4*8, %r13
+	addq	$ 4*8, %r15
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean4-up
+
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	0*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	0*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	0*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	0*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	1*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	1*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	1*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	1*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	1*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	1*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	1*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	1*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	2*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	2*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	2*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	2*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	2*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	2*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	2*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	2*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	3*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	3*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	3*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	3*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	3*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	3*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	3*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	3*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+	addq	$ 4*8, %r13
+	addq	$ 4*8, %r15
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	0*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	0*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	0*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	0*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	subl	$ 1, %r10d
+	addq	$ 1*64, %r11
+	addq	$ 1*8, %r13
+	addq	$ 1*8, %r15
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_3vx8_lib8c)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- sda
+// r13   <- B
+// r14   <- ldb
+// k1    <- m_mask
+// zmm0  <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_3VX7_LIB8C
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_3vx7_lib8c)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	leaq	0(%r13, %r14, 4), %r15
+	leaq	0(%r14, %r14, 2), %rax
+
+	// preload
+
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+//	prefetcht0		32(%r13)
+//	...
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	0*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	0*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	0*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	0*8(%r15, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	1*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	1*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	1*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	1*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	1*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	1*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	1*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	1*8(%r15, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	2*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	2*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	2*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	2*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	2*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	2*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	2*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	2*8(%r15, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	3*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	3*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	3*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	3*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	3*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	3*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	3*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	3*8(%r15, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+	addq	$ 4*8, %r13
+	addq	$ 4*8, %r15
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean4-up
+
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	0*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	0*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	0*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	0*8(%r15, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	1*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	1*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	1*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	1*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	1*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	1*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	1*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	1*8(%r15, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	2*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	2*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	2*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	2*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	2*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	2*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	2*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	2*8(%r15, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	3*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	3*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	3*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	3*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	3*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	3*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	3*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	3*8(%r15, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+	addq	$ 4*8, %r13
+	addq	$ 4*8, %r15
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	0*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	0*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	0*8(%r15, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	0*8(%r15, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	subl	$ 1, %r10d
+	addq	$ 1*64, %r11
+	addq	$ 1*8, %r13
+	addq	$ 1*8, %r15
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_3vx7_lib8c)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- sda
+// r13   <- B
+// r14   <- ldb
+// k1    <- m_mask
+// zmm0  <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_3VX6_LIB8C
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_3vx6_lib8c)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	leaq	0(%r13, %r14, 4), %r15
+	leaq	0(%r14, %r14, 2), %rax
+
+	// preload
+
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+//	prefetcht0		32(%r13)
+//	...
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	0*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	0*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	0*8(%r15, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	0*8(%r15, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	1*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	1*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	1*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	1*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	1*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	1*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	1*8(%r15, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	1*8(%r15, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	2*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	2*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	2*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	2*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	2*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	2*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	2*8(%r15, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	2*8(%r15, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	3*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	3*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	3*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	3*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	3*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	3*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	3*8(%r15, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	3*8(%r15, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+	addq	$ 4*8, %r13
+	addq	$ 4*8, %r15
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean4-up
+
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	0*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	0*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	0*8(%r15, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	0*8(%r15, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	1*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	1*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	1*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	1*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	1*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	1*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	1*8(%r15, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	1*8(%r15, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	2*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	2*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	2*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	2*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	2*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	2*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	2*8(%r15, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	2*8(%r15, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	3*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	3*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	3*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	3*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	3*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	3*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	3*8(%r15, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	3*8(%r15, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+	addq	$ 4*8, %r13
+	addq	$ 4*8, %r15
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	0*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	0*8(%r15, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	0*8(%r15, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	0*8(%r15, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	subl	$ 1, %r10d
+	addq	$ 1*64, %r11
+	addq	$ 1*8, %r13
+	addq	$ 1*8, %r15
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_3vx6_lib8c)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- sda
+// r13   <- B
+// r14   <- ldb
+// k1    <- m_mask
+// zmm0  <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_3VX5_LIB8C
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_3vx5_lib8c)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	leaq	0(%r13, %r14, 4), %r15
+	leaq	0(%r14, %r14, 2), %rax
+
+	// preload
+
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+//	prefetcht0		32(%r13)
+//	...
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	0*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+//	vbroadcastsd	0*8(%r15, %r14), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm26, %zmm24, %zmm13
+//	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	0*8(%r15, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	0*8(%r15, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	1*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	1*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	1*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	1*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	1*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+//	vbroadcastsd	1*8(%r15, %r14), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm26, %zmm24, %zmm13
+//	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	1*8(%r15, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	1*8(%r15, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	2*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	2*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	2*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	2*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	2*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+//	vbroadcastsd	2*8(%r15, %r14), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm26, %zmm24, %zmm13
+//	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	2*8(%r15, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	2*8(%r15, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	3*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	3*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	3*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	3*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	3*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+//	vbroadcastsd	3*8(%r15, %r14), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm26, %zmm24, %zmm13
+//	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	3*8(%r15, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	3*8(%r15, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+	addq	$ 4*8, %r13
+	addq	$ 4*8, %r15
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean4-up
+
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	0*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+//	vbroadcastsd	0*8(%r15, %r14), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm26, %zmm24, %zmm13
+//	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	0*8(%r15, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	0*8(%r15, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	1*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	1*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	1*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	1*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	1*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+//	vbroadcastsd	1*8(%r15, %r14), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm26, %zmm24, %zmm13
+//	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	1*8(%r15, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	1*8(%r15, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	2*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	2*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	2*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	2*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	2*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+//	vbroadcastsd	2*8(%r15, %r14), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm26, %zmm24, %zmm13
+//	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	2*8(%r15, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	2*8(%r15, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	3*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	3*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	3*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	3*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	3*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+//	vbroadcastsd	3*8(%r15, %r14), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm26, %zmm24, %zmm13
+//	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	3*8(%r15, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	3*8(%r15, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+	addq	$ 4*8, %r13
+	addq	$ 4*8, %r15
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	0*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+//	vbroadcastsd	0*8(%r15, %r14), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm26, %zmm24, %zmm13
+//	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	0*8(%r15, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	0*8(%r15, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+
+	subl	$ 1, %r10d
+	addq	$ 1*64, %r11
+	addq	$ 1*8, %r13
+	addq	$ 1*8, %r15
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_3vx5_lib8c)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- sda
+// r13   <- B
+// r14   <- ldb
+// k1    <- m_mask
+// zmm0  <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_3VX4_LIB8C
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_3vx4_lib8c)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	leaq	0(%r13, %r14, 4), %r15
+	leaq	0(%r14, %r14, 2), %rax
+
+	// preload
+
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+//	prefetcht0		32(%r13)
+//	...
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	1*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	1*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	1*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	1*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	2*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	2*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	2*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	2*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	3*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	3*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	3*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	3*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+	addq	$ 4*8, %r13
+	addq	$ 4*8, %r15
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean4-up
+
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	1*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	1*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	1*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	1*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	2*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	2*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	2*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	2*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	3*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	3*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	3*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	3*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+	addq	$ 4*8, %r13
+	addq	$ 4*8, %r15
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	subl	$ 1, %r10d
+	addq	$ 1*64, %r11
+	addq	$ 1*8, %r13
+	addq	$ 1*8, %r15
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_3vx4_lib8c)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- sda
+// r13   <- B
+// r14   <- ldb
+// k1    <- m_mask
+// zmm0  <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_3VX3_LIB8C
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_3vx3_lib8c)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	leaq	0(%r13, %r14, 4), %r15
+	leaq	0(%r14, %r14, 2), %rax
+
+	// preload
+
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+//	prefetcht0		32(%r13)
+//	...
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	1*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	1*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	1*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	1*8(%r13, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	2*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	2*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	2*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	2*8(%r13, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	3*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	3*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	3*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	3*8(%r13, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+	addq	$ 4*8, %r13
+	addq	$ 4*8, %r15
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean4-up
+
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	1*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	1*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	1*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	1*8(%r13, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	2*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	2*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	2*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	2*8(%r13, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	3*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	3*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	3*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	3*8(%r13, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+	addq	$ 4*8, %r13
+	addq	$ 4*8, %r15
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	subl	$ 1, %r10d
+	addq	$ 1*64, %r11
+	addq	$ 1*8, %r13
+	addq	$ 1*8, %r15
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_3vx3_lib8c)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- sda
+// r13   <- B
+// r14   <- ldb
+// k1    <- m_mask
+// zmm0  <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_3VX2_LIB8C
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_3vx2_lib8c)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	leaq	0(%r13, %r14, 4), %r15
+	leaq	0(%r14, %r14, 2), %rax
+
+	// preload
+
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+//	prefetcht0		32(%r13)
+//	...
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	1*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	1*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	1*8(%r13, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	1*8(%r13, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	2*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	2*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	2*8(%r13, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	2*8(%r13, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	3*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	3*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	3*8(%r13, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	3*8(%r13, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+	addq	$ 4*8, %r13
+	addq	$ 4*8, %r15
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean4-up
+
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	1*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	1*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	1*8(%r13, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	1*8(%r13, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	2*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	2*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	2*8(%r13, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	2*8(%r13, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	3*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	3*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	3*8(%r13, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	3*8(%r13, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+	addq	$ 4*8, %r13
+	addq	$ 4*8, %r15
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	subl	$ 1, %r10d
+	addq	$ 1*64, %r11
+	addq	$ 1*8, %r13
+	addq	$ 1*8, %r15
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_3vx2_lib8c)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- sda
+// r13   <- B
+// r14   <- ldb
+// k1    <- m_mask
+// zmm0  <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_3VX1_LIB8C
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_3vx1_lib8c)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	leaq	0(%r13, %r14, 4), %r15
+	leaq	0(%r14, %r14, 2), %rax
+
+	// preload
+
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+//	prefetcht0		32(%r13)
+//	...
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+//	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm26, %zmm24, %zmm9
+//	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	1*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+//	vbroadcastsd	1*8(%r13, %r14), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm26, %zmm24, %zmm9
+//	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	1*8(%r13, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	1*8(%r13, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	2*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+//	vbroadcastsd	2*8(%r13, %r14), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm26, %zmm24, %zmm9
+//	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	2*8(%r13, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	2*8(%r13, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	3*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+//	vbroadcastsd	3*8(%r13, %r14), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm26, %zmm24, %zmm9
+//	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	3*8(%r13, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	3*8(%r13, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+	addq	$ 4*8, %r13
+	addq	$ 4*8, %r15
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean4-up
+
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+//	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm26, %zmm24, %zmm9
+//	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	1*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+//	vbroadcastsd	1*8(%r13, %r14), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm26, %zmm24, %zmm9
+//	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	1*8(%r13, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	1*8(%r13, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	2*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+//	vbroadcastsd	2*8(%r13, %r14), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm26, %zmm24, %zmm9
+//	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	2*8(%r13, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	2*8(%r13, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	3*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+//	vbroadcastsd	3*8(%r13, %r14), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm26, %zmm24, %zmm9
+//	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	3*8(%r13, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	3*8(%r13, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+	addq	$ 4*8, %r13
+	addq	$ 4*8, %r15
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0*8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+//	vbroadcastsd	0*8(%r13, %r14), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm26, %zmm24, %zmm9
+//	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	0*8(%r13, %r14, 2), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	0*8(%r13, %rax), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+
+	subl	$ 1, %r10d
+	addq	$ 1*64, %r11
+	addq	$ 1*8, %r13
+	addq	$ 1*8, %r15
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_3vx1_lib8c)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B
+// r14   <- ldb
+// r15   <- m1
+// rax   <- n1
+// zmm0  <- []
+// ...
+// zmm23 <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// r14   <- ldb
+// r15   <- m1
+// rax   <- n1
+// zmm0  <- []
+// ...
+// zmm23 <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_24X8_VS_LIB8C
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_24x8_vs_lib8c)
+#endif
+
+	// compute mask for rows
+	vcvtsi2sd	%r15d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC01(%rip), %zmm24
+#elif defined(OS_MAC)
+	vmovupd		LC01(%rip), %zmm24
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm24, %zmm25
+	vpmovq2m	%zmm25, %k1
+
+	cmpl	$ 1, %eax
+	jg		100f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_3VX1_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nn_3vx1_lib8c)
+#endif
+	
+	jmp		107f
+
+100:
+
+	cmpl	$ 2, %eax
+	jg		101f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_3VX2_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nn_3vx2_lib8c)
+#endif
+	
+	jmp		107f
+
+101:
+
+	cmpl	$ 3, %eax
+	jg		102f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_3VX3_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nn_3vx3_lib8c)
+#endif
+	
+	jmp		107f
+
+102:
+
+	cmpl	$ 4, %eax
+	jg		103f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_3VX4_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nn_3vx4_lib8c)
+#endif
+	
+	jmp		107f
+
+103:
+
+	cmpl	$ 5, %eax
+	jg		104f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_3VX5_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nn_3vx5_lib8c)
+#endif
+	
+	jmp		107f
+
+104:
+
+	cmpl	$ 6, %eax
+	jg		105f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_3VX6_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nn_3vx6_lib8c)
+#endif
+	
+	jmp		107f
+
+105:
+
+	cmpl	$ 7, %eax
+	jg		106f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_3VX7_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nn_3vx7_lib8c)
+#endif
+	
+	jmp		107f
+
+106:
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_3VX8_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nn_3vx8_lib8c)
+#endif
+
+107:
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_24x8_vs_lib8c)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
 // scale for generic alpha and beta
 //
 // input arguments:
@@ -5151,6 +8573,357 @@
 	ret
 
 	FUN_END(kernel_dgemm_nt_8x24_vs_libc8cc)
+
+
+
+
+
+//                                  1      2              3          4        5          6        7             8          9        10         11
+// void kernel_dgemm_nn_24x8_lib8ccc(int k, double *alpha, double *A, int sda, double *B, int ldb, double *beta, double *C, int ldc, double *D, int ldd);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dgemm_nn_24x8_lib8ccc)
+
+	PROLOGUE
+
+	// zero accumulation registers
+
+	ZERO_ACC
+
+
+	// call inner dgemm kernel nn
+
+	movq	ARG1, %r10 // k
+	movq	ARG3, %r11  // A
+	movq	ARG4, %r12 // sda
+	sall	$ 6, %r12d // 8*sda*sizeof(double)
+	movq	ARG5, %r13  // B
+	movq	ARG6, %r14  // ldb
+	sall	$ 3, %r14d
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_24X8_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nn_24x8_lib8c)
+#endif
+
+
+	// prefetch D
+
+	movq	ARG10, %r10 // D
+	movq	ARG11, %r11 // ldd
+	sall	$ 3, %r11d
+
+#if MACRO_LEVEL>=1
+	INNER_PREFETCH0_24X8_LIB
+#else
+	CALL(inner_prefetch0_24x8_lib)
+#endif
+
+
+	// call inner blend
+
+	movq	ARG2, %r10 // alpha
+	movq	ARG7, %r11 // beta
+	movq	ARG8, %r12   // C
+	movq	ARG9, %r13   // ldc
+	sall	$ 3, %r13d
+
+#if MACRO_LEVEL>=1
+	INNER_SCALE_AB_24X8_LIB
+#else
+	CALL(inner_scale_ab_24x8_lib)
+#endif
+
+
+	// store n
+
+	movq	ARG10, %r10 // D
+	movq	ARG11, %r11 // ldd
+	sall	$ 3, %r11d
+
+#if MACRO_LEVEL>=1
+	INNER_STORE_24X8_LIB
+#else
+	CALL(inner_store_24x8_lib)
+#endif
+
+
+	EPILOGUE
+
+	ret
+
+	FUN_END(kernel_dgemm_nn_24x8_lib8ccc)
+
+
+
+
+
+//                                      1      2              3          4        5          6        7             8          9        10         11       12      13
+// void kernel_dgemm_nn_24x8_vs_lib8ccc(int k, double *alpha, double *A, int sda, double *B, int ldb, double *beta, double *C, int ldc, double *D, int ldd, int m1, int n1);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dgemm_nn_24x8_vs_lib8ccc)
+
+	PROLOGUE
+
+	// zero accumulation registers
+
+	ZERO_ACC
+
+
+	// call inner dgemm kernel nn
+
+	movq	ARG1, %r10 // k
+	movq	ARG3, %r11  // A
+	movq	ARG4, %r12 // sda
+	sall	$ 6, %r12d // 8*sda*sizeof(double)
+	movq	ARG5, %r13  // B
+	movq	ARG6, %r14  // ldb
+	sall	$ 3, %r14d
+	movq	ARG12, %r15 // m1
+	movq	ARG13, %rax // n1
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_24X8_VS_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nn_24x8_vs_lib8c)
+#endif
+
+
+	// prefetch D
+	// TODO prefetch vs !!!
+
+//	movq	ARG9, %r10 // D
+//	movq	ARG10, %r11 // ldd
+//	sall	$ 3, %r11d
+
+#if MACRO_LEVEL>=1
+//	INNER_PREFETCH0_24X8_LIB
+#else
+//	CALL(inner_prefetch0_24x8_lib)
+#endif
+
+
+	// call inner blend
+
+	movq	ARG2, %r10 // alpha
+	movq	ARG7, %r11 // beta
+	movq	ARG8, %r12   // C
+	movq	ARG9, %r13   // ldc
+	sall	$ 3, %r13d
+	movq	ARG12, %r14 // m1
+	movq	ARG13, %r15 // n1
+
+#if MACRO_LEVEL>=1
+	INNER_SCALE_AB_24X8_VS_LIB
+#else
+	CALL(inner_scale_ab_24x8_vs_lib)
+#endif
+
+
+	// store n
+
+	movq	ARG10, %r10 // D
+	movq	ARG11, %r11 // ldd
+	sall	$ 3, %r11d
+	movq	ARG12, %r12 // m1
+	movq	ARG13, %r13 // n1
+
+#if MACRO_LEVEL>=1
+	INNER_STORE_24X8_VS_LIB
+#else
+	CALL(inner_store_24x8_vs_lib)
+#endif
+
+
+	EPILOGUE
+
+	ret
+
+	FUN_END(kernel_dgemm_nn_24x8_vs_lib8ccc)
+
+
+
+
+
+//                                  1      2              3          4        5          6        7             8          9        10         11
+// void kernel_dgemm_tt_8x24_libc8cc(int k, double *alpha, double *A, int lda, double *B, int sdb, double *beta, double *C, int ldc, double *D, int ldd);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dgemm_tt_8x24_libc8cc)
+
+	PROLOGUE
+
+	// zero accumulation registers
+
+	ZERO_ACC
+
+
+	// call inner dgemm kernel nn
+
+	movq	ARG1, %r10 // k
+	movq	ARG5, %r11  // B
+	movq	ARG6, %r12 // sdb
+	sall	$ 6, %r12d // 8*sdb*sizeof(double)
+	movq	ARG3, %r13  // A
+	movq	ARG4, %r14  // lda
+	sall	$ 3, %r14d
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_24X8_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nn_24x8_lib8c)
+#endif
+
+#if MACRO_LEVEL>=1
+	INNER_TRAN_24X8_LIB8
+#else
+	CALL(inner_tran_24x8_lib8)
+#endif
+
+
+	// prefetch D
+
+	movq	ARG10, %r10 // D
+	movq	ARG11, %r11 // ldd
+	sall	$ 3, %r11d
+
+#if MACRO_LEVEL>=1
+	INNER_PREFETCH0_8X24_LIB
+#else
+	CALL(inner_prefetch0_8x24_lib)
+#endif
+
+
+	// call inner blend
+
+	movq	ARG2, %r10 // alpha
+	movq	ARG7, %r11 // beta
+	movq	ARG8, %r12   // C
+	movq	ARG9, %r13   // ldc
+	sall	$ 3, %r13d
+
+#if MACRO_LEVEL>=1
+	INNER_SCALE_AB_8X24_LIB
+#else
+	CALL(inner_scale_ab_8x24_lib)
+#endif
+
+
+	// store n
+
+	movq	ARG10, %r10 // D
+	movq	ARG11, %r11 // ldd
+	sall	$ 3, %r11d
+
+#if MACRO_LEVEL>=1
+	INNER_STORE_8X24_LIB
+#else
+	CALL(inner_store_8x24_lib)
+#endif
+
+
+	EPILOGUE
+
+	ret
+
+	FUN_END(kernel_dgemm_tt_8x24_libc8cc)
+
+
+
+
+
+
+//                                      1      2              3          4        5          6        7             8          9        10         11       12      13
+// void kernel_dgemm_tt_8x24_vs_libc8cc(int k, double *alpha, double *A, int lda, double *B, int sdb, double *beta, double *C, int ldc, double *D, int ldd, int m1, int n1);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dgemm_tt_8x24_vs_libc8cc)
+
+	PROLOGUE
+
+	// zero accumulation registers
+
+	ZERO_ACC
+
+
+	// call inner dgemm kernel nn
+
+	movq	ARG1, %r10 // k
+	movq	ARG5, %r11  // B
+	movq	ARG6, %r12 // sdb
+	sall	$ 6, %r12d // 8*sdb*sizeof(double)
+	movq	ARG3, %r13  // A
+	movq	ARG4, %r14  // lda
+	sall	$ 3, %r14d
+	movq	ARG13, %r15 // n1
+	movq	ARG12, %rax // m1
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_24X8_VS_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nn_24x8_vs_lib8c)
+#endif
+
+#if MACRO_LEVEL>=1
+	INNER_TRAN_24X8_LIB8
+#else
+	CALL(inner_tran_24x8_lib8)
+#endif
+
+
+	// prefetch D
+	// TODO prefetch vs !!!
+
+//	movq	ARG9, %r10 // D
+//	movq	ARG10, %r11 // ldd
+//	sall	$ 3, %r11d
+
+#if MACRO_LEVEL>=1
+//	INNER_PREFETCH0_8X24_LIB
+#else
+//	CALL(inner_prefetch0_8x24_lib)
+#endif
+
+
+	// call inner blend
+
+	movq	ARG2, %r10 // alpha
+	movq	ARG7, %r11 // beta
+	movq	ARG8, %r12   // C
+	movq	ARG9, %r13   // ldc
+	sall	$ 3, %r13d
+	movq	ARG12, %r14 // m1
+	movq	ARG13, %r15 // n1
+
+#if MACRO_LEVEL>=1
+	INNER_SCALE_AB_8X24_VS_LIB
+#else
+	CALL(inner_scale_ab_8x24_vs_lib)
+#endif
+
+
+	// store n
+
+	movq	ARG10, %r10 // D
+	movq	ARG11, %r11 // ldd
+	sall	$ 3, %r11d
+	movq	ARG12, %r12 // m1
+	movq	ARG13, %r13 // n1
+
+#if MACRO_LEVEL>=1
+	INNER_STORE_8X24_VS_LIB
+#else
+	CALL(inner_store_8x24_vs_lib)
+#endif
+
+
+	EPILOGUE
+
+	ret
+
+	FUN_END(kernel_dgemm_tt_8x24_vs_libc8cc)
 
 
 

--- a/kernel/avx512/kernel_dgemm_24x8_lib.S
+++ b/kernel/avx512/kernel_dgemm_24x8_lib.S
@@ -507,7 +507,72 @@
 
 
 
-//                                 1      2              3          4        5          6             7          8        9          10
+// common inner routine with file scope
+//
+// prefetch
+//
+// input arguments:
+// r10  <- D
+// r11  <- ldd
+//
+// output arguments:
+
+#if MACRO_LEVEL>=1
+	.macro INNER_PREFETCH0_24X8_LIB
+#else
+	.p2align 4,,15
+	FUN_START(inner_prefetch0_24x8_lib)
+#endif
+
+	leaq		0(%r11, %r11, 2), %r12
+	leaq		0(%r10, %r11, 4), %r13
+
+	prefetcht0	0(%r10)
+	prefetcht0	64(%r10)
+	prefetcht0	128(%r10)
+	prefetcht0	191(%r10)
+	prefetcht0	0(%r10, %r11)
+	prefetcht0	64(%r10, %r11)
+	prefetcht0	128(%r10, %r11)
+	prefetcht0	191(%r10, %r11)
+	prefetcht0	0(%r10, %r11, 2)
+	prefetcht0	64(%r10, %r11, 2)
+	prefetcht0	128(%r10, %r11, 2)
+	prefetcht0	191(%r10, %r11, 2)
+	prefetcht0	0(%r10, %r12)
+	prefetcht0	64(%r10, %r12)
+	prefetcht0	128(%r10, %r12)
+	prefetcht0	191(%r10, %r12)
+	prefetcht0	0(%r13)
+	prefetcht0	64(%r13)
+	prefetcht0	128(%r13)
+	prefetcht0	191(%r13)
+	prefetcht0	0(%r13, %r11)
+	prefetcht0	64(%r13, %r11)
+	prefetcht0	128(%r13, %r11)
+	prefetcht0	191(%r13, %r11)
+	prefetcht0	0(%r13, %r11, 2)
+	prefetcht0	64(%r13, %r11, 2)
+	prefetcht0	128(%r13, %r11, 2)
+	prefetcht0	191(%r13, %r11, 2)
+	prefetcht0	0(%r13, %r12)
+	prefetcht0	64(%r13, %r12)
+	prefetcht0	128(%r13, %r12)
+	prefetcht0	191(%r13, %r12)
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_prefetch0_24x8_lib)
+#endif
+
+
+
+
+
+//                                   1      2              3          4        5          6             7          8        9          10
 // void kernel_dgemm_nt_24x8_lib88cc(int k, double *alpha, double *A, int sda, double *B, double *beta, double *C, int ldc, double *D, int ldd);
 
 	.p2align 4,,15
@@ -522,23 +587,23 @@
 
 	// prefetch C
 
-//	movq		ARG6, %r10 // beta
-//	vmovsd		0(%r10), %xmm14
-//	vxorpd		%xmm15, %xmm15, %xmm15 // 0.0
-//	vucomisd	%xmm15, %xmm14 // beta==0.0 ?
-//	je			100f // end
+	movq		ARG6, %r10 // beta
+	vmovsd		0(%r10), %xmm14
+	vxorpd		%xmm15, %xmm15, %xmm15 // 0.0
+	vucomisd	%xmm15, %xmm14 // beta==0.0 ?
+	je			100f // end
 
-//	movq	ARG7, %r10 // C
-//	movq	ARG8, %r11 // ldc
-//	sall	$ 3, %r11d
+	movq	ARG7, %r10 // C
+	movq	ARG8, %r11 // ldc
+	sall	$ 3, %r11d
 
 #if MACRO_LEVEL>=1
-//	INNER_PREFETCH0_8X4_LIB
+	INNER_PREFETCH0_24X8_LIB
 #else
-//	CALL(inner_prefetch0_8x4_lib)
+	CALL(inner_prefetch0_24x8_lib)
 #endif
 
-//100:
+100:
 
 
 	// call inner dgemm kernel nn

--- a/kernel/avx512/kernel_dgemm_24x8_lib.S
+++ b/kernel/avx512/kernel_dgemm_24x8_lib.S
@@ -8083,9 +8083,9 @@
 	// prefetch C
 
 	movq		ARG6, %r10 // beta
-	vmovsd		0(%r10), %xmm14
-	vxorpd		%xmm15, %xmm15, %xmm15 // 0.0
-	vucomisd	%xmm15, %xmm14 // beta==0.0 ?
+	vmovsd		0(%r10), %xmm24
+	vxorpd		%xmm25, %xmm25, %xmm25 // 0.0
+	vucomisd	%xmm25, %xmm24 // beta==0.0 ?
 	je			100f // end
 
 	movq	ARG7, %r10 // C

--- a/kernel/avx512/kernel_dgemm_24x8_lib.S
+++ b/kernel/avx512/kernel_dgemm_24x8_lib.S
@@ -37,6 +37,3450 @@
 
 // common inner routine with file scope
 //
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- sda
+// r13   <- B
+// r14   <- ldb
+// zmm0  <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_24X8_LIB8C
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_24x8_lib8c)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// preload
+
+	prefetcht0		0(%r13)
+	prefetcht0		63(%r13)
+	prefetcht0		0(%r13, %r14)
+	prefetcht0		63(%r13, %r14)
+	prefetcht0		0(%r13, %r14, 2)
+	prefetcht0		63(%r13, %r14, 2)
+	leaq			0(%r14, %r14, 2), %r15
+	prefetcht0		0(%r13, %r15)
+	prefetcht0		63(%r13, %r15)
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	prefetcht0		0(%r13, %r14, 4)
+	prefetcht0		63(%r13, %r14, 4)
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 1
+	prefetcht0		0(%r13, %r14, 4)
+	prefetcht0		63(%r13, %r14, 4)
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 2
+	prefetcht0		0(%r13, %r14, 4)
+	prefetcht0		63(%r13, %r14, 4)
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 3
+	prefetcht0		0(%r13, %r14, 4)
+	prefetcht0		63(%r13, %r14, 4)
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean4-up
+
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	subl	$ 1, %r10d
+	addq	$ 1*64, %r11
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_24x8_lib8c)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- sda
+// r13   <- B
+// r14   <- ldb
+// k1    <- m_mask
+// zmm0  <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_3VX8_LIB8C
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_3vx8_lib8c)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// preload
+
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 1
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 2
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 3
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean4-up
+
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm26, %zmm24, %zmm15
+	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	subl	$ 1, %r10d
+	addq	$ 1*64, %r11
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_3vx8_lib8c)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- sda
+// r13   <- B
+// r14   <- ldb
+// k1    <- m_mask
+// zmm0  <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_3VX7_LIB8C
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_3vx7_lib8c)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// preload
+
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 1
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 2
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 3
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean4-up
+
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm26, %zmm24, %zmm14
+	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	subl	$ 1, %r10d
+	addq	$ 1*64, %r11
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_3vx7_lib8c)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- sda
+// r13   <- B
+// r14   <- ldb
+// k1    <- m_mask
+// zmm0  <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_3VX6_LIB8C
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_3vx6_lib8c)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// preload
+
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 1
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 2
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 3
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean4-up
+
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm26, %zmm24, %zmm13
+	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	subl	$ 1, %r10d
+	addq	$ 1*64, %r11
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_3vx6_lib8c)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- sda
+// r13   <- B
+// r14   <- ldb
+// k1    <- m_mask
+// zmm0  <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_3VX5_LIB8C
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_3vx5_lib8c)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// preload
+
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+//	vbroadcastsd	40(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm26, %zmm24, %zmm13
+//	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 1
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+//	vbroadcastsd	40(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm26, %zmm24, %zmm13
+//	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 2
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+//	vbroadcastsd	40(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm26, %zmm24, %zmm13
+//	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 3
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+//	vbroadcastsd	40(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm26, %zmm24, %zmm13
+//	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean4-up
+
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+//	vbroadcastsd	40(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm26, %zmm24, %zmm13
+//	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+//	vbroadcastsd	40(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm26, %zmm24, %zmm13
+//	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+//	vbroadcastsd	40(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm26, %zmm24, %zmm13
+//	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+//	vbroadcastsd	40(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm26, %zmm24, %zmm13
+//	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm26, %zmm24, %zmm12
+	vfmadd231pd		%zmm27, %zmm24, %zmm20
+//	vbroadcastsd	40(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm26, %zmm24, %zmm13
+//	vfmadd231pd		%zmm27, %zmm24, %zmm21
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm26, %zmm24, %zmm14
+//	vfmadd231pd		%zmm27, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm26, %zmm24, %zmm15
+//	vfmadd231pd		%zmm27, %zmm24, %zmm23
+	addq	%r14, %r13
+
+	subl	$ 1, %r10d
+	addq	$ 1*64, %r11
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_3vx5_lib8c)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- sda
+// r13   <- B
+// r14   <- ldb
+// k1    <- m_mask
+// zmm0  <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_3VX4_LIB8C
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_3vx4_lib8c)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// preload
+
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	// unroll 1
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	// unroll 2
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	// unroll 3
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean4-up
+
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm26, %zmm24, %zmm11
+	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	subl	$ 1, %r10d
+	addq	$ 1*64, %r11
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_3vx4_lib8c)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- sda
+// r13   <- B
+// r14   <- ldb
+// k1    <- m_mask
+// zmm0  <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_3VX3_LIB8C
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_3vx3_lib8c)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// preload
+
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	// unroll 1
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	// unroll 2
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	// unroll 3
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean4-up
+
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm26, %zmm24, %zmm10
+	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	subl	$ 1, %r10d
+	addq	$ 1*64, %r11
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_3vx3_lib8c)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- sda
+// r13   <- B
+// r14   <- ldb
+// k1    <- m_mask
+// zmm0  <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_3VX2_LIB8C
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_3vx2_lib8c)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// preload
+
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	// unroll 1
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	// unroll 2
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	// unroll 3
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean4-up
+
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm26, %zmm24, %zmm9
+	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	subl	$ 1, %r10d
+	addq	$ 1*64, %r11
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_3vx2_lib8c)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- sda
+// r13   <- B
+// r14   <- ldb
+// k1    <- m_mask
+// zmm0  <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_3VX1_LIB8C
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_3vx1_lib8c)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// preload
+
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+//	vbroadcastsd	8(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm26, %zmm24, %zmm9
+//	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	// unroll 1
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+//	vbroadcastsd	8(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm26, %zmm24, %zmm9
+//	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	// unroll 2
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+//	vbroadcastsd	8(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm26, %zmm24, %zmm9
+//	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	// unroll 3
+//	prefetcht0		0(%r13, %r14, 8)
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+//	vbroadcastsd	8(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm26, %zmm24, %zmm9
+//	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean4-up
+
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+//	vbroadcastsd	8(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm26, %zmm24, %zmm9
+//	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11, %r12), %zmm26 // A
+	vmovapd			1*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+//	vbroadcastsd	8(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm26, %zmm24, %zmm9
+//	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11, %r12), %zmm26 // A
+	vmovapd			2*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+//	vbroadcastsd	8(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm26, %zmm24, %zmm9
+//	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11, %r12), %zmm26 // A
+	vmovapd			3*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+//	vbroadcastsd	8(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm26, %zmm24, %zmm9
+//	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11, %r12), %zmm26 // A
+	vmovapd			0*64(%r11, %r12, 2), %zmm27 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm26, %zmm24, %zmm8
+	vfmadd231pd		%zmm27, %zmm24, %zmm16
+//	vbroadcastsd	8(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm26, %zmm24, %zmm9
+//	vfmadd231pd		%zmm27, %zmm24, %zmm17
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm26, %zmm24, %zmm10
+//	vfmadd231pd		%zmm27, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm26, %zmm24, %zmm11
+//	vfmadd231pd		%zmm27, %zmm24, %zmm19
+	addq	%r14, %r13
+
+	subl	$ 1, %r10d
+	addq	$ 1*64, %r11
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_3vx1_lib8c)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B
+// r14   <- ldb
+// r15   <- m1
+// rax   <- n1
+// zmm0  <- []
+// ...
+// zmm23 <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// r14   <- ldb
+// r15   <- m1
+// rax   <- n1
+// zmm0  <- []
+// ...
+// zmm23 <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_24X8_VS_LIB8C
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_24x8_vs_lib8c)
+#endif
+
+	// compute mask for rows
+	vcvtsi2sd	%r15d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC01(%rip), %zmm24
+#elif defined(OS_MAC)
+	vmovupd		LC01(%rip), %zmm24
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm24, %zmm25
+	vpmovq2m	%zmm25, %k1
+
+	cmpl	$ 1, %eax
+	jg		100f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_3VX1_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nt_3vx1_lib8c)
+#endif
+	
+	jmp		107f
+
+100:
+
+	cmpl	$ 2, %eax
+	jg		101f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_3VX2_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nt_3vx2_lib8c)
+#endif
+	
+	jmp		107f
+
+101:
+
+	cmpl	$ 3, %eax
+	jg		102f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_3VX3_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nt_3vx3_lib8c)
+#endif
+	
+	jmp		107f
+
+102:
+
+	cmpl	$ 4, %eax
+	jg		103f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_3VX4_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nt_3vx4_lib8c)
+#endif
+	
+	jmp		107f
+
+103:
+
+	cmpl	$ 5, %eax
+	jg		104f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_3VX5_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nt_3vx5_lib8c)
+#endif
+	
+	jmp		107f
+
+104:
+
+	cmpl	$ 6, %eax
+	jg		105f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_3VX6_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nt_3vx6_lib8c)
+#endif
+	
+	jmp		107f
+
+105:
+
+	cmpl	$ 7, %eax
+	jg		106f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_3VX7_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nt_3vx7_lib8c)
+#endif
+	
+	jmp		107f
+
+106:
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_3VX8_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nt_3vx8_lib8c)
+#endif
+
+107:
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_24x8_vs_lib8c)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
 // scale for generic alpha and beta
 //
 // input arguments:
@@ -726,6 +4170,176 @@
 	ret
 
 	FUN_END(kernel_dgemm_nt_24x8_vs_lib88cc)
+
+
+
+
+
+//                                  1      2              3          4        5          6        7             8          9        10         11
+// void kernel_dgemm_nt_24x8_lib8ccc(int k, double *alpha, double *A, int sda, double *B, int ldb, double *beta, double *C, int ldc, double *D, int ldd);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dgemm_nt_24x8_lib8ccc)
+
+	PROLOGUE
+
+	// zero accumulation registers
+
+	ZERO_ACC
+
+
+	// call inner dgemm kernel nn
+
+	movq	ARG1, %r10 // k
+	movq	ARG3, %r11  // A
+	movq	ARG4, %r12 // sda
+	sall	$ 6, %r12d // 8*sda*sizeof(double)
+	movq	ARG5, %r13  // B
+	movq	ARG6, %r14  // ldb
+	sall	$ 3, %r14d
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_24X8_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nt_24x8_lib8c)
+#endif
+
+
+	// prefetch D
+
+	movq	ARG10, %r10 // D
+	movq	ARG11, %r11 // ldd
+	sall	$ 3, %r11d
+
+#if MACRO_LEVEL>=1
+	INNER_PREFETCH0_24X8_LIB
+#else
+	CALL(inner_prefetch0_24x8_lib)
+#endif
+
+
+	// call inner blend
+
+	movq	ARG2, %r10 // alpha
+	movq	ARG7, %r11 // beta
+	movq	ARG8, %r12   // C
+	movq	ARG9, %r13   // ldc
+	sall	$ 3, %r13d
+
+#if MACRO_LEVEL>=1
+	INNER_SCALE_AB_24X8_LIB
+#else
+	CALL(inner_scale_ab_24x8_lib)
+#endif
+
+
+	// store n
+
+	movq	ARG10, %r10 // D
+	movq	ARG11, %r11 // ldd
+	sall	$ 3, %r11d
+
+#if MACRO_LEVEL>=1
+	INNER_STORE_24X8_LIB
+#else
+	CALL(inner_store_24x8_lib)
+#endif
+
+
+	EPILOGUE
+
+	ret
+
+	FUN_END(kernel_dgemm_nt_24x8_lib8ccc)
+
+
+
+
+
+
+//                                      1      2              3          4        5          6        7             8          9        10         11       12      13
+// void kernel_dgemm_nt_24x8_vs_lib8ccc(int k, double *alpha, double *A, int sda, double *B, int ldb, double *beta, double *C, int ldc, double *D, int ldd, int m1, int n1);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dgemm_nt_24x8_vs_lib8ccc)
+
+	PROLOGUE
+
+	// zero accumulation registers
+
+	ZERO_ACC
+
+
+	// call inner dgemm kernel nn
+
+	movq	ARG1, %r10 // k
+	movq	ARG3, %r11  // A
+	movq	ARG4, %r12 // sda
+	sall	$ 6, %r12d // 8*sda*sizeof(double)
+	movq	ARG5, %r13  // B
+	movq	ARG6, %r14  // ldb
+	sall	$ 3, %r14d
+	movq	ARG12, %r15 // m1
+	movq	ARG13, %rax // n1
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_24X8_VS_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nt_24x8_vs_lib8c)
+#endif
+
+
+	// prefetch D
+	// TODO prefetch vs !!!
+
+//	movq	ARG9, %r10 // D
+//	movq	ARG10, %r11 // ldd
+//	sall	$ 3, %r11d
+
+#if MACRO_LEVEL>=1
+//	INNER_PREFETCH0_24X8_LIB
+#else
+//	CALL(inner_prefetch0_24x8_lib)
+#endif
+
+
+	// call inner blend
+
+	movq	ARG2, %r10 // alpha
+	movq	ARG7, %r11 // beta
+	movq	ARG8, %r12   // C
+	movq	ARG9, %r13   // ldc
+	sall	$ 3, %r13d
+	movq	ARG12, %r14 // m1
+	movq	ARG13, %r15 // n1
+
+#if MACRO_LEVEL>=1
+	INNER_SCALE_AB_24X8_VS_LIB
+#else
+	CALL(inner_scale_ab_24x8_vs_lib)
+#endif
+
+
+	// store n
+
+	movq	ARG10, %r10 // D
+	movq	ARG11, %r11 // ldd
+	sall	$ 3, %r11d
+	movq	ARG12, %r12 // m1
+	movq	ARG13, %r13 // n1
+
+#if MACRO_LEVEL>=1
+	INNER_STORE_24X8_VS_LIB
+#else
+	CALL(inner_store_24x8_vs_lib)
+#endif
+
+
+	EPILOGUE
+
+	ret
+
+	FUN_END(kernel_dgemm_nt_24x8_vs_lib8ccc)
 
 
 

--- a/kernel/avx512/kernel_dgemm_24x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_24x8_lib8.S
@@ -1198,6 +1198,491 @@ NAME:
 
 // common inner routine with file scope
 //
+// cholesky factorization 
+//
+// input arguments:
+// r10  <- inv_diag_E
+// r11d <- kn
+// zmm0 <- []
+// ...
+// ymm23 <- []
+//
+// output arguments:
+// r10  <- inv_diag_E
+// r11d <- kn
+// zmm0 <- []
+// ...
+// ymm23 <- []
+
+#if MACRO_LEVEL>=1
+	.macro INNER_EDGE_DPOTRF_24X8_VS_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_edge_dpotrf_24x8_vs_lib8)
+#endif
+
+	vxorpd	%ymm25, %ymm25, %ymm25 // 0.0
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovsd	.LC04(%rip), %xmm24 // 1.0
+#elif defined(OS_MAC)
+	vmovsd	LC04(%rip), %xmm24 // 1.0
+#endif
+
+	// 0
+	vmovsd			%xmm0, %xmm0, %xmm26
+	vucomisd		%xmm25, %xmm26 // d_00 > 0.0 ?
+	jbe				1f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+2:
+	vmovsd			%xmm26, 0(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm0, %zmm26, %zmm0
+	vmulpd			%zmm8, %zmm26, %zmm8
+	vmulpd			%zmm16, %zmm26, %zmm16
+	cmpl			$ 2, %r11d
+	jl				0f // ret
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	vfnmadd231pd	%zmm0, %zmm26, %zmm1
+	vfnmadd231pd	%zmm8, %zmm26, %zmm9
+	vfnmadd231pd	%zmm16, %zmm26, %zmm17
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	vfnmadd231pd	%zmm0, %zmm26, %zmm2
+	vfnmadd231pd	%zmm8, %zmm26, %zmm10
+	vfnmadd231pd	%zmm16, %zmm26, %zmm18
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	vfnmadd231pd	%zmm0, %zmm26, %zmm3
+	vfnmadd231pd	%zmm8, %zmm26, %zmm11
+	vfnmadd231pd	%zmm16, %zmm26, %zmm19
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	vfnmadd231pd	%zmm0, %zmm26, %zmm4
+	vfnmadd231pd	%zmm8, %zmm26, %zmm12
+	vfnmadd231pd	%zmm16, %zmm26, %zmm20
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	vfnmadd231pd	%zmm0, %zmm26, %zmm5
+	vfnmadd231pd	%zmm8, %zmm26, %zmm13
+	vfnmadd231pd	%zmm16, %zmm26, %zmm21
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	vfnmadd231pd	%zmm0, %zmm26, %zmm6
+	vfnmadd231pd	%zmm8, %zmm26, %zmm14
+	vfnmadd231pd	%zmm16, %zmm26, %zmm22
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm26
+	vfnmadd231pd	%zmm0, %zmm26, %zmm7
+	vfnmadd231pd	%zmm8, %zmm26, %zmm15
+	vfnmadd231pd	%zmm16, %zmm26, %zmm23
+
+	// 1
+//	vpermilpd		$ 0x3, %xmm1, %xmm26
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm26
+	vucomisd		%xmm25, %xmm26 // d_11 > 0.0 ?
+	jbe				3f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+4:
+	vmovsd			%xmm26, 8(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm1, %zmm26, %zmm1
+	vmulpd			%zmm9, %zmm26, %zmm9
+	vmulpd			%zmm17, %zmm26, %zmm17
+	cmpl			$ 3, %r11d
+	jl				0f // ret
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm26
+	vfnmadd231pd	%zmm1, %zmm26, %zmm2
+	vfnmadd231pd	%zmm9, %zmm26, %zmm10
+	vfnmadd231pd	%zmm17, %zmm26, %zmm18
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm26
+	vfnmadd231pd	%zmm1, %zmm26, %zmm3
+	vfnmadd231pd	%zmm9, %zmm26, %zmm11
+	vfnmadd231pd	%zmm17, %zmm26, %zmm19
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm26
+	vfnmadd231pd	%zmm1, %zmm26, %zmm4
+	vfnmadd231pd	%zmm9, %zmm26, %zmm12
+	vfnmadd231pd	%zmm17, %zmm26, %zmm20
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm26
+	vfnmadd231pd	%zmm1, %zmm26, %zmm5
+	vfnmadd231pd	%zmm9, %zmm26, %zmm13
+	vfnmadd231pd	%zmm17, %zmm26, %zmm21
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm26
+	vfnmadd231pd	%zmm1, %zmm26, %zmm6
+	vfnmadd231pd	%zmm9, %zmm26, %zmm14
+	vfnmadd231pd	%zmm17, %zmm26, %zmm22
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm26
+	vfnmadd231pd	%zmm1, %zmm26, %zmm7
+	vfnmadd231pd	%zmm9, %zmm26, %zmm15
+	vfnmadd231pd	%zmm17, %zmm26, %zmm23
+
+	// 2
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm26
+	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
+	jbe				5f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+6:
+	vmovsd			%xmm26, 16(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm2, %zmm26, %zmm2
+	vmulpd			%zmm10, %zmm26, %zmm10
+	vmulpd			%zmm18, %zmm26, %zmm18
+	cmpl			$ 4, %r11d
+	jl				0f // ret
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm26
+	vfnmadd231pd	%zmm2, %zmm26, %zmm3
+	vfnmadd231pd	%zmm10, %zmm26, %zmm11
+	vfnmadd231pd	%zmm18, %zmm26, %zmm19
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm26
+	vfnmadd231pd	%zmm2, %zmm26, %zmm4
+	vfnmadd231pd	%zmm10, %zmm26, %zmm12
+	vfnmadd231pd	%zmm18, %zmm26, %zmm20
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm26
+	vfnmadd231pd	%zmm2, %zmm26, %zmm5
+	vfnmadd231pd	%zmm10, %zmm26, %zmm13
+	vfnmadd231pd	%zmm18, %zmm26, %zmm21
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm26
+	vfnmadd231pd	%zmm2, %zmm26, %zmm6
+	vfnmadd231pd	%zmm10, %zmm26, %zmm14
+	vfnmadd231pd	%zmm18, %zmm26, %zmm22
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm26
+	vfnmadd231pd	%zmm2, %zmm26, %zmm7
+	vfnmadd231pd	%zmm10, %zmm26, %zmm15
+	vfnmadd231pd	%zmm18, %zmm26, %zmm23
+
+	// 3
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm3, %zmm27, %zmm26
+	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
+	jbe				7f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+8:
+	vmovsd			%xmm26, 24(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm3, %zmm26, %zmm3
+	vmulpd			%zmm11, %zmm26, %zmm11
+	vmulpd			%zmm19, %zmm26, %zmm19
+	cmpl			$ 5, %r11d
+	jl				0f // ret
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm3, %zmm27, %zmm26
+	vfnmadd231pd	%zmm3, %zmm26, %zmm4
+	vfnmadd231pd	%zmm11, %zmm26, %zmm12
+	vfnmadd231pd	%zmm19, %zmm26, %zmm20
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm3, %zmm27, %zmm26
+	vfnmadd231pd	%zmm3, %zmm26, %zmm5
+	vfnmadd231pd	%zmm11, %zmm26, %zmm13
+	vfnmadd231pd	%zmm19, %zmm26, %zmm21
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm3, %zmm27, %zmm26
+	vfnmadd231pd	%zmm3, %zmm26, %zmm6
+	vfnmadd231pd	%zmm11, %zmm26, %zmm14
+	vfnmadd231pd	%zmm19, %zmm26, %zmm22
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm3, %zmm27, %zmm26
+	vfnmadd231pd	%zmm3, %zmm26, %zmm7
+	vfnmadd231pd	%zmm11, %zmm26, %zmm15
+	vfnmadd231pd	%zmm19, %zmm26, %zmm23
+
+	// 4
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm4, %zmm27, %zmm26
+	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
+	jbe				9f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+10:
+	vmovsd			%xmm26, 32(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm4, %zmm26, %zmm4
+	vmulpd			%zmm12, %zmm26, %zmm12
+	vmulpd			%zmm20, %zmm26, %zmm20
+	cmpl			$ 6, %r11d
+	jl				0f // ret
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm4, %zmm27, %zmm26
+	vfnmadd231pd	%zmm4, %zmm26, %zmm5
+	vfnmadd231pd	%zmm12, %zmm26, %zmm13
+	vfnmadd231pd	%zmm20, %zmm26, %zmm21
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm4, %zmm27, %zmm26
+	vfnmadd231pd	%zmm4, %zmm26, %zmm6
+	vfnmadd231pd	%zmm12, %zmm26, %zmm14
+	vfnmadd231pd	%zmm20, %zmm26, %zmm22
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm4, %zmm27, %zmm26
+	vfnmadd231pd	%zmm4, %zmm26, %zmm7
+	vfnmadd231pd	%zmm12, %zmm26, %zmm15
+	vfnmadd231pd	%zmm20, %zmm26, %zmm23
+
+	// 5
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm5, %zmm27, %zmm26
+	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
+	jbe				11f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+12:
+	vmovsd			%xmm26, 40(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm5, %zmm26, %zmm5
+	vmulpd			%zmm13, %zmm26, %zmm13
+	vmulpd			%zmm21, %zmm26, %zmm21
+	cmpl			$ 7, %r11d
+	jl				0f // ret
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm5, %zmm27, %zmm26
+	vfnmadd231pd	%zmm5, %zmm26, %zmm6
+	vfnmadd231pd	%zmm13, %zmm26, %zmm14
+	vfnmadd231pd	%zmm21, %zmm26, %zmm22
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm5, %zmm27, %zmm26
+	vfnmadd231pd	%zmm5, %zmm26, %zmm7
+	vfnmadd231pd	%zmm13, %zmm26, %zmm15
+	vfnmadd231pd	%zmm21, %zmm26, %zmm23
+
+	// 6
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm6, %zmm27, %zmm26
+	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
+	jbe				13f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+14:
+	vmovsd			%xmm26, 48(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm6, %zmm26, %zmm6
+	vmulpd			%zmm14, %zmm26, %zmm14
+	vmulpd			%zmm22, %zmm26, %zmm22
+	cmpl			$ 8, %r11d
+	jl				0f // ret
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm6, %zmm27, %zmm26
+	vfnmadd231pd	%zmm6, %zmm26, %zmm7
+	vfnmadd231pd	%zmm14, %zmm26, %zmm15
+	vfnmadd231pd	%zmm22, %zmm26, %zmm23
+
+	// 7
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm7, %zmm27, %zmm26
+	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
+	jbe				15f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+16:
+	vmovsd			%xmm26, 56(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm7, %zmm26, %zmm7
+	vmulpd			%zmm15, %zmm26, %zmm15
+	vmulpd			%zmm23, %zmm26, %zmm23
+
+	jmp				0f
+
+1:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				2b
+
+3:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				4b
+
+5:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				6b
+
+7:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				8b
+
+9:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				10b
+
+11:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				12b
+
+13:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				14b
+
+15:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				16b
+
+0:
+	#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_edge_dpotrf_24x8_vs_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
 // scale for generic alpha and beta
 //
 // input arguments:
@@ -1742,21 +2227,21 @@ NAME:
 	vsubpd		%zmm15, %zmm24, %zmm15
 
 	vmovapd		0(%r10, %r11, 2), %zmm24
-	vsubpd		%zmm8, %zmm24, %zmm16
+	vsubpd		%zmm16, %zmm24, %zmm16
 	vmovapd		1*64(%r10, %r11, 2), %zmm24
-	vsubpd		%zmm9, %zmm24, %zmm17
+	vsubpd		%zmm17, %zmm24, %zmm17
 	vmovapd		2*64(%r10, %r11, 2), %zmm24
-	vsubpd		%zmm10, %zmm24, %zmm18
+	vsubpd		%zmm18, %zmm24, %zmm18
 	vmovapd		3*64(%r10, %r11, 2), %zmm24
-	vsubpd		%zmm11, %zmm24, %zmm19
+	vsubpd		%zmm19, %zmm24, %zmm19
 	vmovapd		4*64(%r10, %r11, 2), %zmm24
-	vsubpd		%zmm12, %zmm24, %zmm20
+	vsubpd		%zmm20, %zmm24, %zmm20
 	vmovapd		5*64(%r10, %r11, 2), %zmm24
-	vsubpd		%zmm13, %zmm24, %zmm21
+	vsubpd		%zmm21, %zmm24, %zmm21
 	vmovapd		6*64(%r10, %r11, 2), %zmm24
-	vsubpd		%zmm14, %zmm24, %zmm22
+	vsubpd		%zmm22, %zmm24, %zmm22
 	vmovapd		7*64(%r10, %r11, 2), %zmm24
-	vsubpd		%zmm15, %zmm24, %zmm23
+	vsubpd		%zmm23, %zmm24, %zmm23
 
 #if MACRO_LEVEL>=1
 	.endm
@@ -1802,7 +2287,7 @@ NAME:
 	vmovapd		0(%r10, %r11), %zmm24
 	vsubpd		%zmm8, %zmm24, %zmm8
 	vmovapd		0(%r10, %r11, 2), %zmm24
-	vsubpd		%zmm8, %zmm24, %zmm16
+	vsubpd		%zmm16, %zmm24, %zmm16
 	cmpl	$ 2, %r12d
 	jl		0f // end
 	vmovapd		1*64(%r10), %zmm24
@@ -1810,7 +2295,7 @@ NAME:
 	vmovapd		1*64(%r10, %r11), %zmm24
 	vsubpd		%zmm9, %zmm24, %zmm9
 	vmovapd		1*64(%r10, %r11, 2), %zmm24
-	vsubpd		%zmm9, %zmm24, %zmm17
+	vsubpd		%zmm17, %zmm24, %zmm17
 	cmpl	$ 3, %r12d
 	jl		0f // end
 	vmovapd		2*64(%r10), %zmm24
@@ -1818,7 +2303,7 @@ NAME:
 	vmovapd		2*64(%r10, %r11), %zmm24
 	vsubpd		%zmm10, %zmm24, %zmm10
 	vmovapd		2*64(%r10, %r11, 2), %zmm24
-	vsubpd		%zmm10, %zmm24, %zmm18
+	vsubpd		%zmm18, %zmm24, %zmm18
 	cmpl	$ 4, %r12d
 	jl		0f // end
 	vmovapd		3*64(%r10), %zmm24
@@ -1826,7 +2311,7 @@ NAME:
 	vmovapd		3*64(%r10, %r11), %zmm24
 	vsubpd		%zmm11, %zmm24, %zmm11
 	vmovapd		3*64(%r10, %r11, 2), %zmm24
-	vsubpd		%zmm11, %zmm24, %zmm19
+	vsubpd		%zmm19, %zmm24, %zmm19
 	cmpl	$ 5, %r12d
 	jl		0f // end
 	vmovapd		4*64(%r10), %zmm24
@@ -1834,7 +2319,7 @@ NAME:
 	vmovapd		4*64(%r10, %r11), %zmm24
 	vsubpd		%zmm12, %zmm24, %zmm12
 	vmovapd		4*64(%r10, %r11, 2), %zmm24
-	vsubpd		%zmm12, %zmm24, %zmm20
+	vsubpd		%zmm20, %zmm24, %zmm20
 	cmpl	$ 6, %r12d
 	jl		0f // end
 	vmovapd		5*64(%r10), %zmm24
@@ -1842,7 +2327,7 @@ NAME:
 	vmovapd		5*64(%r10, %r11), %zmm24
 	vsubpd		%zmm13, %zmm24, %zmm13
 	vmovapd		5*64(%r10, %r11, 2), %zmm24
-	vsubpd		%zmm13, %zmm24, %zmm21
+	vsubpd		%zmm21, %zmm24, %zmm21
 	cmpl	$ 7, %r12d
 	jl		0f // end
 	vmovapd		6*64(%r10), %zmm24
@@ -1850,14 +2335,14 @@ NAME:
 	vmovapd		6*64(%r10, %r11), %zmm24
 	vsubpd		%zmm14, %zmm24, %zmm14
 	vmovapd		6*64(%r10, %r11, 2), %zmm24
-	vsubpd		%zmm14, %zmm24, %zmm22
+	vsubpd		%zmm22, %zmm24, %zmm22
 	je		0f // end
 	vmovapd		7*64(%r10), %zmm24
 	vsubpd		%zmm7, %zmm24, %zmm7
 	vmovapd		7*64(%r10, %r11), %zmm24
 	vsubpd		%zmm15, %zmm24, %zmm15
 	vmovapd		7*64(%r10, %r11, 2), %zmm24
-	vsubpd		%zmm15, %zmm24, %zmm23
+	vsubpd		%zmm23, %zmm24, %zmm23
 
 0:
 
@@ -2024,6 +2509,200 @@ NAME:
 	ret
 
 	FUN_END(inner_store_24x8_vs_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// store n
+//
+// input arguments:
+// r10  <- D
+// r11  <- 8*sdd*sizeof(double)
+// zmm0 <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+// r10  <- D
+// r11  <- 8*sdd*sizeof(double)
+// zmm0 <- []
+// ...
+// zmm23 <- []
+
+#if MACRO_LEVEL>=1
+	.macro INNER_STORE_L_24X8_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_store_l_24x8_lib8)
+#endif
+	
+	//
+	vmovapd %zmm0,   0(%r10)
+	//
+	movl	$ 0xfe, %r12d
+	kmovd	%r12d, %k1
+	vmovapd %zmm1,  64(%r10) {%k1}
+	//
+	movl	$ 0xfc, %r12d
+	kmovd	%r12d, %k1
+	vmovapd %zmm2, 128(%r10) {%k1}
+	//
+	movl	$ 0xf8, %r12d
+	kmovd	%r12d, %k1
+	vmovapd %zmm3, 192(%r10) {%k1}
+	//
+	movl	$ 0xf0, %r12d
+	kmovd	%r12d, %k1
+	vmovapd %zmm4,   0+256(%r10) {%k1}
+	//
+	movl	$ 0xe0, %r12d
+	kmovd	%r12d, %k1
+	vmovapd %zmm5,  64+256(%r10) {%k1}
+	//
+	movl	$ 0xc0, %r12d
+	kmovd	%r12d, %k1
+	vmovapd %zmm6, 128+256(%r10) {%k1}
+	//
+	movl	$ 0x80, %r12d
+	kmovd	%r12d, %k1
+	vmovapd %zmm7, 192+256(%r10) {%k1}
+
+	vmovapd %zmm8,   0(%r10, %r11)
+	vmovapd %zmm9,  64(%r10, %r11)
+	vmovapd %zmm10, 128(%r10, %r11)
+	vmovapd %zmm11, 192(%r10, %r11)
+	vmovapd %zmm12,   0+256(%r10, %r11)
+	vmovapd %zmm13,  64+256(%r10, %r11)
+	vmovapd %zmm14, 128+256(%r10, %r11)
+	vmovapd %zmm15, 192+256(%r10, %r11)
+
+	vmovapd %zmm16,   0(%r10, %r11, 2)
+	vmovapd %zmm17,  64(%r10, %r11, 2)
+	vmovapd %zmm18, 128(%r10, %r11, 2)
+	vmovapd %zmm19, 192(%r10, %r11, 2)
+	vmovapd %zmm20,   0+256(%r10, %r11, 2)
+	vmovapd %zmm21,  64+256(%r10, %r11, 2)
+	vmovapd %zmm22, 128+256(%r10, %r11, 2)
+	vmovapd %zmm23, 192+256(%r10, %r11, 2)
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_store_l_24x8_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// store n
+//
+// input arguments:
+// r10  <- D
+// r11  <- 8*sdd*sizeof(double)
+// r12  <- m1
+// r13  <- n1
+// zmm0 <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+// r10  <- D
+// r11  <- 8*sdd*sizeof(double)
+// r12  <- m1
+// r13  <- n1
+// zmm0 <- []
+// ...
+// zmm23 <- []
+
+#if MACRO_LEVEL>=1
+	.macro INNER_STORE_L_24X8_VS_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_store_l_24x8_vs_lib8)
+#endif
+	
+	// compute mask for rows
+	vcvtsi2sd	%r12d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC02(%rip), %zmm24
+#elif defined(OS_MAC)
+	vmovupd		LC02(%rip), %zmm24
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm24, %zmm25
+
+	vpmovq2m	%zmm25, %k1
+
+	vmovapd %zmm0,   0(%r10)
+	vmovapd %zmm8,   0(%r10, %r11)
+	vmovapd %zmm16,   0(%r10, %r11, 2) {%k1}
+	cmpl	$ 2, %r13d
+	jl		0f // end
+	movl	$ 0xfe, %r14d
+	kmovd	%r14d, %k2
+	vmovapd %zmm1,  64(%r10) {%k2}
+	vmovapd %zmm9,  64(%r10, %r11)
+	vmovapd %zmm17,  64(%r10, %r11, 2) {%k1}
+	cmpl	$ 3, %r13d
+	jl		0f // end
+	movl	$ 0xfc, %r14d
+	kmovd	%r14d, %k2
+	vmovapd %zmm2, 128(%r10) {%k2}
+	vmovapd %zmm10, 128(%r10, %r11)
+	vmovapd %zmm18, 128(%r10, %r11, 2) {%k1}
+	cmpl	$ 4, %r13d
+	jl		0f // end
+	movl	$ 0xf8, %r14d
+	kmovd	%r14d, %k2
+	vmovapd %zmm3, 192(%r10) {%k2}
+	vmovapd %zmm11, 192(%r10, %r11)
+	vmovapd %zmm19, 192(%r10, %r11, 2) {%k1}
+	cmpl	$ 5, %r13d
+	jl		0f // end
+	movl	$ 0xf0, %r14d
+	kmovd	%r14d, %k2
+	vmovapd %zmm4,   0+256(%r10) {%k2}
+	vmovapd %zmm12,   0+256(%r10, %r11)
+	vmovapd %zmm20,   0+256(%r10, %r11, 2) {%k1}
+	cmpl	$ 6, %r13d
+	jl		0f // end
+	movl	$ 0xe0, %r14d
+	kmovd	%r14d, %k2
+	vmovapd %zmm5,  64+256(%r10) {%k2}
+	vmovapd %zmm13,  64+256(%r10, %r11)
+	vmovapd %zmm21,  64+256(%r10, %r11, 2) {%k1}
+	cmpl	$ 7, %r13d
+	jl		0f // end
+	movl	$ 0xc0, %r14d
+	kmovd	%r14d, %k2
+	vmovapd %zmm6, 128+256(%r10) {%k2}
+	vmovapd %zmm14, 128+256(%r10, %r11)
+	vmovapd %zmm22, 128+256(%r10, %r11, 2) {%k1}
+	cmpl	$ 7, %r13d
+	je		0f // end
+	movl	$ 0x80, %r14d
+	kmovd	%r14d, %k2
+	vmovapd %zmm7, 192+256(%r10) {%k2}
+	vmovapd %zmm15, 192+256(%r10, %r11)
+	vmovapd %zmm23, 192+256(%r10, %r11, 2) {%k1}
+
+0:
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_store_l_24x8_vs_lib8)
 #endif
 
 
@@ -2512,6 +3191,354 @@ NAME:
 	ret
 
 	FUN_END(kernel_dgemm_dtrsm_nt_rl_inv_24x8_vs_lib8)
+
+
+
+
+
+//                                   1      2          3        4          5          6        7          8        9
+// void kernel_dpotrf_nt_l_24x8_lib8(int k, double *A, int sda, double *B, double *C, int sdc, double *D, int sdd, double *inv_diag_D);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dpotrf_nt_l_24x8_lib8)
+	
+	PROLOGUE
+
+	// zero accumulation registers
+
+	ZERO_ACC
+
+
+	// call inner dgemm kernel nt
+
+	movq	ARG1, %r10
+	movq	ARG2, %r11
+	movq	ARG3, %r12
+	sall	$ 6, %r12d // 8*sda*sizeof(double)
+	movq	ARG4, %r13
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_24X8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_24x8_lib8)
+#endif
+
+
+	// call inner blender nn
+
+	movq	ARG5, %r10 // C
+	movq	ARG6, %r11 // sdc
+	sall	$ 6, %r11d // 8*sdc*sizeof(double)
+
+#if MACRO_LEVEL>=1
+	INNER_SCALE_M11_24X8_LIB8
+#else
+	CALL(inner_scale_m11_24x8_lib8)
+#endif
+
+
+	// factorization
+
+	movq	ARG9, %r10  // inv_diag_D 
+	movl	$ 8, %r11d
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DPOTRF_24X8_VS_LIB8
+#else
+	CALL(inner_edge_dpotrf_24x8_vs_lib8)
+#endif
+
+
+	// store n
+
+	movq	ARG7, %r10 // store address D
+	movq	ARG8, %r11 // sdd
+	sall	$ 6, %r11d // 8*sdd*sizeof(double)
+
+#if MACRO_LEVEL>=1
+	INNER_STORE_L_24X8_LIB8
+#else
+	CALL(inner_store_l_24x8_lib8)
+#endif
+
+
+	EPILOGUE
+	
+	ret
+
+	FUN_END(kernel_dpotrf_nt_l_24x8_lib8)
+
+
+
+
+
+//                                      1      2          3        4          5          6        7          8        9                   10      11
+// void kernel_dpotrf_nt_l_24x8_vs_lib8(int k, double *A, int sda, double *B, double *C, int sdc, double *D, int sdd, double *inv_diag_D, int m1, int n1);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dpotrf_nt_l_24x8_vs_lib8)
+	
+	PROLOGUE
+
+	// zero accumulation registers
+
+	ZERO_ACC
+
+
+	// call inner dgemm kernel nt
+
+	movq	ARG1, %r10
+	movq	ARG2, %r11
+	movq	ARG3, %r12
+	sall	$ 6, %r12d // 8*sda*sizeof(double)
+	movq	ARG4, %r13
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_24X8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_24x8_lib8)
+#endif
+
+
+	// call inner blender nn
+
+	movq	ARG5, %r10 // C
+	movq	ARG6, %r11 // sdc
+	sall	$ 6, %r11d // 8*sdc*sizeof(double)
+	movq	ARG11, %r12 // n1
+
+#if MACRO_LEVEL>=1
+	INNER_SCALE_M11_24X8_VS_LIB8
+#else
+	CALL(inner_scale_m11_24x8_vs_lib8)
+#endif
+
+
+	// factorization
+
+	movq	ARG9, %r10  // inv_diag_D 
+	movq	ARG11, %r11 // n1
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DPOTRF_24X8_VS_LIB8
+#else
+	CALL(inner_edge_dpotrf_24x8_vs_lib8)
+#endif
+
+
+	// store n
+
+	movq	ARG7, %r10 // store address D
+	movq	ARG8, %r11 // sdd
+	sall	$ 6, %r11d // 8*sdd*sizeof(double)
+	movq	ARG10, %r12 // m1
+	movq	ARG11, %r13 // n1
+
+#if MACRO_LEVEL>=1
+	INNER_STORE_L_24X8_VS_LIB8
+#else
+	CALL(inner_store_l_24x8_vs_lib8)
+#endif
+
+
+	EPILOGUE
+	
+	ret
+
+	FUN_END(kernel_dpotrf_nt_l_24x8_vs_lib8)
+
+
+
+
+
+//                                         1       2           3         4           5       6           7         8           9          10       11         12       13
+// void kernel_dsyrk_dpotrf_nt_l_24x8_lib8(int kp, double *Ap, int sdap, double *Bp, int km, double *Am, int sdam, double *Bm, double *C, int sdc, double *D, int sdd, double *inv_diag_D);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dsyrk_dpotrf_nt_l_24x8_lib8)
+	
+	PROLOGUE
+
+	// zero accumulation registers
+
+	ZERO_ACC
+
+
+	// call inner dgemm kernel nt add
+
+	movq	ARG1, %r10 // kp
+	movq	ARG2, %r11  // Ap
+	movq	ARG3, %r12 // sdap
+	sall	$ 6, %r12d   // 4*sdap*sizeof(double)
+	movq	ARG4, %r13  // Bp
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_24X8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_24x8_lib8)
+#endif
+
+
+	// change sign
+	NEG_ACC
+
+
+	// call inner dgemm kernel nt sub
+
+	movq	ARG5, %r10 // km
+	movq	ARG6, %r11 // Am
+	movq	ARG7, %r12 // sdam
+	sall	$ 6, %r12d // 4*sdam*sizeof(double)
+	movq	ARG8, %r13  // Bm
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_24X8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_24x8_lib8)
+#endif
+
+
+	// call inner blender nn
+
+	movq	ARG9, %r10 // C
+	movq	ARG10, %r11 // sdc
+	sall	$ 6, %r11d // 4*sdc*sizeof(double)
+
+#if MACRO_LEVEL>=1
+	INNER_SCALE_M11_24X8_LIB8
+#else
+	CALL(inner_scale_m11_24x8_lib8)
+#endif
+
+
+	// factorization
+
+	movq	ARG13, %r10  // inv_diag_D 
+	movl	$ 8, %r11d
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DPOTRF_24X8_VS_LIB8
+#else
+	CALL(inner_edge_dpotrf_24x8_vs_lib8)
+#endif
+
+
+	// store n
+
+	movq	ARG11, %r10 // store address D
+	movq	ARG12, %r11 // sdd
+	sall	$ 6, %r11d // 4*sdd*sizeof(double)
+
+#if MACRO_LEVEL>=1
+	INNER_STORE_L_24X8_LIB8
+#else
+	CALL(inner_store_l_24x8_lib8)
+#endif
+
+
+	EPILOGUE
+	
+	ret
+
+	FUN_END(kernel_dsyrk_dpotrf_nt_l_24x8_lib8)
+
+
+
+
+
+//                                            1       2           3         4           5       6           7         8           9          10       11         12       13                  14      15
+// void kernel_dsyrk_dpotrf_nt_l_24x8_vs_lib8(int kp, double *Ap, int sdap, double *Bp, int km, double *Am, int sdam, double *Bm, double *C, int sdc, double *D, int sdd, double *inv_diag_D, int m1, int n1);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dsyrk_dpotrf_nt_l_24x8_vs_lib8)
+	
+	PROLOGUE
+
+	// zero accumulation registers
+
+	ZERO_ACC
+
+
+	// call inner dgemm kernel nt add
+
+	movq	ARG1, %r10 // kp
+	movq	ARG2, %r11  // Ap
+	movq	ARG3, %r12 // sdap
+	sall	$ 6, %r12d   // 4*sdap*sizeof(double)
+	movq	ARG4, %r13  // Bp
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_24X8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_24x8_lib8)
+#endif
+
+
+	// change sign
+	NEG_ACC
+
+
+	// call inner dgemm kernel nt sub
+
+	movq	ARG5, %r10 // km
+	movq	ARG6, %r11 // Am
+	movq	ARG7, %r12 // sdam
+	sall	$ 6, %r12d // 4*sdam*sizeof(double)
+	movq	ARG8, %r13  // Bm
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_24X8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_24x8_lib8)
+#endif
+
+
+	// call inner blender nn
+
+	movq	ARG9, %r10 // C
+	movq	ARG10, %r11 // sdc
+	sall	$ 6, %r11d // 4*sdc*sizeof(double)
+	movq	ARG15, %r12 // n1
+
+#if MACRO_LEVEL>=1
+	INNER_SCALE_M11_24X8_VS_LIB8
+#else
+	CALL(inner_scale_m11_24x8_vs_lib8)
+#endif
+
+
+	// factorization
+
+	movq	ARG13, %r10  // inv_diag_D 
+	movq	ARG15, %r11 // n1
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DPOTRF_24X8_VS_LIB8
+#else
+	CALL(inner_edge_dpotrf_24x8_vs_lib8)
+#endif
+
+
+	// store n
+
+	movq	ARG11, %r10 // store address D
+	movq	ARG12, %r11 // sdd
+	sall	$ 6, %r11d // 4*sdd*sizeof(double)
+	movq	ARG14, %r12 // m1
+	movq	ARG15, %r13 // n1
+
+#if MACRO_LEVEL>=1
+	INNER_STORE_L_24X8_VS_LIB8
+#else
+	CALL(inner_store_l_24x8_vs_lib8)
+#endif
+
+
+	EPILOGUE
+	
+	ret
+
+	FUN_END(kernel_dsyrk_dpotrf_nt_l_24x8_vs_lib8)
 
 
 

--- a/kernel/avx512/kernel_dgemm_24x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_24x8_lib8.S
@@ -3774,6 +3774,300 @@ NAME:
 
 // common inner routine with file scope
 //
+// input arguments:
+// r10d  <- k
+// r11   <- B
+// r12   <- C
+// r13   <- 64*sdc
+// zmm0  <- [a00 ... a70]
+// ...
+// zmm7  <- [a07 ... a77]
+// zmm8  <- [a87 ... af7]
+// ...
+// zmm15 <- [a87 ... af7]
+// zmm16 <- [ag7 ... an7]
+// ...
+// zmm23 <- [ag7 ... an7]
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- ?
+// r12   <- ?
+// r13   <- 64*sdc
+// zmm0  <- [a00 ... a70]
+// ...
+// zmm7  <- [a07 ... a77]
+// zmm8  <- [a87 ... af7]
+// ...
+// zmm15 <- [a87 ... af7]
+// zmm16 <- [ag7 ... an7]
+// ...
+// zmm23 <- [ag7 ... an7]
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEBP_NN_24X8_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgebp_nn_24x8_lib8)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		0f // return
+
+	cmpl	$ 3, %r10d
+	jle		2f // cleanup loop
+
+	// main loop
+	.p2align 
+1:
+	// merged k-iter 0-3 to have more independent acc
+	// 0-1
+	vmovapd			0*64(%r12), %zmm28
+	vmovapd			0*64(%r12, %r13), %zmm24
+	vmovapd			0*64(%r12, %r13, 2), %zmm26
+	vbroadcastsd	0+0*64(%r11), %zmm31
+	vfmadd231pd		%zmm0, %zmm31, %zmm28
+	vfmadd231pd		%zmm8, %zmm31, %zmm24
+	vfmadd231pd		%zmm16, %zmm31, %zmm26
+	vmovapd			1*64(%r12), %zmm29
+	vmovapd			1*64(%r12, %r13), %zmm25
+	vmovapd			1*64(%r12, %r13, 2), %zmm27
+	vbroadcastsd	0+1*64(%r11), %zmm31
+	vfmadd231pd		%zmm0, %zmm31, %zmm29
+	vfmadd231pd		%zmm8, %zmm31, %zmm25
+	vfmadd231pd		%zmm16, %zmm31, %zmm27
+
+	vbroadcastsd	8+0*64(%r11), %zmm31
+	vfmadd231pd		%zmm1, %zmm31, %zmm28
+	vfmadd231pd		%zmm9, %zmm31, %zmm24
+	vfmadd231pd		%zmm17, %zmm31, %zmm26
+	vbroadcastsd	8+1*64(%r11), %zmm31
+	vfmadd231pd		%zmm1, %zmm31, %zmm29
+	vfmadd231pd		%zmm9, %zmm31, %zmm25
+	vfmadd231pd		%zmm17, %zmm31, %zmm27
+
+	vbroadcastsd	16+0*64(%r11), %zmm31
+	vfmadd231pd		%zmm2, %zmm31, %zmm28
+	vfmadd231pd		%zmm10, %zmm31, %zmm24
+	vfmadd231pd		%zmm18, %zmm31, %zmm26
+	vbroadcastsd	16+1*64(%r11), %zmm31
+	vfmadd231pd		%zmm2, %zmm31, %zmm29
+	vfmadd231pd		%zmm10, %zmm31, %zmm25
+	vfmadd231pd		%zmm18, %zmm31, %zmm27
+
+	vbroadcastsd	24+0*64(%r11), %zmm31
+	vfmadd231pd		%zmm3, %zmm31, %zmm28
+	vfmadd231pd		%zmm11, %zmm31, %zmm24
+	vfmadd231pd		%zmm19, %zmm31, %zmm26
+	vbroadcastsd	24+1*64(%r11), %zmm31
+	vfmadd231pd		%zmm3, %zmm31, %zmm29
+	vfmadd231pd		%zmm11, %zmm31, %zmm25
+	vfmadd231pd		%zmm19, %zmm31, %zmm27
+
+	vbroadcastsd	32+0*64(%r11), %zmm31
+	vfmadd231pd		%zmm4, %zmm31, %zmm28
+	vfmadd231pd		%zmm12, %zmm31, %zmm24
+	vfmadd231pd		%zmm20, %zmm31, %zmm26
+	vbroadcastsd	32+1*64(%r11), %zmm31
+	vfmadd231pd		%zmm4, %zmm31, %zmm29
+	vfmadd231pd		%zmm12, %zmm31, %zmm25
+	vfmadd231pd		%zmm20, %zmm31, %zmm27
+
+	vbroadcastsd	40+0*64(%r11), %zmm31
+	vfmadd231pd		%zmm5, %zmm31, %zmm28
+	vfmadd231pd		%zmm13, %zmm31, %zmm24
+	vfmadd231pd		%zmm21, %zmm31, %zmm26
+	vbroadcastsd	40+1*64(%r11), %zmm31
+	vfmadd231pd		%zmm5, %zmm31, %zmm29
+	vfmadd231pd		%zmm13, %zmm31, %zmm25
+	vfmadd231pd		%zmm21, %zmm31, %zmm27
+
+	vbroadcastsd	48+0*64(%r11), %zmm31
+	vfmadd231pd		%zmm6, %zmm31, %zmm28
+	vfmadd231pd		%zmm14, %zmm31, %zmm24
+	vfmadd231pd		%zmm22, %zmm31, %zmm26
+	vbroadcastsd	48+1*64(%r11), %zmm31
+	vfmadd231pd		%zmm6, %zmm31, %zmm29
+	vfmadd231pd		%zmm14, %zmm31, %zmm25
+	vfmadd231pd		%zmm22, %zmm31, %zmm27
+
+	vbroadcastsd	56+0*64(%r11), %zmm31
+	vfmadd231pd		%zmm7, %zmm31, %zmm28
+	vfmadd231pd		%zmm15, %zmm31, %zmm24
+	vfmadd231pd		%zmm23, %zmm31, %zmm26
+	vmovapd			%zmm28, 0*64(%r12)
+	vmovapd			%zmm24, 0*64(%r12, %r13)
+	vmovapd			%zmm26, 0*64(%r12, %r13, 2)
+	vbroadcastsd	56+1*64(%r11), %zmm31
+	vfmadd231pd		%zmm7, %zmm31, %zmm29
+	vfmadd231pd		%zmm15, %zmm31, %zmm25
+	vfmadd231pd		%zmm23, %zmm31, %zmm27
+	vmovapd			%zmm29, 1*64(%r12)
+	vmovapd			%zmm25, 1*64(%r12, %r13)
+	vmovapd			%zmm27, 1*64(%r12, %r13, 2)
+
+
+	// 2-3
+	vmovapd			2*64(%r12), %zmm28
+	vmovapd			2*64(%r12, %r13), %zmm24
+	vmovapd			2*64(%r12, %r13, 2), %zmm26
+	vbroadcastsd	0+2*64(%r11), %zmm31
+	vfmadd231pd		%zmm0, %zmm31, %zmm28
+	vfmadd231pd		%zmm8, %zmm31, %zmm24
+	vfmadd231pd		%zmm16, %zmm31, %zmm26
+	vmovapd			3*64(%r12), %zmm29
+	vmovapd			3*64(%r12, %r13), %zmm25
+	vmovapd			3*64(%r12, %r13, 2), %zmm27
+	vbroadcastsd	0+3*64(%r11), %zmm31
+	vfmadd231pd		%zmm0, %zmm31, %zmm29
+	vfmadd231pd		%zmm8, %zmm31, %zmm25
+	vfmadd231pd		%zmm16, %zmm31, %zmm27
+
+	vbroadcastsd	8+2*64(%r11), %zmm31
+	vfmadd231pd		%zmm1, %zmm31, %zmm28
+	vfmadd231pd		%zmm9, %zmm31, %zmm24
+	vfmadd231pd		%zmm17, %zmm31, %zmm26
+	vbroadcastsd	8+3*64(%r11), %zmm31
+	vfmadd231pd		%zmm1, %zmm31, %zmm29
+	vfmadd231pd		%zmm9, %zmm31, %zmm25
+	vfmadd231pd		%zmm17, %zmm31, %zmm27
+
+	vbroadcastsd	16+2*64(%r11), %zmm31
+	vfmadd231pd		%zmm2, %zmm31, %zmm28
+	vfmadd231pd		%zmm10, %zmm31, %zmm24
+	vfmadd231pd		%zmm18, %zmm31, %zmm26
+	vbroadcastsd	16+3*64(%r11), %zmm31
+	vfmadd231pd		%zmm2, %zmm31, %zmm29
+	vfmadd231pd		%zmm10, %zmm31, %zmm25
+	vfmadd231pd		%zmm18, %zmm31, %zmm27
+
+	vbroadcastsd	24+2*64(%r11), %zmm31
+	vfmadd231pd		%zmm3, %zmm31, %zmm28
+	vfmadd231pd		%zmm11, %zmm31, %zmm24
+	vfmadd231pd		%zmm19, %zmm31, %zmm26
+	vbroadcastsd	24+3*64(%r11), %zmm31
+	vfmadd231pd		%zmm3, %zmm31, %zmm29
+	vfmadd231pd		%zmm11, %zmm31, %zmm25
+	vfmadd231pd		%zmm19, %zmm31, %zmm27
+
+	vbroadcastsd	32+2*64(%r11), %zmm31
+	vfmadd231pd		%zmm4, %zmm31, %zmm28
+	vfmadd231pd		%zmm12, %zmm31, %zmm24
+	vfmadd231pd		%zmm20, %zmm31, %zmm26
+	vbroadcastsd	32+3*64(%r11), %zmm31
+	vfmadd231pd		%zmm4, %zmm31, %zmm29
+	vfmadd231pd		%zmm12, %zmm31, %zmm25
+	vfmadd231pd		%zmm20, %zmm31, %zmm27
+
+	vbroadcastsd	40+2*64(%r11), %zmm31
+	vfmadd231pd		%zmm5, %zmm31, %zmm28
+	vfmadd231pd		%zmm13, %zmm31, %zmm24
+	vfmadd231pd		%zmm21, %zmm31, %zmm26
+	vbroadcastsd	40+3*64(%r11), %zmm31
+	vfmadd231pd		%zmm5, %zmm31, %zmm29
+	vfmadd231pd		%zmm13, %zmm31, %zmm25
+	vfmadd231pd		%zmm21, %zmm31, %zmm27
+
+	vbroadcastsd	48+2*64(%r11), %zmm31
+	vfmadd231pd		%zmm6, %zmm31, %zmm28
+	vfmadd231pd		%zmm14, %zmm31, %zmm24
+	vfmadd231pd		%zmm22, %zmm31, %zmm26
+	vbroadcastsd	48+3*64(%r11), %zmm31
+	vfmadd231pd		%zmm6, %zmm31, %zmm29
+	vfmadd231pd		%zmm14, %zmm31, %zmm25
+	vfmadd231pd		%zmm22, %zmm31, %zmm27
+
+	vbroadcastsd	56+2*64(%r11), %zmm31
+	vfmadd231pd		%zmm7, %zmm31, %zmm28
+	vfmadd231pd		%zmm15, %zmm31, %zmm24
+	vfmadd231pd		%zmm23, %zmm31, %zmm26
+	vmovapd			%zmm28, 2*64(%r12)
+	vmovapd			%zmm24, 2*64(%r12, %r13)
+	vmovapd			%zmm26, 2*64(%r12, %r13, 2)
+	vbroadcastsd	56+3*64(%r11), %zmm31
+	vfmadd231pd		%zmm7, %zmm31, %zmm29
+	vfmadd231pd		%zmm15, %zmm31, %zmm25
+	vfmadd231pd		%zmm23, %zmm31, %zmm27
+	vmovapd			%zmm29, 3*64(%r12)
+	vmovapd			%zmm25, 3*64(%r12, %r13)
+	vmovapd			%zmm27, 3*64(%r12, %r13, 2)
+
+	addq	$ 256, %r11
+	addq	$ 256, %r12
+	subl	$ 4, %r10d
+
+	cmpl	$ 3, %r10d
+	jg		1b // main loop
+
+	cmpl	$ 0, %r10d
+	jle		0f // return
+
+	// cleanup loop
+2:
+	vmovapd			0*64(%r12), %zmm28
+	vmovapd			0*64(%r12, %r13), %zmm24
+	vmovapd			0*64(%r12, %r13, 2), %zmm26
+	vbroadcastsd	0+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm0, %zmm23, %zmm28
+	vfmadd231pd		%zmm8, %zmm23, %zmm24
+	vfmadd231pd		%zmm16, %zmm23, %zmm26
+	vbroadcastsd	8+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm1, %zmm23, %zmm28
+	vfmadd231pd		%zmm9, %zmm23, %zmm24
+	vfmadd231pd		%zmm17, %zmm23, %zmm26
+	vbroadcastsd	16+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm2, %zmm23, %zmm28
+	vfmadd231pd		%zmm10, %zmm23, %zmm24
+	vfmadd231pd		%zmm18, %zmm23, %zmm26
+	vbroadcastsd	24+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm3, %zmm23, %zmm28
+	vfmadd231pd		%zmm11, %zmm23, %zmm24
+	vfmadd231pd		%zmm19, %zmm23, %zmm26
+	vbroadcastsd	32+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm4, %zmm23, %zmm28
+	vfmadd231pd		%zmm12, %zmm23, %zmm24
+	vfmadd231pd		%zmm20, %zmm23, %zmm26
+	vbroadcastsd	40+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm5, %zmm23, %zmm28
+	vfmadd231pd		%zmm13, %zmm23, %zmm24
+	vfmadd231pd		%zmm21, %zmm23, %zmm26
+	vbroadcastsd	48+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm6, %zmm23, %zmm28
+	vfmadd231pd		%zmm14, %zmm23, %zmm24
+	vfmadd231pd		%zmm22, %zmm23, %zmm26
+	vbroadcastsd	56+0*64(%r11), %zmm23
+	vfmadd231pd		%zmm7, %zmm23, %zmm28
+	vfmadd231pd		%zmm15, %zmm23, %zmm24
+	vfmadd231pd		%zmm23, %zmm23, %zmm26
+	vmovapd			%zmm28, 0*64(%r12)
+	vmovapd			%zmm24, 0*64(%r12, %r13)
+	vmovapd			%zmm26, 0*64(%r12, %r13, 2)
+
+	subl	$ 1, %r10d
+	addq	$ 64, %r11
+	addq	$ 64, %r12
+
+	cmpl	$ 0, %r10d
+	jg		2b // main loop
+
+	// return
+0:
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgebp_nn_24x8_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
 // triangular substitution:
 // side = right
 // uplo = lower
@@ -6685,6 +6979,553 @@ NAME:
 	ret
 
 	FUN_END(kernel_dsyrk_dpotrf_nt_l_24x8_vs_lib8)
+
+
+
+
+
+//                                1         2           3           4           5
+// void kernel_dlarfb8_rn_24_lib8(int kmax, double *pV, double *pT, double *pD, int sdd);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dlarfb8_rn_24_lib8)
+	
+	PROLOGUE
+
+	// zero accumulation registers
+
+//	ZERO_ACC
+
+	movq	ARG1, %r10 // k
+	movq	ARG4, %r11 // D
+	movq	ARG5, %r12 // sdd
+	sall	$ 6, %r12d
+	movq	ARG2, %r13 // V
+
+	//
+	vmovapd			0*64(%r11), %zmm0
+	vmovapd			0*64(%r11, %r12), %zmm8
+	vmovapd			0*64(%r11, %r12, 2), %zmm16
+	//
+	vmovapd			1*64(%r11), %zmm1
+	vmovapd			1*64(%r11, %r12), %zmm9
+	vmovapd			1*64(%r11, %r12), %zmm17
+	vbroadcastsd	1*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm1, %zmm0
+	vfmadd231pd		%zmm24, %zmm9, %zmm8
+	vfmadd231pd		%zmm24, %zmm17, %zmm16
+	//
+	vmovapd			2*64(%r11), %zmm2
+	vmovapd			2*64(%r11, %r12), %zmm10
+	vmovapd			2*64(%r11, %r12, 2), %zmm18
+	vbroadcastsd	0+2*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm2, %zmm0
+	vfmadd231pd		%zmm24, %zmm10, %zmm8
+	vfmadd231pd		%zmm24, %zmm18, %zmm16
+	vbroadcastsd	8+2*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm2, %zmm1
+	vfmadd231pd		%zmm24, %zmm10, %zmm9
+	vfmadd231pd		%zmm24, %zmm18, %zmm17
+	//
+	vmovapd			3*64(%r11), %zmm3
+	vmovapd			3*64(%r11, %r12), %zmm11
+	vmovapd			3*64(%r11, %r12, 2), %zmm19
+	vbroadcastsd	0+3*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm3, %zmm0
+	vfmadd231pd		%zmm24, %zmm11, %zmm8
+	vfmadd231pd		%zmm24, %zmm19, %zmm16
+	vbroadcastsd	8+3*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm3, %zmm1
+	vfmadd231pd		%zmm24, %zmm11, %zmm9
+	vfmadd231pd		%zmm24, %zmm19, %zmm17
+	vbroadcastsd	16+3*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm3, %zmm2
+	vfmadd231pd		%zmm24, %zmm11, %zmm10
+	vfmadd231pd		%zmm24, %zmm19, %zmm18
+	//
+	vmovapd			4*64(%r11), %zmm4
+	vmovapd			4*64(%r11, %r12), %zmm12
+	vmovapd			4*64(%r11, %r12, 2), %zmm20
+	vbroadcastsd	0+4*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm4, %zmm0
+	vfmadd231pd		%zmm24, %zmm12, %zmm8
+	vfmadd231pd		%zmm24, %zmm20, %zmm16
+	vbroadcastsd	8+4*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm4, %zmm1
+	vfmadd231pd		%zmm24, %zmm12, %zmm9
+	vfmadd231pd		%zmm24, %zmm20, %zmm17
+	vbroadcastsd	16+4*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm4, %zmm2
+	vfmadd231pd		%zmm24, %zmm12, %zmm10
+	vfmadd231pd		%zmm24, %zmm20, %zmm18
+	vbroadcastsd	24+4*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm4, %zmm3
+	vfmadd231pd		%zmm24, %zmm12, %zmm11
+	vfmadd231pd		%zmm24, %zmm20, %zmm19
+	//
+	vmovapd			5*64(%r11), %zmm5
+	vmovapd			5*64(%r11, %r12), %zmm13
+	vmovapd			5*64(%r11, %r12, 2), %zmm21
+	vbroadcastsd	0+5*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm5, %zmm0
+	vfmadd231pd		%zmm24, %zmm13, %zmm8
+	vfmadd231pd		%zmm24, %zmm21, %zmm16
+	vbroadcastsd	8+5*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm5, %zmm1
+	vfmadd231pd		%zmm24, %zmm13, %zmm9
+	vfmadd231pd		%zmm24, %zmm21, %zmm17
+	vbroadcastsd	16+5*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm5, %zmm2
+	vfmadd231pd		%zmm24, %zmm13, %zmm10
+	vfmadd231pd		%zmm24, %zmm21, %zmm18
+	vbroadcastsd	24+5*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm5, %zmm3
+	vfmadd231pd		%zmm24, %zmm13, %zmm11
+	vfmadd231pd		%zmm24, %zmm21, %zmm19
+	vbroadcastsd	32+5*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm5, %zmm4
+	vfmadd231pd		%zmm24, %zmm13, %zmm12
+	vfmadd231pd		%zmm24, %zmm21, %zmm20
+	//
+	vmovapd			6*64(%r11), %zmm6
+	vmovapd			6*64(%r11, %r12), %zmm14
+	vmovapd			6*64(%r11, %r12, 2), %zmm22
+	vbroadcastsd	0+6*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm6, %zmm0
+	vfmadd231pd		%zmm24, %zmm14, %zmm8
+	vfmadd231pd		%zmm24, %zmm22, %zmm16
+	vbroadcastsd	8+6*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm6, %zmm1
+	vfmadd231pd		%zmm24, %zmm14, %zmm9
+	vfmadd231pd		%zmm24, %zmm22, %zmm17
+	vbroadcastsd	16+6*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm6, %zmm2
+	vfmadd231pd		%zmm24, %zmm14, %zmm10
+	vfmadd231pd		%zmm24, %zmm22, %zmm18
+	vbroadcastsd	24+6*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm6, %zmm3
+	vfmadd231pd		%zmm24, %zmm14, %zmm11
+	vfmadd231pd		%zmm24, %zmm22, %zmm19
+	vbroadcastsd	32+6*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm6, %zmm4
+	vfmadd231pd		%zmm24, %zmm14, %zmm12
+	vfmadd231pd		%zmm24, %zmm22, %zmm20
+	vbroadcastsd	40+6*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm6, %zmm5
+	vfmadd231pd		%zmm24, %zmm14, %zmm13
+	vfmadd231pd		%zmm24, %zmm22, %zmm21
+	//
+	vmovapd			7*64(%r11), %zmm7
+	vmovapd			7*64(%r11, %r12), %zmm15
+	vmovapd			7*64(%r11, %r12, 2), %zmm23
+	vbroadcastsd	0+7*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm7, %zmm0
+	vfmadd231pd		%zmm24, %zmm15, %zmm8
+	vfmadd231pd		%zmm24, %zmm23, %zmm16
+	vbroadcastsd	8+7*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm7, %zmm1
+	vfmadd231pd		%zmm24, %zmm15, %zmm9
+	vfmadd231pd		%zmm24, %zmm23, %zmm17
+	vbroadcastsd	16+7*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm7, %zmm2
+	vfmadd231pd		%zmm24, %zmm15, %zmm10
+	vfmadd231pd		%zmm24, %zmm23, %zmm18
+	vbroadcastsd	24+7*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm7, %zmm3
+	vfmadd231pd		%zmm24, %zmm15, %zmm11
+	vfmadd231pd		%zmm24, %zmm23, %zmm19
+	vbroadcastsd	32+7*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm7, %zmm4
+	vfmadd231pd		%zmm24, %zmm15, %zmm12
+	vfmadd231pd		%zmm24, %zmm23, %zmm20
+	vbroadcastsd	40+7*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm7, %zmm5
+	vfmadd231pd		%zmm24, %zmm15, %zmm13
+	vfmadd231pd		%zmm24, %zmm23, %zmm21
+	vbroadcastsd	48+7*64(%r13), %zmm24
+	vfmadd231pd		%zmm24, %zmm7, %zmm6
+	vfmadd231pd		%zmm24, %zmm15, %zmm14
+	vfmadd231pd		%zmm24, %zmm23, %zmm22
+
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+	addq	$ 512, %r13
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_24X8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_24x8_lib8)
+#endif
+
+	movq	ARG3, %r10 // T
+
+	//
+	vbroadcastsd	56+7*64(%r10), %zmm24
+	vmulpd			%zmm7, %zmm24, %zmm7
+	vmulpd			%zmm15, %zmm24, %zmm15
+	vmulpd			%zmm23, %zmm24, %zmm23
+	//
+	vbroadcastsd	48+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm6, %zmm24, %zmm7
+	vfmadd231pd		%zmm14, %zmm24, %zmm15
+	vfmadd231pd		%zmm22, %zmm24, %zmm23
+	vbroadcastsd	48+6*64(%r10), %zmm24
+	vmulpd			%zmm6, %zmm24, %zmm6
+	vmulpd			%zmm14, %zmm24, %zmm14
+	vmulpd			%zmm22, %zmm24, %zmm22
+	//
+	vbroadcastsd	40+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm5, %zmm24, %zmm7
+	vfmadd231pd		%zmm13, %zmm24, %zmm15
+	vfmadd231pd		%zmm21, %zmm24, %zmm23
+	vbroadcastsd	40+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm5, %zmm24, %zmm6
+	vfmadd231pd		%zmm13, %zmm24, %zmm14
+	vfmadd231pd		%zmm21, %zmm24, %zmm22
+	vbroadcastsd	40+5*64(%r10), %zmm24
+	vmulpd			%zmm5, %zmm24, %zmm5
+	vmulpd			%zmm13, %zmm24, %zmm13
+	vmulpd			%zmm21, %zmm24, %zmm21
+	//
+	vbroadcastsd	32+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm7
+	vfmadd231pd		%zmm12, %zmm24, %zmm15
+	vfmadd231pd		%zmm20, %zmm24, %zmm23
+	vbroadcastsd	32+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm6
+	vfmadd231pd		%zmm12, %zmm24, %zmm14
+	vfmadd231pd		%zmm20, %zmm24, %zmm22
+	vbroadcastsd	32+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm5
+	vfmadd231pd		%zmm12, %zmm24, %zmm13
+	vfmadd231pd		%zmm20, %zmm24, %zmm21
+	vbroadcastsd	32+4*64(%r10), %zmm24
+	vmulpd			%zmm4, %zmm24, %zmm4
+	vmulpd			%zmm12, %zmm24, %zmm12
+	vmulpd			%zmm20, %zmm24, %zmm20
+	//
+	vbroadcastsd	24+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm7
+	vfmadd231pd		%zmm11, %zmm24, %zmm15
+	vfmadd231pd		%zmm19, %zmm24, %zmm23
+	vbroadcastsd	24+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm6
+	vfmadd231pd		%zmm11, %zmm24, %zmm14
+	vfmadd231pd		%zmm19, %zmm24, %zmm22
+	vbroadcastsd	24+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm5
+	vfmadd231pd		%zmm11, %zmm24, %zmm13
+	vfmadd231pd		%zmm19, %zmm24, %zmm21
+	vbroadcastsd	24+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm4
+	vfmadd231pd		%zmm11, %zmm24, %zmm12
+	vfmadd231pd		%zmm19, %zmm24, %zmm20
+	vbroadcastsd	24+3*64(%r10), %zmm24
+	vmulpd			%zmm3, %zmm24, %zmm3
+	vmulpd			%zmm11, %zmm24, %zmm11
+	vmulpd			%zmm19, %zmm24, %zmm19
+	//
+	vbroadcastsd	16+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm7
+	vfmadd231pd		%zmm10, %zmm24, %zmm15
+	vfmadd231pd		%zmm18, %zmm24, %zmm23
+	vbroadcastsd	16+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm6
+	vfmadd231pd		%zmm10, %zmm24, %zmm14
+	vfmadd231pd		%zmm18, %zmm24, %zmm22
+	vbroadcastsd	16+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm5
+	vfmadd231pd		%zmm10, %zmm24, %zmm13
+	vfmadd231pd		%zmm18, %zmm24, %zmm21
+	vbroadcastsd	16+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm4
+	vfmadd231pd		%zmm10, %zmm24, %zmm12
+	vfmadd231pd		%zmm18, %zmm24, %zmm20
+	vbroadcastsd	16+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm3
+	vfmadd231pd		%zmm10, %zmm24, %zmm11
+	vfmadd231pd		%zmm18, %zmm24, %zmm19
+	vbroadcastsd	16+2*64(%r10), %zmm24
+	vmulpd			%zmm2, %zmm24, %zmm2
+	vmulpd			%zmm10, %zmm24, %zmm10
+	vmulpd			%zmm18, %zmm24, %zmm18
+	//
+	vbroadcastsd	8+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm7
+	vfmadd231pd		%zmm9, %zmm24, %zmm15
+	vfmadd231pd		%zmm17, %zmm24, %zmm23
+	vbroadcastsd	8+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm6
+	vfmadd231pd		%zmm9, %zmm24, %zmm14
+	vfmadd231pd		%zmm17, %zmm24, %zmm22
+	vbroadcastsd	8+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm5
+	vfmadd231pd		%zmm9, %zmm24, %zmm13
+	vfmadd231pd		%zmm17, %zmm24, %zmm21
+	vbroadcastsd	8+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm4
+	vfmadd231pd		%zmm9, %zmm24, %zmm12
+	vfmadd231pd		%zmm17, %zmm24, %zmm20
+	vbroadcastsd	8+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm3
+	vfmadd231pd		%zmm9, %zmm24, %zmm11
+	vfmadd231pd		%zmm17, %zmm24, %zmm19
+	vbroadcastsd	8+2*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm2
+	vfmadd231pd		%zmm9, %zmm24, %zmm10
+	vfmadd231pd		%zmm17, %zmm24, %zmm18
+	vbroadcastsd	8+1*64(%r10), %zmm24
+	vmulpd			%zmm1, %zmm24, %zmm1
+	vmulpd			%zmm9, %zmm24, %zmm9
+	vmulpd			%zmm17, %zmm24, %zmm17
+	//
+	vbroadcastsd	0+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm7
+	vfmadd231pd		%zmm8, %zmm24, %zmm15
+	vfmadd231pd		%zmm16, %zmm24, %zmm23
+	vbroadcastsd	0+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm6
+	vfmadd231pd		%zmm8, %zmm24, %zmm14
+	vfmadd231pd		%zmm16, %zmm24, %zmm22
+	vbroadcastsd	0+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm5
+	vfmadd231pd		%zmm8, %zmm24, %zmm13
+	vfmadd231pd		%zmm16, %zmm24, %zmm21
+	vbroadcastsd	0+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm4
+	vfmadd231pd		%zmm8, %zmm24, %zmm12
+	vfmadd231pd		%zmm16, %zmm24, %zmm20
+	vbroadcastsd	0+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm3
+	vfmadd231pd		%zmm8, %zmm24, %zmm11
+	vfmadd231pd		%zmm16, %zmm24, %zmm19
+	vbroadcastsd	0+2*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm2
+	vfmadd231pd		%zmm8, %zmm24, %zmm10
+	vfmadd231pd		%zmm16, %zmm24, %zmm18
+	vbroadcastsd	0+1*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm1
+	vfmadd231pd		%zmm8, %zmm24, %zmm9
+	vfmadd231pd		%zmm16, %zmm24, %zmm17
+	vbroadcastsd	0+0*64(%r10), %zmm24
+	vmulpd			%zmm0, %zmm24, %zmm0
+	vmulpd			%zmm8, %zmm24, %zmm8
+	vmulpd			%zmm16, %zmm24, %zmm16
+
+	movq	ARG1, %r10 // k
+	movq	ARG2, %r11 // V
+	movq	ARG4, %r12 // D
+	movq	ARG5, %r13 // sdd
+	sall	$ 6, %r13d
+
+	//
+	vmovapd			0+0*64(%r12), %zmm24
+	vmovapd			0+0*64(%r12, %r13), %zmm26
+	vmovapd			0+0*64(%r12, %r13, 2), %zmm27
+	vaddpd			%zmm24, %zmm0, %zmm24
+	vaddpd			%zmm26, %zmm8, %zmm26
+	vaddpd			%zmm27, %zmm16, %zmm27
+	vmovapd			%zmm24, 0+0*64(%r12)
+	vmovapd			%zmm26, 0+0*64(%r12, %r13)
+	vmovapd			%zmm27, 0+0*64(%r12, %r13, 2)
+	//
+	vmovapd			0+1*64(%r12), %zmm24
+	vmovapd			0+1*64(%r12, %r13), %zmm26
+	vmovapd			0+1*64(%r12, %r13, 2), %zmm27
+	vbroadcastsd	0+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm24
+	vfmadd231pd		%zmm8, %zmm25, %zmm26
+	vfmadd231pd		%zmm16, %zmm25, %zmm27
+	vaddpd			%zmm24, %zmm1, %zmm24
+	vaddpd			%zmm26, %zmm9, %zmm26
+	vaddpd			%zmm27, %zmm17, %zmm27
+	vmovapd			%zmm24, 0+1*64(%r12)
+	vmovapd			%zmm26, 0+1*64(%r12, %r13)
+	vmovapd			%zmm27, 0+1*64(%r12, %r13, 2)
+	//
+	vmovapd			0+2*64(%r12), %zmm24
+	vmovapd			0+2*64(%r12, %r13), %zmm26
+	vmovapd			0+2*64(%r12, %r13, 2), %zmm27
+	vbroadcastsd	0+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm24
+	vfmadd231pd		%zmm8, %zmm25, %zmm26
+	vfmadd231pd		%zmm16, %zmm25, %zmm27
+	vbroadcastsd	8+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm24
+	vfmadd231pd		%zmm9, %zmm25, %zmm26
+	vfmadd231pd		%zmm17, %zmm25, %zmm27
+	vaddpd			%zmm24, %zmm2, %zmm24
+	vaddpd			%zmm26, %zmm10, %zmm26
+	vaddpd			%zmm27, %zmm18, %zmm27
+	vmovapd			%zmm24, 0+2*64(%r12)
+	vmovapd			%zmm26, 0+2*64(%r12, %r13)
+	vmovapd			%zmm27, 0+2*64(%r12, %r13, 2)
+	//
+	vmovapd			0+3*64(%r12), %zmm24
+	vmovapd			0+3*64(%r12, %r13), %zmm26
+	vmovapd			0+3*64(%r12, %r13, 2), %zmm27
+	vbroadcastsd	0+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm24
+	vfmadd231pd		%zmm8, %zmm25, %zmm26
+	vfmadd231pd		%zmm16, %zmm25, %zmm27
+	vbroadcastsd	8+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm24
+	vfmadd231pd		%zmm9, %zmm25, %zmm26
+	vfmadd231pd		%zmm17, %zmm25, %zmm27
+	vbroadcastsd	16+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm24
+	vfmadd231pd		%zmm10, %zmm25, %zmm26
+	vfmadd231pd		%zmm18, %zmm25, %zmm27
+	vaddpd			%zmm24, %zmm3, %zmm24
+	vaddpd			%zmm26, %zmm11, %zmm26
+	vaddpd			%zmm27, %zmm19, %zmm27
+	vmovapd			%zmm24, 0+3*64(%r12)
+	vmovapd			%zmm26, 0+3*64(%r12, %r13)
+	vmovapd			%zmm27, 0+3*64(%r12, %r13, 2)
+	//
+	vmovapd			0+4*64(%r12), %zmm24
+	vmovapd			0+4*64(%r12, %r13), %zmm26
+	vmovapd			0+4*64(%r12, %r13, 2), %zmm27
+	vbroadcastsd	0+4*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm24
+	vfmadd231pd		%zmm8, %zmm25, %zmm26
+	vfmadd231pd		%zmm16, %zmm25, %zmm27
+	vbroadcastsd	8+4*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm24
+	vfmadd231pd		%zmm9, %zmm25, %zmm26
+	vfmadd231pd		%zmm17, %zmm25, %zmm27
+	vbroadcastsd	16+4*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm24
+	vfmadd231pd		%zmm10, %zmm25, %zmm26
+	vfmadd231pd		%zmm18, %zmm25, %zmm27
+	vbroadcastsd	24+4*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm24
+	vfmadd231pd		%zmm11, %zmm25, %zmm26
+	vfmadd231pd		%zmm19, %zmm25, %zmm27
+	vaddpd			%zmm24, %zmm4, %zmm24
+	vaddpd			%zmm26, %zmm12, %zmm26
+	vaddpd			%zmm27, %zmm20, %zmm27
+	vmovapd			%zmm24, 0+4*64(%r12)
+	vmovapd			%zmm26, 0+4*64(%r12, %r13)
+	vmovapd			%zmm27, 0+4*64(%r12, %r13, 2)
+	//
+	vmovapd			0+5*64(%r12), %zmm24
+	vmovapd			0+5*64(%r12, %r13), %zmm26
+	vmovapd			0+5*64(%r12, %r13, 2), %zmm27
+	vbroadcastsd	0+5*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm24
+	vfmadd231pd		%zmm8, %zmm25, %zmm26
+	vfmadd231pd		%zmm16, %zmm25, %zmm27
+	vbroadcastsd	8+5*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm24
+	vfmadd231pd		%zmm9, %zmm25, %zmm26
+	vfmadd231pd		%zmm17, %zmm25, %zmm27
+	vbroadcastsd	16+5*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm24
+	vfmadd231pd		%zmm10, %zmm25, %zmm26
+	vfmadd231pd		%zmm18, %zmm25, %zmm27
+	vbroadcastsd	24+5*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm24
+	vfmadd231pd		%zmm11, %zmm25, %zmm26
+	vfmadd231pd		%zmm19, %zmm25, %zmm27
+	vbroadcastsd	32+5*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm24
+	vfmadd231pd		%zmm12, %zmm25, %zmm26
+	vfmadd231pd		%zmm20, %zmm25, %zmm27
+	vaddpd			%zmm24, %zmm5, %zmm24
+	vaddpd			%zmm26, %zmm13, %zmm26
+	vaddpd			%zmm27, %zmm21, %zmm27
+	vmovapd			%zmm24, 0+5*64(%r12)
+	vmovapd			%zmm26, 0+5*64(%r12, %r13)
+	vmovapd			%zmm27, 0+5*64(%r12, %r13, 2)
+	//
+	vmovapd			0+6*64(%r12), %zmm24
+	vmovapd			0+6*64(%r12, %r13), %zmm26
+	vmovapd			0+6*64(%r12, %r13, 2), %zmm27
+	vbroadcastsd	0+6*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm24
+	vfmadd231pd		%zmm8, %zmm25, %zmm26
+	vfmadd231pd		%zmm16, %zmm25, %zmm27
+	vbroadcastsd	8+6*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm24
+	vfmadd231pd		%zmm9, %zmm25, %zmm26
+	vfmadd231pd		%zmm17, %zmm25, %zmm27
+	vbroadcastsd	16+6*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm24
+	vfmadd231pd		%zmm10, %zmm25, %zmm26
+	vfmadd231pd		%zmm18, %zmm25, %zmm27
+	vbroadcastsd	24+6*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm24
+	vfmadd231pd		%zmm11, %zmm25, %zmm26
+	vfmadd231pd		%zmm19, %zmm25, %zmm27
+	vbroadcastsd	32+6*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm24
+	vfmadd231pd		%zmm12, %zmm25, %zmm26
+	vfmadd231pd		%zmm20, %zmm25, %zmm27
+	vbroadcastsd	40+6*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm24
+	vfmadd231pd		%zmm13, %zmm25, %zmm26
+	vfmadd231pd		%zmm21, %zmm25, %zmm27
+	vaddpd			%zmm24, %zmm6, %zmm24
+	vaddpd			%zmm26, %zmm14, %zmm26
+	vaddpd			%zmm27, %zmm22, %zmm27
+	vmovapd			%zmm24, 0+6*64(%r12)
+	vmovapd			%zmm26, 0+6*64(%r12, %r13)
+	vmovapd			%zmm27, 0+6*64(%r12, %r13, 2)
+	//
+	vmovapd			0+7*64(%r12), %zmm24
+	vmovapd			0+7*64(%r12, %r13), %zmm26
+	vmovapd			0+7*64(%r12, %r13, 2), %zmm27
+	vbroadcastsd	0+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm24
+	vfmadd231pd		%zmm8, %zmm25, %zmm26
+	vfmadd231pd		%zmm16, %zmm25, %zmm27
+	vbroadcastsd	8+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm24
+	vfmadd231pd		%zmm9, %zmm25, %zmm26
+	vfmadd231pd		%zmm17, %zmm25, %zmm27
+	vbroadcastsd	16+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm24
+	vfmadd231pd		%zmm10, %zmm25, %zmm26
+	vfmadd231pd		%zmm18, %zmm25, %zmm27
+	vbroadcastsd	24+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm24
+	vfmadd231pd		%zmm11, %zmm25, %zmm26
+	vfmadd231pd		%zmm19, %zmm25, %zmm27
+	vbroadcastsd	32+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm24
+	vfmadd231pd		%zmm12, %zmm25, %zmm26
+	vfmadd231pd		%zmm20, %zmm25, %zmm27
+	vbroadcastsd	40+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm24
+	vfmadd231pd		%zmm13, %zmm25, %zmm26
+	vfmadd231pd		%zmm21, %zmm25, %zmm27
+	vbroadcastsd	48+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm6, %zmm25, %zmm24
+	vfmadd231pd		%zmm14, %zmm25, %zmm26
+	vfmadd231pd		%zmm22, %zmm25, %zmm27
+	vaddpd			%zmm24, %zmm7, %zmm24
+	vaddpd			%zmm26, %zmm15, %zmm26
+	vaddpd			%zmm27, %zmm23, %zmm27
+	vmovapd			%zmm24, 0+7*64(%r12)
+	vmovapd			%zmm26, 0+7*64(%r12, %r13)
+	vmovapd			%zmm27, 0+7*64(%r12, %r13, 2)
+
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+	addq	$ 512, %r12
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEBP_NN_24X8_LIB8
+#else
+	CALL(inner_kernel_dgebp_nn_24x8_lib8)
+#endif
+
+	EPILOGUE
+
+	ret
+
+	FUN_END(kernel_dlarfb8_rn_24_lib8)
 
 
 

--- a/kernel/avx512/kernel_dgemm_24x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_24x8_lib8.S
@@ -6560,7 +6560,7 @@ NAME:
 //#if defined(BLAS_API)
 #if ( defined(BLAS_API) | ( defined(LA_HIGH_PERFORMANCE) & defined(MF_COLMAJ) ) )
 
-//#include "kernel_dgemm_24x8_lib.S"
+#include "kernel_dgemm_24x8_lib.S"
 
 #endif
 

--- a/kernel/avx512/kernel_dgemm_24x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_24x8_lib8.S
@@ -381,13 +381,15 @@ NAME:
 	jle		2f // return
 
 	// prefetch
-//	prefetcht0	0(%r13) // software prefetch
-//	prefetcht0	0+64(%r13) // software prefetch
+	prefetcht0	0+0*64(%r13) // software prefetch
+	prefetcht0	0+1*64(%r13) // software prefetch
+	prefetcht0	0+2*64(%r13) // software prefetch
+	prefetcht0	0+3*64(%r13) // software prefetch
 
 	// preload
 	vmovapd 		0(%r11), %zmm25 // A0
 	vmovapd 		0(%r11, %r12), %zmm27 // A1
-	vmovapd 		0(%r11, %r12, 2), %zmm29 // A1
+	vmovapd 		0(%r11, %r12, 2), %zmm29 // A2
 
 	cmpl	$ 4, %r10d
 	jle		0f // consider clean-up loop
@@ -407,13 +409,13 @@ NAME:
 	vfmadd231pd		%zmm27, %zmm24, %zmm9
 	vfmadd231pd		%zmm29, %zmm24, %zmm17
 	vmovapd			64(%r11, %r12), %zmm28 // A
-//	prefetcht0	128(%r13) // software prefetch
+	prefetcht0	256+0*64(%r13) // software prefetch
 	vbroadcastsd	16(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm2
 	vfmadd231pd		%zmm27, %zmm24, %zmm10
 	vfmadd231pd		%zmm29, %zmm24, %zmm18
 	vmovapd			64(%r11, %r12, 2), %zmm30 // A
-//	prefetcht0	128+64(%r13) // software prefetch
+	prefetcht0	256+1*64(%r13) // software prefetch
 	vbroadcastsd	24(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm3
 	vfmadd231pd		%zmm27, %zmm24, %zmm11
@@ -484,13 +486,13 @@ NAME:
 	vfmadd231pd		%zmm27, %zmm24, %zmm9
 	vfmadd231pd		%zmm29, %zmm24, %zmm17
 	vmovapd			192(%r11, %r12), %zmm28 // A
-//	prefetcht0	128(%r13) // software prefetch
+	prefetcht0	256+2*64(%r13) // software prefetch
 	vbroadcastsd	16+128(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm2
 	vfmadd231pd		%zmm27, %zmm24, %zmm10
 	vfmadd231pd		%zmm29, %zmm24, %zmm18
 	vmovapd			192(%r11, %r12, 2), %zmm30 // A
-//	prefetcht0	128+64(%r13) // software prefetch
+	prefetcht0	256+3*64(%r13) // software prefetch
 	vbroadcastsd	24+128(%r13), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm3
 	vfmadd231pd		%zmm27, %zmm24, %zmm11

--- a/kernel/avx512/kernel_dgemm_24x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_24x8_lib8.S
@@ -4483,23 +4483,21 @@ NAME:
 //
 // input arguments:
 // r10  <- inv_diag_E
-// r11d <- kn
 // zmm0 <- []
 // ...
 // ymm23 <- []
 //
 // output arguments:
 // r10  <- inv_diag_E
-// r11d <- kn
 // zmm0 <- []
 // ...
 // ymm23 <- []
 
 #if MACRO_LEVEL>=1
-	.macro INNER_EDGE_DPOTRF_24X8_VS_LIB8
+	.macro INNER_EDGE_DPOTRF_24X8_LIB8
 #else
 	.p2align 4,,15
-	FUN_START(inner_edge_dpotrf_24x8_vs_lib8)
+	FUN_START(inner_edge_dpotrf_24x8_lib8)
 #endif
 
 	vxorpd	%ymm25, %ymm25, %ymm25 // 0.0
@@ -4521,7 +4519,514 @@ NAME:
 	vmulpd			%zmm0, %zmm26, %zmm0
 	vmulpd			%zmm8, %zmm26, %zmm8
 	vmulpd			%zmm16, %zmm26, %zmm16
-	cmpl			$ 2, %r11d
+	vmovapd			%zmm1, %zmm26
+	vfnmadd231pd	%zmm0, %zmm0, %zmm26
+
+	// 1
+//	vpermilpd		$ 0x3, %xmm1, %xmm26
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm26, %zmm27, %zmm26
+	vucomisd		%xmm25, %xmm26 // d_11 > 0.0 ?
+	jbe				3f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+4:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm1
+	vfnmadd231pd	%zmm8, %zmm27, %zmm9
+	vfnmadd231pd	%zmm16, %zmm27, %zmm17
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm2
+	vfnmadd231pd	%zmm8, %zmm27, %zmm10
+	vfnmadd231pd	%zmm16, %zmm27, %zmm18
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm3
+	vfnmadd231pd	%zmm8, %zmm27, %zmm11
+	vfnmadd231pd	%zmm16, %zmm27, %zmm19
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm4
+	vfnmadd231pd	%zmm8, %zmm27, %zmm12
+	vfnmadd231pd	%zmm16, %zmm27, %zmm20
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm5
+	vfnmadd231pd	%zmm8, %zmm27, %zmm13
+	vfnmadd231pd	%zmm16, %zmm27, %zmm21
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm6
+	vfnmadd231pd	%zmm8, %zmm27, %zmm14
+	vfnmadd231pd	%zmm16, %zmm27, %zmm22
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm7
+	vfnmadd231pd	%zmm8, %zmm27, %zmm15
+	vfnmadd231pd	%zmm16, %zmm27, %zmm23
+	vmovsd			%xmm26, 8(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm1, %zmm26, %zmm1
+	vmulpd			%zmm9, %zmm26, %zmm9
+	vmulpd			%zmm17, %zmm26, %zmm17
+	vmovapd			%zmm2, %zmm26
+	vfnmadd231pd	%zmm1, %zmm1, %zmm26
+
+	// 2
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm26, %zmm27, %zmm26
+	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
+	jbe				5f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+6:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm2
+	vfnmadd231pd	%zmm9, %zmm27, %zmm10
+	vfnmadd231pd	%zmm17, %zmm27, %zmm18
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm3
+	vfnmadd231pd	%zmm9, %zmm27, %zmm11
+	vfnmadd231pd	%zmm17, %zmm27, %zmm19
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm4
+	vfnmadd231pd	%zmm9, %zmm27, %zmm12
+	vfnmadd231pd	%zmm17, %zmm27, %zmm20
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm5
+	vfnmadd231pd	%zmm9, %zmm27, %zmm13
+	vfnmadd231pd	%zmm17, %zmm27, %zmm21
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm6
+	vfnmadd231pd	%zmm9, %zmm27, %zmm14
+	vfnmadd231pd	%zmm17, %zmm27, %zmm22
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm7
+	vfnmadd231pd	%zmm9, %zmm27, %zmm15
+	vfnmadd231pd	%zmm17, %zmm27, %zmm23
+	vmovsd			%xmm26, 16(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm2, %zmm26, %zmm2
+	vmulpd			%zmm10, %zmm26, %zmm10
+	vmulpd			%zmm18, %zmm26, %zmm18
+	vmovapd			%zmm3, %zmm26
+	vfnmadd231pd	%zmm2, %zmm2, %zmm26
+
+	// 3
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm26, %zmm27, %zmm26
+	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
+	jbe				7f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+8:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm27
+	vfnmadd231pd	%zmm2, %zmm27, %zmm3
+	vfnmadd231pd	%zmm10, %zmm27, %zmm11
+	vfnmadd231pd	%zmm18, %zmm27, %zmm19
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm27
+	vfnmadd231pd	%zmm2, %zmm27, %zmm4
+	vfnmadd231pd	%zmm10, %zmm27, %zmm12
+	vfnmadd231pd	%zmm18, %zmm27, %zmm20
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm27
+	vfnmadd231pd	%zmm2, %zmm27, %zmm5
+	vfnmadd231pd	%zmm10, %zmm27, %zmm13
+	vfnmadd231pd	%zmm18, %zmm27, %zmm21
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm27
+	vfnmadd231pd	%zmm2, %zmm27, %zmm6
+	vfnmadd231pd	%zmm10, %zmm27, %zmm14
+	vfnmadd231pd	%zmm18, %zmm27, %zmm22
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm27
+	vfnmadd231pd	%zmm2, %zmm27, %zmm7
+	vfnmadd231pd	%zmm10, %zmm27, %zmm15
+	vfnmadd231pd	%zmm18, %zmm27, %zmm23
+	vmovsd			%xmm26, 24(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm3, %zmm26, %zmm3
+	vmulpd			%zmm11, %zmm26, %zmm11
+	vmulpd			%zmm19, %zmm26, %zmm19
+	vmovapd			%zmm4, %zmm26
+	vfnmadd231pd	%zmm3, %zmm3, %zmm26
+
+	// 4
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm26, %zmm27, %zmm26
+	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
+	jbe				9f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+10:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm3, %zmm27, %zmm27
+	vfnmadd231pd	%zmm3, %zmm27, %zmm4
+	vfnmadd231pd	%zmm11, %zmm27, %zmm12
+	vfnmadd231pd	%zmm19, %zmm27, %zmm20
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm3, %zmm27, %zmm27
+	vfnmadd231pd	%zmm3, %zmm27, %zmm5
+	vfnmadd231pd	%zmm11, %zmm27, %zmm13
+	vfnmadd231pd	%zmm19, %zmm27, %zmm21
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm3, %zmm27, %zmm27
+	vfnmadd231pd	%zmm3, %zmm27, %zmm6
+	vfnmadd231pd	%zmm11, %zmm27, %zmm14
+	vfnmadd231pd	%zmm19, %zmm27, %zmm22
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm3, %zmm27, %zmm27
+	vfnmadd231pd	%zmm3, %zmm27, %zmm7
+	vfnmadd231pd	%zmm11, %zmm27, %zmm15
+	vfnmadd231pd	%zmm19, %zmm27, %zmm23
+	vmovsd			%xmm26, 32(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm4, %zmm26, %zmm4
+	vmulpd			%zmm12, %zmm26, %zmm12
+	vmulpd			%zmm20, %zmm26, %zmm20
+	vmovapd			%zmm5, %zmm26
+	vfnmadd231pd	%zmm4, %zmm4, %zmm26
+
+	// 5
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm26, %zmm27, %zmm26
+	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
+	jbe				11f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+12:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm4, %zmm27, %zmm27
+	vfnmadd231pd	%zmm4, %zmm27, %zmm5
+	vfnmadd231pd	%zmm12, %zmm27, %zmm13
+	vfnmadd231pd	%zmm20, %zmm27, %zmm21
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm4, %zmm27, %zmm27
+	vfnmadd231pd	%zmm4, %zmm27, %zmm6
+	vfnmadd231pd	%zmm12, %zmm27, %zmm14
+	vfnmadd231pd	%zmm20, %zmm27, %zmm22
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm4, %zmm27, %zmm27
+	vfnmadd231pd	%zmm4, %zmm27, %zmm7
+	vfnmadd231pd	%zmm12, %zmm27, %zmm15
+	vfnmadd231pd	%zmm20, %zmm27, %zmm23
+	vmovsd			%xmm26, 40(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm5, %zmm26, %zmm5
+	vmulpd			%zmm13, %zmm26, %zmm13
+	vmulpd			%zmm21, %zmm26, %zmm21
+	vmovapd			%zmm6, %zmm26
+	vfnmadd231pd	%zmm5, %zmm5, %zmm26
+
+	// 6
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm26, %zmm27, %zmm26
+	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
+	jbe				13f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+14:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm5, %zmm27, %zmm27
+	vfnmadd231pd	%zmm5, %zmm27, %zmm6
+	vfnmadd231pd	%zmm13, %zmm27, %zmm14
+	vfnmadd231pd	%zmm21, %zmm27, %zmm22
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm5, %zmm27, %zmm27
+	vfnmadd231pd	%zmm5, %zmm27, %zmm7
+	vfnmadd231pd	%zmm13, %zmm27, %zmm15
+	vfnmadd231pd	%zmm21, %zmm27, %zmm23
+	vmovsd			%xmm26, 48(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm6, %zmm26, %zmm6
+	vmulpd			%zmm14, %zmm26, %zmm14
+	vmulpd			%zmm22, %zmm26, %zmm22
+	vmovapd			%zmm7, %zmm26
+	vfnmadd231pd	%zmm6, %zmm6, %zmm26
+
+	// 7
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm26, %zmm27, %zmm26
+	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
+	jbe				15f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+16:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm6, %zmm27, %zmm27
+	vfnmadd231pd	%zmm6, %zmm27, %zmm7
+	vfnmadd231pd	%zmm14, %zmm27, %zmm15
+	vfnmadd231pd	%zmm22, %zmm27, %zmm23
+	vmovsd			%xmm26, 56(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm7, %zmm26, %zmm7
+	vmulpd			%zmm15, %zmm26, %zmm15
+	vmulpd			%zmm23, %zmm26, %zmm23
+
+	jmp				0f
+
+1:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				2b
+
+3:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				4b
+
+5:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				6b
+
+7:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				8b
+
+9:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				10b
+
+11:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				12b
+
+13:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				14b
+
+15:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				16b
+
+0:
+	#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_edge_dpotrf_24x8_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// cholesky factorization 
+//
+// input arguments:
+// r10  <- inv_diag_E
+// r11d <- m1
+// r12d <- n1
+// zmm0 <- []
+// ...
+// ymm23 <- []
+//
+// output arguments:
+// r10  <- inv_diag_E
+// r11d <- m1
+// r12d <- n1
+// zmm0 <- []
+// ...
+// ymm23 <- []
+
+#if MACRO_LEVEL>=1
+	.macro INNER_EDGE_DPOTRF_24X8_VS_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_edge_dpotrf_24x8_vs_lib8)
+#endif
+
+	vxorpd	%ymm25, %ymm25, %ymm25 // 0.0
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovsd	.LC04(%rip), %xmm24 // 1.0
+#elif defined(OS_MAC)
+	vmovsd	LC04(%rip), %xmm24 // 1.0
+#endif
+
+	// compute mask for rows
+	vcvtsi2sd	%r11d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC02(%rip), %zmm24
+#elif defined(OS_MAC)
+	vmovupd		LC02(%rip), %zmm24
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm24, %zmm25
+	vpmovq2m	%zmm25, %k1
+
+	vmovapd		%zmm16, %zmm16 {%k1}{z}
+	vmovapd		%zmm17, %zmm17 {%k1}{z}
+	vmovapd		%zmm18, %zmm18 {%k1}{z}
+	vmovapd		%zmm19, %zmm19 {%k1}{z}
+	vmovapd		%zmm20, %zmm20 {%k1}{z}
+	vmovapd		%zmm21, %zmm21 {%k1}{z}
+	vmovapd		%zmm22, %zmm22 {%k1}{z}
+	vmovapd		%zmm23, %zmm23 {%k1}{z}
+
+	// 0
+	vmovsd			%xmm0, %xmm0, %xmm26
+	vucomisd		%xmm25, %xmm26 // d_00 > 0.0 ?
+	jbe				1f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+2:
+	vmovsd			%xmm26, 0(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm0, %zmm26, %zmm0
+	vmulpd			%zmm8, %zmm26, %zmm8
+	vmulpd			%zmm16, %zmm26, %zmm16
+	cmpl			$ 2, %r12d
 	jl				0f // ret
 	vmovapd			%zmm1, %zmm26
 	vfnmadd231pd	%zmm0, %zmm0, %zmm26
@@ -4607,7 +5112,7 @@ NAME:
 	vmulpd			%zmm1, %zmm26, %zmm1
 	vmulpd			%zmm9, %zmm26, %zmm9
 	vmulpd			%zmm17, %zmm26, %zmm17
-	cmpl			$ 3, %r11d
+	cmpl			$ 3, %r12d
 	jl				0f // ret
 	vmovapd			%zmm2, %zmm26
 	vfnmadd231pd	%zmm1, %zmm1, %zmm26
@@ -4683,7 +5188,7 @@ NAME:
 	vmulpd			%zmm2, %zmm26, %zmm2
 	vmulpd			%zmm10, %zmm26, %zmm10
 	vmulpd			%zmm18, %zmm26, %zmm18
-	cmpl			$ 4, %r11d
+	cmpl			$ 4, %r12d
 	jl				0f // ret
 	vmovapd			%zmm3, %zmm26
 	vfnmadd231pd	%zmm2, %zmm2, %zmm26
@@ -4750,7 +5255,7 @@ NAME:
 	vmulpd			%zmm3, %zmm26, %zmm3
 	vmulpd			%zmm11, %zmm26, %zmm11
 	vmulpd			%zmm19, %zmm26, %zmm19
-	cmpl			$ 5, %r11d
+	cmpl			$ 5, %r12d
 	jl				0f // ret
 	vmovapd			%zmm4, %zmm26
 	vfnmadd231pd	%zmm3, %zmm3, %zmm26
@@ -4808,7 +5313,7 @@ NAME:
 	vmulpd			%zmm4, %zmm26, %zmm4
 	vmulpd			%zmm12, %zmm26, %zmm12
 	vmulpd			%zmm20, %zmm26, %zmm20
-	cmpl			$ 6, %r11d
+	cmpl			$ 6, %r12d
 	jl				0f // ret
 	vmovapd			%zmm5, %zmm26
 	vfnmadd231pd	%zmm4, %zmm4, %zmm26
@@ -4857,7 +5362,7 @@ NAME:
 	vmulpd			%zmm5, %zmm26, %zmm5
 	vmulpd			%zmm13, %zmm26, %zmm13
 	vmulpd			%zmm21, %zmm26, %zmm21
-	cmpl			$ 7, %r11d
+	cmpl			$ 7, %r12d
 	jl				0f // ret
 	vmovapd			%zmm6, %zmm26
 	vfnmadd231pd	%zmm5, %zmm5, %zmm26
@@ -4897,7 +5402,7 @@ NAME:
 	vmulpd			%zmm6, %zmm26, %zmm6
 	vmulpd			%zmm14, %zmm26, %zmm14
 	vmulpd			%zmm22, %zmm26, %zmm22
-	cmpl			$ 8, %r11d
+	cmpl			$ 8, %r12d
 	jl				0f // ret
 	vmovapd			%zmm7, %zmm26
 	vfnmadd231pd	%zmm6, %zmm6, %zmm26
@@ -5115,7 +5620,8 @@ NAME:
 // r11   <- beta
 // r12   <- C
 // r13   <- 8*sdc*sizeof(double)
-// r14   <- n1
+// r14   <- m1
+// r15   <- n1
 // zmm0 <- []
 // ...
 // zmm23 <- []
@@ -5125,7 +5631,8 @@ NAME:
 // r11   <- beta
 // r10   <- C
 // r13   <- 8*sdc*sizeof(double)
-// r14   <- n1
+// r14   <- m1
+// r15   <- n1
 // zmm0 <- []
 // ...
 // zmm23 <- []
@@ -5173,67 +5680,78 @@ NAME:
 	vucomisd	%xmm25, %xmm24 // beta==0.0 ?
 	je			0f // end
 
+	// compute mask for rows
+	vcvtsi2sd	%r14d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC02(%rip), %zmm26
+#elif defined(OS_MAC)
+	vmovupd		LC02(%rip), %zmm26
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm26, %zmm25
+	vpmovq2m	%zmm25, %k1
+
 	vmovapd		0(%r12), %zmm25
 	vfmadd231pd	%zmm24, %zmm25, %zmm0
 	vmovapd		0(%r12, %r13), %zmm25
 	vfmadd231pd	%zmm24, %zmm25, %zmm8
-	vmovapd		0(%r12, %r13, 2), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm16
-	cmpl	$ 2, %r14d
+	vmovapd		0(%r12, %r13, 2), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm16 {%k1}
+	cmpl	$ 2, %r15d
 	jl		0f // end
 	vmovapd		64(%r12), %zmm25
 	vfmadd231pd	%zmm24, %zmm25, %zmm1
 	vmovapd		64(%r12, %r13), %zmm25
 	vfmadd231pd	%zmm24, %zmm25, %zmm9
-	vmovapd		64(%r12, %r13, 2), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm17
-	cmpl	$ 3, %r14d
+	vmovapd		64(%r12, %r13, 2), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm17 {%k1}
+	cmpl	$ 3, %r15d
 	jl		0f // end
 	vmovapd		128(%r12), %zmm25
 	vfmadd231pd	%zmm24, %zmm25, %zmm2
 	vmovapd		128(%r12, %r13), %zmm25
 	vfmadd231pd	%zmm24, %zmm25, %zmm10
-	vmovapd		128(%r12, %r13, 2), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm18
-	cmpl	$ 4, %r14d
+	vmovapd		128(%r12, %r13, 2), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm18 {%k1}
+	cmpl	$ 4, %r15d
 	jl		0f // end
 	vmovapd		192(%r12), %zmm25
 	vfmadd231pd	%zmm24, %zmm25, %zmm3
 	vmovapd		192(%r12, %r13), %zmm25
 	vfmadd231pd	%zmm24, %zmm25, %zmm11
-	vmovapd		192(%r12, %r13, 2), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm19
-	cmpl	$ 5, %r14d
+	vmovapd		192(%r12, %r13, 2), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm19 {%k1}
+	cmpl	$ 5, %r15d
 	jl		0f // end
 	vmovapd		0+256(%r12), %zmm25
 	vfmadd231pd	%zmm24, %zmm25, %zmm4
 	vmovapd		0+256(%r12, %r13), %zmm25
 	vfmadd231pd	%zmm24, %zmm25, %zmm12
-	vmovapd		0+256(%r12, %r13, 2), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm20
-	cmpl	$ 6, %r14d
+	vmovapd		0+256(%r12, %r13, 2), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm20 {%k1}
+	cmpl	$ 6, %r15d
 	jl		0f // end
 	vmovapd		64+256(%r12), %zmm25
 	vfmadd231pd	%zmm24, %zmm25, %zmm5
 	vmovapd		64+256(%r12, %r13), %zmm25
 	vfmadd231pd	%zmm24, %zmm25, %zmm13
-	vmovapd		64+256(%r12, %r13, 2), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm21
-	cmpl	$ 7, %r14d
+	vmovapd		64+256(%r12, %r13, 2), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm21 {%k1}
+	cmpl	$ 7, %r15d
 	jl		0f // end
 	vmovapd		128+256(%r12), %zmm25
 	vfmadd231pd	%zmm24, %zmm25, %zmm6
 	vmovapd		128+256(%r12, %r13), %zmm25
 	vfmadd231pd	%zmm24, %zmm25, %zmm14
-	vmovapd		128+256(%r12, %r13, 2), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm22
+	vmovapd		128+256(%r12, %r13, 2), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm22 {%k1}
 	je		0f // end
 	vmovapd		192+256(%r12), %zmm25
 	vfmadd231pd	%zmm24, %zmm25, %zmm7
 	vmovapd		192+256(%r12, %r13), %zmm25
 	vfmadd231pd	%zmm24, %zmm25, %zmm15
-	vmovapd		192+256(%r12, %r13, 2), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm23
+	vmovapd		192+256(%r12, %r13, 2), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm23 {%k1}
 
 0:
 
@@ -5357,7 +5875,8 @@ NAME:
 // r10   <- beta
 // r11   <- C
 // r12   <- sdc
-// r13d  <- n1
+// r13d  <- m1
+// r14d  <- n1
 // zmm0 <- []
 // ...
 // zmm23 <- []
@@ -5365,8 +5884,9 @@ NAME:
 // output arguments:
 // r10   <- beta
 // r11   <- C
-// r13d  <- n1
 // r12   <- sdc
+// r13d  <- m1
+// r14d  <- n1
 // zmm0 <- []
 // ...
 // zmm23 <- []
@@ -5386,67 +5906,78 @@ NAME:
 	vucomisd	%xmm25, %xmm24 // beta==0.0 ?
 	je			0f // end
 
+	// compute mask for rows
+	vcvtsi2sd	%r13d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC02(%rip), %zmm26
+#elif defined(OS_MAC)
+	vmovupd		LC02(%rip), %zmm26
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm26, %zmm25
+	vpmovq2m	%zmm25, %k1
+
 	vmovapd		0(%r11), %zmm25
 	vfmsub231pd	%zmm24, %zmm25, %zmm0
 	vmovapd		0(%r11, %r12), %zmm25
 	vfmsub231pd	%zmm24, %zmm25, %zmm8
-	vmovapd		0(%r11, %r12, 2), %zmm25
-	vfmsub231pd	%zmm24, %zmm25, %zmm16
-	cmpl	$ 2, %r13d
+	vmovapd		0(%r11, %r12, 2), %zmm25 {%k1}{z}
+	vfmsub231pd	%zmm24, %zmm25, %zmm16 {%k1}
+	cmpl	$ 2, %r14d
 	jl		0f // end
 	vmovapd		1*64(%r11), %zmm25
 	vfmsub231pd	%zmm24, %zmm25, %zmm1
 	vmovapd		1*64(%r11, %r12), %zmm25
 	vfmsub231pd	%zmm24, %zmm25, %zmm9
-	vmovapd		1*64(%r11, %r12, 2), %zmm25
-	vfmsub231pd	%zmm24, %zmm25, %zmm17
-	cmpl	$ 3, %r13d
+	vmovapd		1*64(%r11, %r12, 2), %zmm25 {%k1}{z}
+	vfmsub231pd	%zmm24, %zmm25, %zmm17 {%k1}
+	cmpl	$ 3, %r14d
 	jl		0f // end
 	vmovapd		2*64(%r11), %zmm25
 	vfmsub231pd	%zmm24, %zmm25, %zmm2
 	vmovapd		2*64(%r11, %r12), %zmm25
 	vfmsub231pd	%zmm24, %zmm25, %zmm10
-	vmovapd		2*64(%r11, %r12, 2), %zmm25
-	vfmsub231pd	%zmm24, %zmm25, %zmm18
-	cmpl	$ 4, %r13d
+	vmovapd		2*64(%r11, %r12, 2), %zmm25 {%k1}{z}
+	vfmsub231pd	%zmm24, %zmm25, %zmm18 {%k1}
+	cmpl	$ 4, %r14d
 	jl		0f // end
 	vmovapd		3*64(%r11), %zmm25
 	vfmsub231pd	%zmm24, %zmm25, %zmm3
 	vmovapd		3*64(%r11, %r12), %zmm25
 	vfmsub231pd	%zmm24, %zmm25, %zmm11
-	vmovapd		3*64(%r11, %r12, 2), %zmm25
-	vfmsub231pd	%zmm24, %zmm25, %zmm19
-	cmpl	$ 5, %r13d
+	vmovapd		3*64(%r11, %r12, 2), %zmm25 {%k1}{z}
+	vfmsub231pd	%zmm24, %zmm25, %zmm19 {%k1}
+	cmpl	$ 5, %r14d
 	jl		0f // end
 	vmovapd		4*64(%r11), %zmm25
 	vfmsub231pd	%zmm24, %zmm25, %zmm4
 	vmovapd		4*64(%r11, %r12), %zmm25
 	vfmsub231pd	%zmm24, %zmm25, %zmm12
-	vmovapd		4*64(%r11, %r12, 2), %zmm25
-	vfmsub231pd	%zmm24, %zmm25, %zmm20
-	cmpl	$ 6, %r13d
+	vmovapd		4*64(%r11, %r12, 2), %zmm25 {%k1}{z}
+	vfmsub231pd	%zmm24, %zmm25, %zmm20 {%k1}
+	cmpl	$ 6, %r14d
 	jl		0f // end
 	vmovapd		5*64(%r11), %zmm25
 	vfmsub231pd	%zmm24, %zmm25, %zmm5
 	vmovapd		5*64(%r11, %r12), %zmm25
 	vfmsub231pd	%zmm24, %zmm25, %zmm13
-	vmovapd		5*64(%r11, %r12, 2), %zmm25
-	vfmsub231pd	%zmm24, %zmm25, %zmm21
-	cmpl	$ 7, %r13d
+	vmovapd		5*64(%r11, %r12, 2), %zmm25 {%k1}{z}
+	vfmsub231pd	%zmm24, %zmm25, %zmm21 {%k1}
+	cmpl	$ 7, %r14d
 	jl		0f // end
 	vmovapd		6*64(%r11), %zmm25
 	vfmsub231pd	%zmm24, %zmm25, %zmm6
 	vmovapd		6*64(%r11, %r12), %zmm25
 	vfmsub231pd	%zmm24, %zmm25, %zmm14
-	vmovapd		6*64(%r11, %r12, 2), %zmm25
-	vfmsub231pd	%zmm24, %zmm25, %zmm22
+	vmovapd		6*64(%r11, %r12, 2), %zmm25 {%k1}{z}
+	vfmsub231pd	%zmm24, %zmm25, %zmm22 {%k1}
 	je		0f // end
 	vmovapd		7*64(%r11), %zmm25
 	vfmsub231pd	%zmm24, %zmm25, %zmm7
 	vmovapd		7*64(%r11, %r12), %zmm25
 	vfmsub231pd	%zmm24, %zmm25, %zmm15
-	vmovapd		7*64(%r11, %r12, 2), %zmm25
-	vfmsub231pd	%zmm24, %zmm25, %zmm23
+	vmovapd		7*64(%r11, %r12, 2), %zmm25 {%k1}{z}
+	vfmsub231pd	%zmm24, %zmm25, %zmm23 {%k1}
 
 0:
 
@@ -5557,7 +6088,8 @@ NAME:
 // input arguments:
 // r10   <- C
 // r11   <- sdc
-// r12   <- n1
+// r12   <- m1
+// r13   <- n1
 // zmm0 <- []
 // ...
 // zmm23 <- []
@@ -5565,7 +6097,8 @@ NAME:
 // output arguments:
 // r10   <- C
 // r11   <- sdc
-// r12   <- n1
+// r12   <- m1
+// r13   <- n1
 // zmm0 <- []
 // ...
 // zmm23 <- []
@@ -5577,67 +6110,78 @@ NAME:
 	FUN_START(inner_scale_m11_24x8_vs_lib8)
 #endif	
 	
+	// compute mask for rows
+	vcvtsi2sd	%r12d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC02(%rip), %zmm26
+#elif defined(OS_MAC)
+	vmovupd		LC02(%rip), %zmm26
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm26, %zmm25
+	vpmovq2m	%zmm25, %k1
+
 	vmovapd		0(%r10), %zmm24
 	vsubpd		%zmm0, %zmm24, %zmm0
 	vmovapd		0(%r10, %r11), %zmm24
 	vsubpd		%zmm8, %zmm24, %zmm8
-	vmovapd		0(%r10, %r11, 2), %zmm24
-	vsubpd		%zmm16, %zmm24, %zmm16
-	cmpl	$ 2, %r12d
+	vmovapd		0(%r10, %r11, 2), %zmm24 {%k1}{z}
+	vsubpd		%zmm16, %zmm24, %zmm16 {%k1}
+	cmpl	$ 2, %r13d
 	jl		0f // end
 	vmovapd		1*64(%r10), %zmm24
 	vsubpd		%zmm1, %zmm24, %zmm1
 	vmovapd		1*64(%r10, %r11), %zmm24
 	vsubpd		%zmm9, %zmm24, %zmm9
-	vmovapd		1*64(%r10, %r11, 2), %zmm24
-	vsubpd		%zmm17, %zmm24, %zmm17
-	cmpl	$ 3, %r12d
+	vmovapd		1*64(%r10, %r11, 2), %zmm24 {%k1}{z}
+	vsubpd		%zmm17, %zmm24, %zmm17 {%k1}
+	cmpl	$ 3, %r13d
 	jl		0f // end
 	vmovapd		2*64(%r10), %zmm24
 	vsubpd		%zmm2, %zmm24, %zmm2
 	vmovapd		2*64(%r10, %r11), %zmm24
 	vsubpd		%zmm10, %zmm24, %zmm10
-	vmovapd		2*64(%r10, %r11, 2), %zmm24
-	vsubpd		%zmm18, %zmm24, %zmm18
-	cmpl	$ 4, %r12d
+	vmovapd		2*64(%r10, %r11, 2), %zmm24 {%k1}{z}
+	vsubpd		%zmm18, %zmm24, %zmm18 {%k1}
+	cmpl	$ 4, %r13d
 	jl		0f // end
 	vmovapd		3*64(%r10), %zmm24
 	vsubpd		%zmm3, %zmm24, %zmm3
 	vmovapd		3*64(%r10, %r11), %zmm24
 	vsubpd		%zmm11, %zmm24, %zmm11
-	vmovapd		3*64(%r10, %r11, 2), %zmm24
-	vsubpd		%zmm19, %zmm24, %zmm19
-	cmpl	$ 5, %r12d
+	vmovapd		3*64(%r10, %r11, 2), %zmm24 {%k1}{z}
+	vsubpd		%zmm19, %zmm24, %zmm19 {%k1}
+	cmpl	$ 5, %r13d
 	jl		0f // end
 	vmovapd		4*64(%r10), %zmm24
 	vsubpd		%zmm4, %zmm24, %zmm4
 	vmovapd		4*64(%r10, %r11), %zmm24
 	vsubpd		%zmm12, %zmm24, %zmm12
-	vmovapd		4*64(%r10, %r11, 2), %zmm24
-	vsubpd		%zmm20, %zmm24, %zmm20
-	cmpl	$ 6, %r12d
+	vmovapd		4*64(%r10, %r11, 2), %zmm24 {%k1}{z}
+	vsubpd		%zmm20, %zmm24, %zmm20 {%k1}
+	cmpl	$ 6, %r13d
 	jl		0f // end
 	vmovapd		5*64(%r10), %zmm24
 	vsubpd		%zmm5, %zmm24, %zmm5
 	vmovapd		5*64(%r10, %r11), %zmm24
 	vsubpd		%zmm13, %zmm24, %zmm13
-	vmovapd		5*64(%r10, %r11, 2), %zmm24
-	vsubpd		%zmm21, %zmm24, %zmm21
-	cmpl	$ 7, %r12d
+	vmovapd		5*64(%r10, %r11, 2), %zmm24 {%k1}{z}
+	vsubpd		%zmm21, %zmm24, %zmm21 {%k1}
+	cmpl	$ 7, %r13d
 	jl		0f // end
 	vmovapd		6*64(%r10), %zmm24
 	vsubpd		%zmm6, %zmm24, %zmm6
 	vmovapd		6*64(%r10, %r11), %zmm24
 	vsubpd		%zmm14, %zmm24, %zmm14
-	vmovapd		6*64(%r10, %r11, 2), %zmm24
-	vsubpd		%zmm22, %zmm24, %zmm22
+	vmovapd		6*64(%r10, %r11, 2), %zmm24 {%k1}{z}
+	vsubpd		%zmm22, %zmm24, %zmm22 {%k1}
 	je		0f // end
 	vmovapd		7*64(%r10), %zmm24
 	vsubpd		%zmm7, %zmm24, %zmm7
 	vmovapd		7*64(%r10, %r11), %zmm24
 	vsubpd		%zmm15, %zmm24, %zmm15
-	vmovapd		7*64(%r10, %r11, 2), %zmm24
-	vsubpd		%zmm23, %zmm24, %zmm23
+	vmovapd		7*64(%r10, %r11, 2), %zmm24 {%k1}{z}
+	vsubpd		%zmm23, %zmm24, %zmm23 {%k1}
 
 0:
 
@@ -6238,7 +6782,8 @@ NAME:
 	movq	ARG7, %r12 // C
 	movq	ARG8, %r13 // sdc
 	sall	$ 6, %r13d // 8*sdc*sizeof(double)
-	movq	ARG12, %r14 // n1
+	movq	ARG11, %r14 // m1
+	movq	ARG12, %r15 // n1
 
 #if MACRO_LEVEL>=1
 	INNER_SCALE_AB_24X8_VS_LIB8
@@ -6385,7 +6930,8 @@ NAME:
 	movq	ARG6, %r11 // C
 	movq	ARG7, %r12 // sdc
 	sall	$ 6, %r12d // 4*sdc*sizeof(double)
-	movq	ARG13, %r13 // n1
+	movq	ARG12, %r13 // m1
+	movq	ARG13, %r14 // n1
 
 #if MACRO_LEVEL>=1
 	INNER_SCALE_M1B_24X8_VS_LIB8
@@ -6583,7 +7129,8 @@ NAME:
 	movq	ARG9, %r10  // C
 	movq	ARG10, %r11 // sdc
 	sall	$ 6, %r11d // 4*sdc*sizeof(double)
-	movq	ARG16, %r12 // n1
+	movq	ARG15, %r12 // m1
+	movq	ARG16, %r13 // n1
 
 #if MACRO_LEVEL>=1
 	INNER_SCALE_M11_24X8_VS_LIB8
@@ -6674,12 +7221,11 @@ NAME:
 	// factorization
 
 	movq	ARG9, %r10  // inv_diag_D 
-	movl	$ 8, %r11d
 
 #if MACRO_LEVEL>=1
-	INNER_EDGE_DPOTRF_24X8_VS_LIB8
+	INNER_EDGE_DPOTRF_24X8_LIB8
 #else
-	CALL(inner_edge_dpotrf_24x8_vs_lib8)
+	CALL(inner_edge_dpotrf_24x8_lib8)
 #endif
 
 
@@ -6741,7 +7287,8 @@ NAME:
 	movq	ARG5, %r10 // C
 	movq	ARG6, %r11 // sdc
 	sall	$ 6, %r11d // 8*sdc*sizeof(double)
-	movq	ARG11, %r12 // n1
+	movq	ARG10, %r12 // m1
+	movq	ARG11, %r13 // n1
 
 #if MACRO_LEVEL>=1
 	INNER_SCALE_M11_24X8_VS_LIB8
@@ -6753,7 +7300,8 @@ NAME:
 	// factorization
 
 	movq	ARG9, %r10  // inv_diag_D 
-	movq	ARG11, %r11 // n1
+	movq	ARG10, %r11 // m1
+	movq	ARG11, %r12 // n1
 
 #if MACRO_LEVEL>=1
 	INNER_EDGE_DPOTRF_24X8_VS_LIB8
@@ -6850,12 +7398,11 @@ NAME:
 	// factorization
 
 	movq	ARG13, %r10  // inv_diag_D 
-	movl	$ 8, %r11d
 
 #if MACRO_LEVEL>=1
-	INNER_EDGE_DPOTRF_24X8_VS_LIB8
+	INNER_EDGE_DPOTRF_24X8_LIB8
 #else
-	CALL(inner_edge_dpotrf_24x8_vs_lib8)
+	CALL(inner_edge_dpotrf_24x8_lib8)
 #endif
 
 
@@ -6938,7 +7485,8 @@ NAME:
 	movq	ARG9, %r10 // C
 	movq	ARG10, %r11 // sdc
 	sall	$ 6, %r11d // 4*sdc*sizeof(double)
-	movq	ARG15, %r12 // n1
+	movq	ARG14, %r12 // m1
+	movq	ARG15, %r13 // n1
 
 #if MACRO_LEVEL>=1
 	INNER_SCALE_M11_24X8_VS_LIB8
@@ -6950,7 +7498,8 @@ NAME:
 	// factorization
 
 	movq	ARG13, %r10  // inv_diag_D 
-	movq	ARG15, %r11 // n1
+	movq	ARG14, %r11 // m1
+	movq	ARG15, %r12 // n1
 
 #if MACRO_LEVEL>=1
 	INNER_EDGE_DPOTRF_24X8_VS_LIB8

--- a/kernel/avx512/kernel_dgemm_24x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_24x8_lib8.S
@@ -358,7 +358,7 @@ NAME:
 // r13   <- B
 // zmm0  <- []
 // ...
-// zmm15  <- []
+// zmm23  <- []
 
 //
 // output arguments:
@@ -368,7 +368,7 @@ NAME:
 // r13   <- B+8*k*sizeof(double)
 // zmm0  <- []
 // ...
-// zmm15  <- []
+// zmm23  <- []
 
 #if MACRO_LEVEL>=2
 	.macro INNER_KERNEL_DGEMM_NT_24X8_LIB8
@@ -787,6 +787,417 @@ NAME:
 
 // common inner routine with file scope
 //
+// triangular substitution:
+// side = right
+// uplo = lower
+// tran = transposed
+// requires explicit inverse of diagonal
+//
+// input arguments:
+// r10  <- E
+// r11  <- inv_diag_E
+// zmm0 <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+// r10  <- E
+// r11  <- inv_diag_E
+// zmm0 <- []
+// ...
+// zmm23 <- []
+
+#if MACRO_LEVEL>=1
+	.macro INNER_EDGE_DTRSM_RLT_INV_24X8_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_edge_dtrsm_rlt_inv_24x8_lib8)
+#endif
+	
+	vbroadcastsd	0(%r11), %zmm24
+	vmulpd			%zmm0, %zmm24, %zmm0
+	vmulpd			%zmm8, %zmm24, %zmm8
+	vmulpd			%zmm16, %zmm24, %zmm16
+	vbroadcastsd	8+0*64(%r10), %zmm24
+	vfnmadd231pd	%zmm0, %zmm24, %zmm1
+	vfnmadd231pd	%zmm8, %zmm24, %zmm9
+	vfnmadd231pd	%zmm16, %zmm24, %zmm17
+	vbroadcastsd	16+0*64(%r10), %zmm24
+	vfnmadd231pd	%zmm0, %zmm24, %zmm2
+	vfnmadd231pd	%zmm8, %zmm24, %zmm10
+	vfnmadd231pd	%zmm16, %zmm24, %zmm18
+	vbroadcastsd	24+0*64(%r10), %zmm24
+	vfnmadd231pd	%zmm0, %zmm24, %zmm3
+	vfnmadd231pd	%zmm8, %zmm24, %zmm11
+	vfnmadd231pd	%zmm16, %zmm24, %zmm19
+	vbroadcastsd	32+0*64(%r10), %zmm24
+	vfnmadd231pd	%zmm0, %zmm24, %zmm4
+	vfnmadd231pd	%zmm8, %zmm24, %zmm12
+	vfnmadd231pd	%zmm16, %zmm24, %zmm20
+	vbroadcastsd	40+0*64(%r10), %zmm24
+	vfnmadd231pd	%zmm0, %zmm24, %zmm5
+	vfnmadd231pd	%zmm8, %zmm24, %zmm13
+	vfnmadd231pd	%zmm16, %zmm24, %zmm21
+	vbroadcastsd	48+0*64(%r10), %zmm24
+	vfnmadd231pd	%zmm0, %zmm24, %zmm6
+	vfnmadd231pd	%zmm8, %zmm24, %zmm14
+	vfnmadd231pd	%zmm16, %zmm24, %zmm22
+	vbroadcastsd	56+0*64(%r10), %zmm24
+	vfnmadd231pd	%zmm0, %zmm24, %zmm7
+	vfnmadd231pd	%zmm8, %zmm24, %zmm15
+	vfnmadd231pd	%zmm16, %zmm24, %zmm23
+
+	vbroadcastsd	8(%r11), %zmm24
+	vmulpd			%zmm1, %zmm24, %zmm1
+	vmulpd			%zmm9, %zmm24, %zmm9
+	vmulpd			%zmm17, %zmm24, %zmm17
+	vbroadcastsd	16+1*64(%r10), %zmm24
+	vfnmadd231pd	%zmm1, %zmm24, %zmm2
+	vfnmadd231pd	%zmm9, %zmm24, %zmm10
+	vfnmadd231pd	%zmm17, %zmm24, %zmm18
+	vbroadcastsd	24+1*64(%r10), %zmm24
+	vfnmadd231pd	%zmm1, %zmm24, %zmm3
+	vfnmadd231pd	%zmm9, %zmm24, %zmm11
+	vfnmadd231pd	%zmm17, %zmm24, %zmm19
+	vbroadcastsd	32+1*64(%r10), %zmm24
+	vfnmadd231pd	%zmm1, %zmm24, %zmm4
+	vfnmadd231pd	%zmm9, %zmm24, %zmm12
+	vfnmadd231pd	%zmm17, %zmm24, %zmm20
+	vbroadcastsd	40+1*64(%r10), %zmm24
+	vfnmadd231pd	%zmm1, %zmm24, %zmm5
+	vfnmadd231pd	%zmm9, %zmm24, %zmm13
+	vfnmadd231pd	%zmm17, %zmm24, %zmm21
+	vbroadcastsd	48+1*64(%r10), %zmm24
+	vfnmadd231pd	%zmm1, %zmm24, %zmm6
+	vfnmadd231pd	%zmm9, %zmm24, %zmm14
+	vfnmadd231pd	%zmm17, %zmm24, %zmm22
+	vbroadcastsd	56+1*64(%r10), %zmm24
+	vfnmadd231pd	%zmm1, %zmm24, %zmm7
+	vfnmadd231pd	%zmm9, %zmm24, %zmm15
+	vfnmadd231pd	%zmm17, %zmm24, %zmm23
+
+	vbroadcastsd	16(%r11), %zmm24
+	vmulpd			%zmm2, %zmm24, %zmm2
+	vmulpd			%zmm10, %zmm24, %zmm10
+	vmulpd			%zmm18, %zmm24, %zmm18
+	vbroadcastsd	24+2*64(%r10), %zmm24
+	vfnmadd231pd	%zmm2, %zmm24, %zmm3
+	vfnmadd231pd	%zmm10, %zmm24, %zmm11
+	vfnmadd231pd	%zmm18, %zmm24, %zmm19
+	vbroadcastsd	32+2*64(%r10), %zmm24
+	vfnmadd231pd	%zmm2, %zmm24, %zmm4
+	vfnmadd231pd	%zmm10, %zmm24, %zmm12
+	vfnmadd231pd	%zmm18, %zmm24, %zmm20
+	vbroadcastsd	40+2*64(%r10), %zmm24
+	vfnmadd231pd	%zmm2, %zmm24, %zmm5
+	vfnmadd231pd	%zmm10, %zmm24, %zmm13
+	vfnmadd231pd	%zmm18, %zmm24, %zmm21
+	vbroadcastsd	48+2*64(%r10), %zmm24
+	vfnmadd231pd	%zmm2, %zmm24, %zmm6
+	vfnmadd231pd	%zmm10, %zmm24, %zmm14
+	vfnmadd231pd	%zmm18, %zmm24, %zmm22
+	vbroadcastsd	56+2*64(%r10), %zmm24
+	vfnmadd231pd	%zmm2, %zmm24, %zmm7
+	vfnmadd231pd	%zmm10, %zmm24, %zmm15
+	vfnmadd231pd	%zmm18, %zmm24, %zmm23
+
+	vbroadcastsd	24(%r11), %zmm24
+	vmulpd			%zmm3, %zmm24, %zmm3
+	vmulpd			%zmm11, %zmm24, %zmm11
+	vmulpd			%zmm19, %zmm24, %zmm19
+	vbroadcastsd	32+3*64(%r10), %zmm24
+	vfnmadd231pd	%zmm3, %zmm24, %zmm4
+	vfnmadd231pd	%zmm11, %zmm24, %zmm12
+	vfnmadd231pd	%zmm19, %zmm24, %zmm20
+	vbroadcastsd	40+3*64(%r10), %zmm24
+	vfnmadd231pd	%zmm3, %zmm24, %zmm5
+	vfnmadd231pd	%zmm11, %zmm24, %zmm13
+	vfnmadd231pd	%zmm19, %zmm24, %zmm21
+	vbroadcastsd	48+3*64(%r10), %zmm24
+	vfnmadd231pd	%zmm3, %zmm24, %zmm6
+	vfnmadd231pd	%zmm11, %zmm24, %zmm14
+	vfnmadd231pd	%zmm19, %zmm24, %zmm22
+	vbroadcastsd	56+3*64(%r10), %zmm24
+	vfnmadd231pd	%zmm3, %zmm24, %zmm7
+	vfnmadd231pd	%zmm11, %zmm24, %zmm15
+	vfnmadd231pd	%zmm19, %zmm24, %zmm23
+
+	vbroadcastsd	32(%r11), %zmm24
+	vmulpd			%zmm4, %zmm24, %zmm4
+	vmulpd			%zmm12, %zmm24, %zmm12
+	vmulpd			%zmm20, %zmm24, %zmm20
+	vbroadcastsd	40+4*64(%r10), %zmm24
+	vfnmadd231pd	%zmm4, %zmm24, %zmm5
+	vfnmadd231pd	%zmm12, %zmm24, %zmm13
+	vfnmadd231pd	%zmm20, %zmm24, %zmm21
+	vbroadcastsd	48+4*64(%r10), %zmm24
+	vfnmadd231pd	%zmm4, %zmm24, %zmm6
+	vfnmadd231pd	%zmm12, %zmm24, %zmm14
+	vfnmadd231pd	%zmm20, %zmm24, %zmm22
+	vbroadcastsd	56+4*64(%r10), %zmm24
+	vfnmadd231pd	%zmm4, %zmm24, %zmm7
+	vfnmadd231pd	%zmm12, %zmm24, %zmm15
+	vfnmadd231pd	%zmm20, %zmm24, %zmm23
+
+	vbroadcastsd	40(%r11), %zmm24
+	vmulpd			%zmm5, %zmm24, %zmm5
+	vmulpd			%zmm13, %zmm24, %zmm13
+	vmulpd			%zmm21, %zmm24, %zmm21
+	vbroadcastsd	48+5*64(%r10), %zmm24
+	vfnmadd231pd	%zmm5, %zmm24, %zmm6
+	vfnmadd231pd	%zmm13, %zmm24, %zmm14
+	vfnmadd231pd	%zmm21, %zmm24, %zmm22
+	vbroadcastsd	56+5*64(%r10), %zmm24
+	vfnmadd231pd	%zmm5, %zmm24, %zmm7
+	vfnmadd231pd	%zmm13, %zmm24, %zmm15
+	vfnmadd231pd	%zmm21, %zmm24, %zmm23
+
+	vbroadcastsd	48(%r11), %zmm24
+	vmulpd			%zmm6, %zmm24, %zmm6
+	vmulpd			%zmm14, %zmm24, %zmm14
+	vmulpd			%zmm22, %zmm24, %zmm22
+	vbroadcastsd	56+6*64(%r10), %zmm24
+	vfnmadd231pd	%zmm6, %zmm24, %zmm7
+	vfnmadd231pd	%zmm14, %zmm24, %zmm15
+	vfnmadd231pd	%zmm22, %zmm24, %zmm23
+
+	vbroadcastsd	56(%r11), %zmm24
+	vmulpd			%zmm7, %zmm24, %zmm7
+	vmulpd			%zmm15, %zmm24, %zmm15
+	vmulpd			%zmm23, %zmm24, %zmm23
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_edge_dtrsm_rlt_inv_16x8_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// triangular substitution:
+// side = right
+// uplo = lower
+// tran = transposed
+// requires explicit inverse of diagonal
+//
+// input arguments:
+// r10  <- D
+// r11  <- inv_diag_D
+// r12d <- n1
+// zmm0 <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+// r10  <- D
+// r11  <- inv_diag_D
+// r12d <- n1
+// zmm0 <- []
+// ...
+// zmm23 <- []
+
+#if MACRO_LEVEL>=1
+	.macro INNER_EDGE_DTRSM_RLT_INV_24X8_VS_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_edge_dtrsm_rlt_inv_24x8_vs_lib8)
+#endif
+	
+	vbroadcastsd	0(%r11), %zmm24
+	vmulpd			%zmm0, %zmm24, %zmm0
+	vmulpd			%zmm8, %zmm24, %zmm8
+	vmulpd			%zmm26, %zmm24, %zmm26
+
+	cmpl			$ 2, %r12d
+	jl				0f // ret
+
+	vbroadcastsd	8+0*64(%r10), %zmm24
+	vfnmadd231pd	%zmm0, %zmm24, %zmm1
+	vfnmadd231pd	%zmm8, %zmm24, %zmm9
+	vfnmadd231pd	%zmm16, %zmm24, %zmm17
+	vbroadcastsd	8(%r11), %zmm24
+	vmulpd			%zmm1, %zmm24, %zmm1
+	vmulpd			%zmm9, %zmm24, %zmm9
+	vmulpd			%zmm17, %zmm24, %zmm17
+
+	cmpl			$ 3, %r12d
+	jl				0f // ret
+
+	vbroadcastsd	16+0*64(%r10), %zmm24
+	vfnmadd231pd	%zmm0, %zmm24, %zmm2
+	vfnmadd231pd	%zmm8, %zmm24, %zmm10
+	vfnmadd231pd	%zmm16, %zmm24, %zmm18
+	vbroadcastsd	16+1*64(%r10), %zmm24
+	vfnmadd231pd	%zmm1, %zmm24, %zmm2
+	vfnmadd231pd	%zmm9, %zmm24, %zmm10
+	vfnmadd231pd	%zmm17, %zmm24, %zmm18
+	vbroadcastsd	16(%r11), %zmm24
+	vmulpd			%zmm2, %zmm24, %zmm2
+	vmulpd			%zmm10, %zmm24, %zmm10
+	vmulpd			%zmm18, %zmm24, %zmm18
+
+	cmpl			$ 4, %r12d
+	jl				0f // ret
+
+	vbroadcastsd	24+0*64(%r10), %zmm24
+	vfnmadd231pd	%zmm0, %zmm24, %zmm3
+	vfnmadd231pd	%zmm8, %zmm24, %zmm11
+	vfnmadd231pd	%zmm16, %zmm24, %zmm19
+	vbroadcastsd	24+1*64(%r10), %zmm24
+	vfnmadd231pd	%zmm1, %zmm24, %zmm3
+	vfnmadd231pd	%zmm9, %zmm24, %zmm11
+	vfnmadd231pd	%zmm17, %zmm24, %zmm19
+	vbroadcastsd	24+2*64(%r10), %zmm24
+	vfnmadd231pd	%zmm2, %zmm24, %zmm3
+	vfnmadd231pd	%zmm10, %zmm24, %zmm11
+	vfnmadd231pd	%zmm18, %zmm24, %zmm19
+	vbroadcastsd	24(%r11), %zmm24
+	vmulpd			%zmm3, %zmm24, %zmm3
+	vmulpd			%zmm11, %zmm24, %zmm11
+	vmulpd			%zmm19, %zmm24, %zmm19
+
+	cmpl			$ 5, %r12d
+	jl				0f // ret
+
+	vbroadcastsd	32+0*64(%r10), %zmm24
+	vfnmadd231pd	%zmm0, %zmm24, %zmm4
+	vfnmadd231pd	%zmm8, %zmm24, %zmm12
+	vfnmadd231pd	%zmm16, %zmm24, %zmm20
+	vbroadcastsd	32+1*64(%r10), %zmm24
+	vfnmadd231pd	%zmm1, %zmm24, %zmm4
+	vfnmadd231pd	%zmm9, %zmm24, %zmm12
+	vfnmadd231pd	%zmm17, %zmm24, %zmm20
+	vbroadcastsd	32+2*64(%r10), %zmm24
+	vfnmadd231pd	%zmm2, %zmm24, %zmm4
+	vfnmadd231pd	%zmm10, %zmm24, %zmm12
+	vfnmadd231pd	%zmm18, %zmm24, %zmm20
+	vbroadcastsd	32+3*64(%r10), %zmm24
+	vfnmadd231pd	%zmm3, %zmm24, %zmm4
+	vfnmadd231pd	%zmm11, %zmm24, %zmm12
+	vfnmadd231pd	%zmm19, %zmm24, %zmm20
+	vbroadcastsd	32(%r11), %zmm24
+	vmulpd			%zmm4, %zmm24, %zmm4
+	vmulpd			%zmm12, %zmm24, %zmm12
+	vmulpd			%zmm20, %zmm24, %zmm20
+
+	cmpl			$ 6, %r12d
+	jl				0f // ret
+
+	vbroadcastsd	40+0*64(%r10), %zmm24
+	vfnmadd231pd	%zmm0, %zmm24, %zmm5
+	vfnmadd231pd	%zmm8, %zmm24, %zmm13
+	vfnmadd231pd	%zmm16, %zmm24, %zmm21
+	vbroadcastsd	40+1*64(%r10), %zmm24
+	vfnmadd231pd	%zmm1, %zmm24, %zmm5
+	vfnmadd231pd	%zmm9, %zmm24, %zmm13
+	vfnmadd231pd	%zmm17, %zmm24, %zmm21
+	vbroadcastsd	40+2*64(%r10), %zmm24
+	vfnmadd231pd	%zmm2, %zmm24, %zmm5
+	vfnmadd231pd	%zmm10, %zmm24, %zmm13
+	vfnmadd231pd	%zmm18, %zmm24, %zmm21
+	vbroadcastsd	40+3*64(%r10), %zmm24
+	vfnmadd231pd	%zmm3, %zmm24, %zmm5
+	vfnmadd231pd	%zmm11, %zmm24, %zmm13
+	vfnmadd231pd	%zmm19, %zmm24, %zmm21
+	vbroadcastsd	40+4*64(%r10), %zmm24
+	vfnmadd231pd	%zmm4, %zmm24, %zmm5
+	vfnmadd231pd	%zmm12, %zmm24, %zmm13
+	vfnmadd231pd	%zmm20, %zmm24, %zmm21
+	vbroadcastsd	40(%r11), %zmm24
+	vmulpd			%zmm5, %zmm24, %zmm5
+	vmulpd			%zmm13, %zmm24, %zmm13
+	vmulpd			%zmm21, %zmm24, %zmm21
+
+	cmpl			$ 7, %r12d
+	jl				0f // ret
+
+	vbroadcastsd	48+0*64(%r10), %zmm24
+	vfnmadd231pd	%zmm0, %zmm24, %zmm6
+	vfnmadd231pd	%zmm8, %zmm24, %zmm14
+	vfnmadd231pd	%zmm16, %zmm24, %zmm22
+	vbroadcastsd	48+1*64(%r10), %zmm24
+	vfnmadd231pd	%zmm1, %zmm24, %zmm6
+	vfnmadd231pd	%zmm9, %zmm24, %zmm14
+	vfnmadd231pd	%zmm17, %zmm24, %zmm22
+	vbroadcastsd	48+2*64(%r10), %zmm24
+	vfnmadd231pd	%zmm2, %zmm24, %zmm6
+	vfnmadd231pd	%zmm10, %zmm24, %zmm14
+	vfnmadd231pd	%zmm18, %zmm24, %zmm22
+	vbroadcastsd	48+3*64(%r10), %zmm24
+	vfnmadd231pd	%zmm3, %zmm24, %zmm6
+	vfnmadd231pd	%zmm11, %zmm24, %zmm14
+	vfnmadd231pd	%zmm19, %zmm24, %zmm22
+	vbroadcastsd	48+4*64(%r10), %zmm24
+	vfnmadd231pd	%zmm4, %zmm24, %zmm6
+	vfnmadd231pd	%zmm12, %zmm24, %zmm14
+	vfnmadd231pd	%zmm20, %zmm24, %zmm22
+	vbroadcastsd	48+5*64(%r10), %zmm24
+	vfnmadd231pd	%zmm5, %zmm24, %zmm6
+	vfnmadd231pd	%zmm13, %zmm24, %zmm14
+	vfnmadd231pd	%zmm21, %zmm24, %zmm22
+	vbroadcastsd	48(%r11), %zmm24
+	vmulpd			%zmm6, %zmm24, %zmm6
+	vmulpd			%zmm14, %zmm24, %zmm14
+	vmulpd			%zmm22, %zmm24, %zmm22
+
+	cmpl			$ 8, %r12d
+	jl				0f // ret
+
+	vbroadcastsd	56+0*64(%r10), %zmm24
+	vfnmadd231pd	%zmm0, %zmm24, %zmm7
+	vfnmadd231pd	%zmm8, %zmm24, %zmm15
+	vfnmadd231pd	%zmm16, %zmm24, %zmm23
+	vbroadcastsd	56+1*64(%r10), %zmm24
+	vfnmadd231pd	%zmm1, %zmm24, %zmm7
+	vfnmadd231pd	%zmm9, %zmm24, %zmm15
+	vfnmadd231pd	%zmm17, %zmm24, %zmm23
+	vbroadcastsd	56+2*64(%r10), %zmm24
+	vfnmadd231pd	%zmm2, %zmm24, %zmm7
+	vfnmadd231pd	%zmm10, %zmm24, %zmm15
+	vfnmadd231pd	%zmm18, %zmm24, %zmm23
+	vbroadcastsd	56+3*64(%r10), %zmm24
+	vfnmadd231pd	%zmm3, %zmm24, %zmm7
+	vfnmadd231pd	%zmm11, %zmm24, %zmm15
+	vfnmadd231pd	%zmm19, %zmm24, %zmm23
+	vbroadcastsd	56+4*64(%r10), %zmm24
+	vfnmadd231pd	%zmm4, %zmm24, %zmm7
+	vfnmadd231pd	%zmm12, %zmm24, %zmm15
+	vfnmadd231pd	%zmm20, %zmm24, %zmm23
+	vbroadcastsd	56+5*64(%r10), %zmm24
+	vfnmadd231pd	%zmm5, %zmm24, %zmm7
+	vfnmadd231pd	%zmm13, %zmm24, %zmm15
+	vfnmadd231pd	%zmm21, %zmm24, %zmm23
+	vbroadcastsd	56+6*64(%r10), %zmm24
+	vfnmadd231pd	%zmm6, %zmm24, %zmm7
+	vfnmadd231pd	%zmm14, %zmm24, %zmm15
+	vfnmadd231pd	%zmm22, %zmm24, %zmm23
+	vbroadcastsd	56(%r11), %zmm24
+	vmulpd			%zmm7, %zmm24, %zmm7
+	vmulpd			%zmm15, %zmm24, %zmm15
+	vmulpd			%zmm23, %zmm24, %zmm23
+
+0:
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_edge_dtrsm_rlt_inv_24x8_vs_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
 // scale for generic alpha and beta
 //
 // input arguments:
@@ -796,7 +1207,7 @@ NAME:
 // r13   <- 8*sdc*sizeof(double)
 // zmm0 <- []
 // ...
-// zmm15 <- []
+// zmm23 <- []
 //
 // output arguments:
 // r10   <- alpha
@@ -805,7 +1216,7 @@ NAME:
 // r13   <- 8*sdc*sizeof(double)
 // zmm0 <- []
 // ...
-// zmm15 <- []
+// zmm23 <- []
 
 #if MACRO_LEVEL>=1
 	.macro INNER_SCALE_AB_24X8_LIB8
@@ -927,7 +1338,7 @@ NAME:
 // r14   <- n1
 // zmm0 <- []
 // ...
-// zmm15 <- []
+// zmm23 <- []
 //
 // output arguments:
 // r10   <- alpha
@@ -937,7 +1348,7 @@ NAME:
 // r14   <- n1
 // zmm0 <- []
 // ...
-// zmm15 <- []
+// zmm23 <- []
 
 #if MACRO_LEVEL>=1
 	.macro INNER_SCALE_AB_24X8_VS_LIB8
@@ -1060,6 +1471,410 @@ NAME:
 
 // common inner routine with file scope
 //
+// scale for alpha = -1.0 and beta
+//
+// input arguments:
+// r10   <- beta
+// r11   <- C
+// r12   <- sdc
+// zmm0 <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+// r10   <- beta
+// r11   <- C
+// r12   <- sdc
+// zmm0 <- []
+// ...
+// zmm23 <- []
+
+#if MACRO_LEVEL>=1
+	.macro INNER_SCALE_M1B_24X8_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_scale_m1b_24x8_lib8)
+#endif	
+	
+	// beta
+	vbroadcastsd	0(%r10), %zmm24
+
+	vxorpd		%zmm25, %zmm25, %zmm25 // 0.0
+
+	vucomisd	%xmm25, %xmm24 // beta==0.0 ?
+	je			0f // end
+
+	vmovapd		0(%r11), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm0
+	vmovapd		1*64(%r11), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm1
+	vmovapd		2*64(%r11), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm2
+	vmovapd		3*64(%r11), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm3
+	vmovapd		4*64(%r11), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm4
+	vmovapd		5*64(%r11), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm5
+	vmovapd		6*64(%r11), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm6
+	vmovapd		7*64(%r11), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm7
+
+	vmovapd		0(%r11, %r12), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm8
+	vmovapd		1*64(%r11, %r12), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm9
+	vmovapd		2*64(%r11, %r12), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm10
+	vmovapd		3*64(%r11, %r12), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm11
+	vmovapd		4*64(%r11, %r12), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm12
+	vmovapd		5*64(%r11, %r12), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm13
+	vmovapd		6*64(%r11, %r12), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm14
+	vmovapd		7*64(%r11, %r12), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm15
+
+	vmovapd		0(%r11, %r12, 2), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm16
+	vmovapd		1*64(%r11, %r12, 2), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm17
+	vmovapd		2*64(%r11, %r12, 2), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm18
+	vmovapd		3*64(%r11, %r12, 2), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm19
+	vmovapd		4*64(%r11, %r12, 2), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm20
+	vmovapd		5*64(%r11, %r12, 2), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm21
+	vmovapd		6*64(%r11, %r12, 2), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm22
+	vmovapd		7*64(%r11, %r12, 2), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm23
+
+0:
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_scale_m1b_24x8_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// scale for alpha = -1.0 and beta
+//
+// input arguments:
+// r10   <- beta
+// r11   <- C
+// r12   <- sdc
+// r13d  <- n1
+// zmm0 <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+// r10   <- beta
+// r11   <- C
+// r13d  <- n1
+// r12   <- sdc
+// zmm0 <- []
+// ...
+// zmm23 <- []
+
+#if MACRO_LEVEL>=1
+	.macro INNER_SCALE_M1B_24X8_VS_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_scale_m1b_24x8_vs_lib8)
+#endif	
+	
+	// beta
+	vbroadcastsd	0(%r10), %zmm24
+
+	vxorpd		%zmm25, %zmm25, %zmm25 // 0.0
+
+	vucomisd	%xmm25, %xmm24 // beta==0.0 ?
+	je			0f // end
+
+	vmovapd		0(%r11), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm0
+	vmovapd		0(%r11, %r12), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm8
+	vmovapd		0(%r11, %r12, 2), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm16
+	cmpl	$ 2, %r13d
+	jl		0f // end
+	vmovapd		1*64(%r11), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm1
+	vmovapd		1*64(%r11, %r12), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm9
+	vmovapd		1*64(%r11, %r12, 2), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm17
+	cmpl	$ 3, %r13d
+	jl		0f // end
+	vmovapd		2*64(%r11), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm2
+	vmovapd		2*64(%r11, %r12), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm10
+	vmovapd		2*64(%r11, %r12, 2), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm18
+	cmpl	$ 4, %r13d
+	jl		0f // end
+	vmovapd		3*64(%r11), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm3
+	vmovapd		3*64(%r11, %r12), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm11
+	vmovapd		3*64(%r11, %r12, 2), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm19
+	cmpl	$ 5, %r13d
+	jl		0f // end
+	vmovapd		4*64(%r11), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm4
+	vmovapd		4*64(%r11, %r12), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm12
+	vmovapd		4*64(%r11, %r12, 2), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm20
+	cmpl	$ 6, %r13d
+	jl		0f // end
+	vmovapd		5*64(%r11), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm5
+	vmovapd		5*64(%r11, %r12), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm13
+	vmovapd		5*64(%r11, %r12, 2), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm21
+	cmpl	$ 7, %r13d
+	jl		0f // end
+	vmovapd		6*64(%r11), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm6
+	vmovapd		6*64(%r11, %r12), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm14
+	vmovapd		6*64(%r11, %r12, 2), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm22
+	je		0f // end
+	vmovapd		7*64(%r11), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm7
+	vmovapd		7*64(%r11, %r12), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm15
+	vmovapd		7*64(%r11, %r12, 2), %zmm25
+	vfmsub231pd	%zmm24, %zmm25, %zmm23
+
+0:
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_scale_m1b_24x8_vs_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// scale for alpha = -1.0 and beta=1.0
+//
+// input arguments:
+// r10   <- C
+// r11   <- sdc
+// zmm0 <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+// r10   <- C
+// r11   <- sdc
+// zmm0 <- []
+// ...
+// zmm23 <- []
+
+#if MACRO_LEVEL>=1
+	.macro INNER_SCALE_M11_24X8_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_scale_m11_24x8_lib8)
+#endif	
+	
+	vmovapd		0(%r10), %zmm24
+	vsubpd		%zmm0, %zmm24, %zmm0
+	vmovapd		1*64(%r10), %zmm24
+	vsubpd		%zmm1, %zmm24, %zmm1
+	vmovapd		2*64(%r10), %zmm24
+	vsubpd		%zmm2, %zmm24, %zmm2
+	vmovapd		3*64(%r10), %zmm24
+	vsubpd		%zmm3, %zmm24, %zmm3
+	vmovapd		4*64(%r10), %zmm24
+	vsubpd		%zmm4, %zmm24, %zmm4
+	vmovapd		5*64(%r10), %zmm24
+	vsubpd		%zmm5, %zmm24, %zmm5
+	vmovapd		6*64(%r10), %zmm24
+	vsubpd		%zmm6, %zmm24, %zmm6
+	vmovapd		7*64(%r10), %zmm24
+	vsubpd		%zmm7, %zmm24, %zmm7
+
+	vmovapd		0(%r10, %r11), %zmm24
+	vsubpd		%zmm8, %zmm24, %zmm8
+	vmovapd		1*64(%r10, %r11), %zmm24
+	vsubpd		%zmm9, %zmm24, %zmm9
+	vmovapd		2*64(%r10, %r11), %zmm24
+	vsubpd		%zmm10, %zmm24, %zmm10
+	vmovapd		3*64(%r10, %r11), %zmm24
+	vsubpd		%zmm11, %zmm24, %zmm11
+	vmovapd		4*64(%r10, %r11), %zmm24
+	vsubpd		%zmm12, %zmm24, %zmm12
+	vmovapd		5*64(%r10, %r11), %zmm24
+	vsubpd		%zmm13, %zmm24, %zmm13
+	vmovapd		6*64(%r10, %r11), %zmm24
+	vsubpd		%zmm14, %zmm24, %zmm14
+	vmovapd		7*64(%r10, %r11), %zmm24
+	vsubpd		%zmm15, %zmm24, %zmm15
+
+	vmovapd		0(%r10, %r11, 2), %zmm24
+	vsubpd		%zmm8, %zmm24, %zmm16
+	vmovapd		1*64(%r10, %r11, 2), %zmm24
+	vsubpd		%zmm9, %zmm24, %zmm17
+	vmovapd		2*64(%r10, %r11, 2), %zmm24
+	vsubpd		%zmm10, %zmm24, %zmm18
+	vmovapd		3*64(%r10, %r11, 2), %zmm24
+	vsubpd		%zmm11, %zmm24, %zmm19
+	vmovapd		4*64(%r10, %r11, 2), %zmm24
+	vsubpd		%zmm12, %zmm24, %zmm20
+	vmovapd		5*64(%r10, %r11, 2), %zmm24
+	vsubpd		%zmm13, %zmm24, %zmm21
+	vmovapd		6*64(%r10, %r11, 2), %zmm24
+	vsubpd		%zmm14, %zmm24, %zmm22
+	vmovapd		7*64(%r10, %r11, 2), %zmm24
+	vsubpd		%zmm15, %zmm24, %zmm23
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_scale_m11_24x8_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// scale for alpha = -1.0 and beta=1.0
+//
+// input arguments:
+// r10   <- C
+// r11   <- sdc
+// r12   <- n1
+// zmm0 <- []
+// ...
+// zmm23 <- []
+//
+// output arguments:
+// r10   <- C
+// r11   <- sdc
+// r12   <- n1
+// zmm0 <- []
+// ...
+// zmm23 <- []
+
+#if MACRO_LEVEL>=1
+	.macro INNER_SCALE_M11_24X8_VS_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_scale_m11_24x8_vs_lib8)
+#endif	
+	
+	vmovapd		0(%r10), %zmm24
+	vsubpd		%zmm0, %zmm24, %zmm0
+	vmovapd		0(%r10, %r11), %zmm24
+	vsubpd		%zmm8, %zmm24, %zmm8
+	vmovapd		0(%r10, %r11, 2), %zmm24
+	vsubpd		%zmm8, %zmm24, %zmm16
+	cmpl	$ 2, %r12d
+	jl		0f // end
+	vmovapd		1*64(%r10), %zmm24
+	vsubpd		%zmm1, %zmm24, %zmm1
+	vmovapd		1*64(%r10, %r11), %zmm24
+	vsubpd		%zmm9, %zmm24, %zmm9
+	vmovapd		1*64(%r10, %r11, 2), %zmm24
+	vsubpd		%zmm9, %zmm24, %zmm17
+	cmpl	$ 3, %r12d
+	jl		0f // end
+	vmovapd		2*64(%r10), %zmm24
+	vsubpd		%zmm2, %zmm24, %zmm2
+	vmovapd		2*64(%r10, %r11), %zmm24
+	vsubpd		%zmm10, %zmm24, %zmm10
+	vmovapd		2*64(%r10, %r11, 2), %zmm24
+	vsubpd		%zmm10, %zmm24, %zmm18
+	cmpl	$ 4, %r12d
+	jl		0f // end
+	vmovapd		3*64(%r10), %zmm24
+	vsubpd		%zmm3, %zmm24, %zmm3
+	vmovapd		3*64(%r10, %r11), %zmm24
+	vsubpd		%zmm11, %zmm24, %zmm11
+	vmovapd		3*64(%r10, %r11, 2), %zmm24
+	vsubpd		%zmm11, %zmm24, %zmm19
+	cmpl	$ 5, %r12d
+	jl		0f // end
+	vmovapd		4*64(%r10), %zmm24
+	vsubpd		%zmm4, %zmm24, %zmm4
+	vmovapd		4*64(%r10, %r11), %zmm24
+	vsubpd		%zmm12, %zmm24, %zmm12
+	vmovapd		4*64(%r10, %r11, 2), %zmm24
+	vsubpd		%zmm12, %zmm24, %zmm20
+	cmpl	$ 6, %r12d
+	jl		0f // end
+	vmovapd		5*64(%r10), %zmm24
+	vsubpd		%zmm5, %zmm24, %zmm5
+	vmovapd		5*64(%r10, %r11), %zmm24
+	vsubpd		%zmm13, %zmm24, %zmm13
+	vmovapd		5*64(%r10, %r11, 2), %zmm24
+	vsubpd		%zmm13, %zmm24, %zmm21
+	cmpl	$ 7, %r12d
+	jl		0f // end
+	vmovapd		6*64(%r10), %zmm24
+	vsubpd		%zmm6, %zmm24, %zmm6
+	vmovapd		6*64(%r10, %r11), %zmm24
+	vsubpd		%zmm14, %zmm24, %zmm14
+	vmovapd		6*64(%r10, %r11, 2), %zmm24
+	vsubpd		%zmm14, %zmm24, %zmm22
+	je		0f // end
+	vmovapd		7*64(%r10), %zmm24
+	vsubpd		%zmm7, %zmm24, %zmm7
+	vmovapd		7*64(%r10, %r11), %zmm24
+	vsubpd		%zmm15, %zmm24, %zmm15
+	vmovapd		7*64(%r10, %r11, 2), %zmm24
+	vsubpd		%zmm15, %zmm24, %zmm23
+
+0:
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_scale_m11_24x8_vs_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
 // store n
 //
 // input arguments:
@@ -1067,14 +1882,14 @@ NAME:
 // r11  <- 8*sdd*sizeof(double)
 // zmm0 <- []
 // ...
-// zmm15 <- []
+// zmm23 <- []
 //
 // output arguments:
 // r10  <- D
 // r11  <- 8*sdd*sizeof(double)
 // zmm0 <- []
 // ...
-// zmm15 <- []
+// zmm23 <- []
 
 #if MACRO_LEVEL>=1
 	.macro INNER_STORE_24X8_LIB8
@@ -1133,7 +1948,7 @@ NAME:
 // r13  <- n1
 // zmm0 <- []
 // ...
-// zmm15 <- []
+// zmm23 <- []
 //
 // output arguments:
 // r10  <- D
@@ -1142,7 +1957,7 @@ NAME:
 // r13  <- n1
 // zmm0 <- []
 // ...
-// zmm15 <- []
+// zmm23 <- []
 
 #if MACRO_LEVEL>=1
 	.macro INNER_STORE_24X8_VS_LIB8
@@ -1345,6 +2160,358 @@ NAME:
 	ret
 
 	FUN_END(kernel_dgemm_nt_24x8_vs_lib8)
+
+
+
+
+
+//                                       1      2          3        4          5             6          7        8          9        10         11
+// void kernel_dtrsm_nt_rl_inv_24x8_lib8(int k, double *A, int sda, double *B, double *beta, double *C, int sdc, double *D, int sdd, double *E, double *inv_diag_E);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dtrsm_nt_rl_inv_24x8_lib8)
+	
+	PROLOGUE
+
+	// zero accumulation registers
+
+	ZERO_ACC
+
+
+	// call inner dgemm kernel nt
+
+	movq	ARG1, %r10 // kmax
+	movq	ARG2, %r11 // A
+	movq	ARG3, %r12 // sda
+	sall	$ 6, %r12d // 4*sda*sizeof(double)
+	movq	ARG4, %r13 // B
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_24X8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_24x8_lib8)
+#endif
+
+
+	// call inner blender nn
+
+	movq	ARG5, %r10 // beta
+	movq	ARG6, %r11 // C
+	movq	ARG7, %r12 // sdc
+	sall	$ 6, %r12d // 4*sdc*sizeof(double)
+
+#if MACRO_LEVEL>=1
+	INNER_SCALE_M1B_24X8_LIB8
+#else
+	CALL(inner_scale_m1b_24x8_lib8)
+#endif
+
+
+	// solve
+
+	movq	ARG10, %r10  // E 
+	movq	ARG11, %r11  // inv_diag_E 
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DTRSM_RLT_INV_24X8_LIB8
+#else
+	CALL(inner_edge_dtrsm_rlt_inv_24x8_lib8)
+#endif
+
+
+	// store n
+
+	movq	ARG8, %r10 // store address D
+	movq	ARG9, %r11 // sdd
+	sall	$ 6, %r11d // 4*sdd*sizeof(double)
+
+#if MACRO_LEVEL>=1
+	INNER_STORE_24X8_LIB8
+#else
+	CALL(inner_store_24x8_lib8)
+#endif
+
+
+	EPILOGUE
+	
+	ret
+
+	FUN_END(kernel_dtrsm_nt_rl_inv_24x8_lib8)
+
+
+
+
+
+//                                          1      2          3        4          5             6          7        8          9        10         11                  12      13
+// void kernel_dtrsm_nt_rl_inv_24x8_vs_lib8(int k, double *A, int sda, double *B, double *beta, double *C, int sdc, double *D, int sdd, double *E, double *inv_diag_E, int m1, int n1);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dtrsm_nt_rl_inv_24x8_vs_lib8)
+	
+	PROLOGUE
+
+	// zero accumulation registers
+
+	ZERO_ACC
+
+
+	// call inner dgemm kernel nt
+
+	movq	ARG1, %r10 // kmax
+	movq	ARG2, %r11 // A
+	movq	ARG3, %r12 // sda
+	sall	$ 6, %r12d // 4*sda*sizeof(double)
+	movq	ARG4, %r13 // B
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_24X8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_24x8_lib8)
+#endif
+
+
+	// call inner blender nn
+
+	movq	ARG5, %r10 // beta
+	movq	ARG6, %r11 // C
+	movq	ARG7, %r12 // sdc
+	sall	$ 6, %r12d // 4*sdc*sizeof(double)
+	movq	ARG13, %r13 // n1
+
+#if MACRO_LEVEL>=1
+	INNER_SCALE_M1B_24X8_VS_LIB8
+#else
+	CALL(inner_scale_m1b_24x8_vs_lib8)
+#endif
+
+
+	// solve
+
+	movq	ARG10, %r10  // E 
+	movq	ARG11, %r11  // inv_diag_E 
+	movq	ARG13, %r12 // n1
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DTRSM_RLT_INV_24X8_VS_LIB8
+#else
+	CALL(inner_edge_dtrsm_rlt_inv_24x8_vs_lib8)
+#endif
+
+
+	// store n
+
+	movq	ARG8, %r10 // store address D
+	movq	ARG9, %r11 // sdd
+	sall	$ 6, %r11d // 4*sdd*sizeof(double)
+	movq	ARG12, %r12 // m1
+	movq	ARG13, %r13 // n1
+
+#if MACRO_LEVEL>=1
+	INNER_STORE_24X8_VS_LIB8
+#else
+	CALL(inner_store_24x8_vs_lib8)
+#endif
+
+
+	EPILOGUE
+	
+	ret
+
+	FUN_END(kernel_dtrsm_nt_rl_inv_24x8_vs_lib8)
+
+
+
+
+
+//                                             1       2           3         4           5       6           7         8           9          10       11         12       13         14
+// void kernel_dgemm_dtrsm_nt_rl_inv_24x8_lib8(int kp, double *Ap, int sdap, double *Bp, int km, double *Am, int sdam, double *Bm, double *C, int sdc, double *D, int sdd, double *E, double *inv_diag_E);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dgemm_dtrsm_nt_rl_inv_24x8_lib8)
+	
+	PROLOGUE
+
+	// zero accumulation registers
+
+	ZERO_ACC
+
+
+	// call inner dgemm kernel nt add
+
+	movq	ARG1, %r10 // kp
+	movq	ARG2, %r11  // Ap
+	movq	ARG3, %r12 // sdap
+	sall	$ 6, %r12d   // 4*sdap*sizeof(double)
+	movq	ARG4, %r13  // Bp
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_24X8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_24x8_lib8)
+#endif
+
+
+	// change sign
+	NEG_ACC
+
+
+	// call inner dgemm kernel nt sub
+
+	movq	ARG5, %r10 // km
+	movq	ARG6, %r11 // Am
+	movq	ARG7, %r12 // sdam
+	sall	$ 6, %r12d // 4*sda*sizeof(double)
+	movq	ARG8, %r13  // Bm
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_24X8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_24x8_lib8)
+#endif
+
+
+	// call inner blender nn
+
+	movq	ARG9, %r10  // C
+	movq	ARG10, %r11 // sdc
+	sall	$ 6, %r11d // 4*sdc*sizeof(double)
+
+#if MACRO_LEVEL>=1
+	INNER_SCALE_M11_24X8_LIB8
+#else
+	CALL(inner_scale_m11_24x8_lib8)
+#endif
+
+
+	// solve
+
+	movq	ARG13, %r10  // E 
+	movq	ARG14, %r11  // inv_diag_E 
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DTRSM_RLT_INV_24X8_LIB8
+#else
+	CALL(inner_edge_dtrsm_rlt_inv_24x8_lib8)
+#endif
+
+
+	// store n
+
+	movq	ARG11, %r10 // store address D
+	movq	ARG12, %r11 // sdd
+	sall	$ 6, %r11d // 4*sdd*sizeof(double)
+
+#if MACRO_LEVEL>=1
+	INNER_STORE_24X8_LIB8
+#else
+	CALL(inner_store_24x8_lib8)
+#endif
+
+
+	EPILOGUE
+	
+	ret
+
+	FUN_END(kernel_dgemm_dtrsm_nt_rl_inv_24x8_lib8)
+
+
+
+
+
+//                                                1       2           3         4           5       6           7         8           9          10       11         12       13         14                  15      16
+// void kernel_dgemm_dtrsm_nt_rl_inv_24x8_vs_lib8(int kp, double *Ap, int sdap, double *Bp, int km, double *Am, int sdam, double *Bm, double *C, int sdc, double *D, int sdd, double *E, double *inv_diag_E, int m1, int n1);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dgemm_dtrsm_nt_rl_inv_24x8_vs_lib8)
+	
+	PROLOGUE
+
+	// zero accumulation registers
+
+	ZERO_ACC
+
+
+	// call inner dgemm kernel nt add
+
+	movq	ARG1, %r10 // kp
+	movq	ARG2, %r11  // Ap
+	movq	ARG3, %r12 // sdap
+	sall	$ 6, %r12d   // 4*sdap*sizeof(double)
+	movq	ARG4, %r13  // Bp
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_24X8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_24x8_lib8)
+#endif
+
+
+	// change sign
+	NEG_ACC
+
+
+	// call inner dgemm kernel nt sub
+
+	movq	ARG5, %r10 // km
+	movq	ARG6, %r11 // Am
+	movq	ARG7, %r12 // sdam
+	sall	$ 6, %r12d // 4*sda*sizeof(double)
+	movq	ARG8, %r13  // Bm
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_24X8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_24x8_lib8)
+#endif
+
+
+	// call inner blender nn
+
+	movq	ARG9, %r10  // C
+	movq	ARG10, %r11 // sdc
+	sall	$ 6, %r11d // 4*sdc*sizeof(double)
+	movq	ARG16, %r12 // n1
+
+#if MACRO_LEVEL>=1
+	INNER_SCALE_M11_24X8_VS_LIB8
+#else
+	CALL(inner_scale_m11_24x8_vs_lib8)
+#endif
+
+
+	// solve
+
+	movq	ARG13, %r10  // E 
+	movq	ARG14, %r11  // inv_diag_E 
+	movq	ARG16, %r12 // n1
+
+#if MACRO_LEVEL>=1
+	INNER_EDGE_DTRSM_RLT_INV_24X8_VS_LIB8
+#else
+	CALL(inner_edge_dtrsm_rlt_inv_24x8_vs_lib8)
+#endif
+
+
+	// store n
+
+	movq	ARG11, %r10 // store address D
+	movq	ARG12, %r11 // sdd
+	sall	$ 6, %r11d // 4*sdd*sizeof(double)
+	movq	ARG15, %r12 // m1
+	movq	ARG16, %r13 // n1
+
+#if MACRO_LEVEL>=1
+	INNER_STORE_24X8_VS_LIB8
+#else
+	CALL(inner_store_24x8_vs_lib8)
+#endif
+
+
+	EPILOGUE
+	
+	ret
+
+	FUN_END(kernel_dgemm_dtrsm_nt_rl_inv_24x8_vs_lib8)
 
 
 

--- a/kernel/avx512/kernel_dgemm_24x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_24x8_lib8.S
@@ -4293,7 +4293,7 @@ NAME:
 	vbroadcastsd	0(%r11), %zmm24
 	vmulpd			%zmm0, %zmm24, %zmm0
 	vmulpd			%zmm8, %zmm24, %zmm8
-	vmulpd			%zmm26, %zmm24, %zmm26
+	vmulpd			%zmm16, %zmm24, %zmm16
 
 	cmpl			$ 2, %r12d
 	jl				0f // ret
@@ -4987,13 +4987,6 @@ NAME:
 	FUN_START(inner_edge_dpotrf_24x8_vs_lib8)
 #endif
 
-	vxorpd	%ymm25, %ymm25, %ymm25 // 0.0
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vmovsd	.LC04(%rip), %xmm24 // 1.0
-#elif defined(OS_MAC)
-	vmovsd	LC04(%rip), %xmm24 // 1.0
-#endif
-
 	// compute mask for rows
 	vcvtsi2sd	%r11d, %xmm25, %xmm25
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -5013,6 +5006,13 @@ NAME:
 	vmovapd		%zmm21, %zmm21 {%k1}{z}
 	vmovapd		%zmm22, %zmm22 {%k1}{z}
 	vmovapd		%zmm23, %zmm23 {%k1}{z}
+
+	vxorpd	%ymm25, %ymm25, %ymm25 // 0.0
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovsd	.LC04(%rip), %xmm24 // 1.0
+#elif defined(OS_MAC)
+	vmovsd	LC04(%rip), %xmm24 // 1.0
+#endif
 
 	// 0
 	vmovsd			%xmm0, %xmm0, %xmm26

--- a/kernel/avx512/kernel_dgemm_24x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_24x8_lib8.S
@@ -1242,15 +1242,8 @@ NAME:
 	vmulpd			%zmm16, %zmm26, %zmm16
 	cmpl			$ 2, %r11d
 	jl				0f // ret
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+1*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+1*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm0, %zmm27, %zmm27
-	vfnmadd231pd	%zmm0, %zmm27, %zmm1
-	vfnmadd231pd	%zmm8, %zmm27, %zmm9
-	vfnmadd231pd	%zmm16, %zmm27, %zmm17
+	vmovapd			%zmm1, %zmm26
+	vfnmadd231pd	%zmm0, %zmm0, %zmm26
 
 	// 1
 //	vpermilpd		$ 0x3, %xmm1, %xmm26
@@ -1259,12 +1252,21 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+1*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm1, %zmm27, %zmm26
+	vpermpd			%zmm26, %zmm27, %zmm26
 	vucomisd		%xmm25, %xmm26 // d_11 > 0.0 ?
 	jbe				3f
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 4:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm1
+	vfnmadd231pd	%zmm8, %zmm27, %zmm9
+	vfnmadd231pd	%zmm16, %zmm27, %zmm17
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
 	vbroadcastsd	.LC05+2*8(%rip), %zmm27
 #elif defined(OS_MAC)
@@ -1326,15 +1328,8 @@ NAME:
 	vmulpd			%zmm17, %zmm26, %zmm17
 	cmpl			$ 3, %r11d
 	jl				0f // ret
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+2*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+2*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm1, %zmm27, %zmm27
-	vfnmadd231pd	%zmm1, %zmm27, %zmm2
-	vfnmadd231pd	%zmm9, %zmm27, %zmm10
-	vfnmadd231pd	%zmm17, %zmm27, %zmm18
+	vmovapd			%zmm2, %zmm26
+	vfnmadd231pd	%zmm1, %zmm1, %zmm26
 
 	// 2
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -1342,12 +1337,21 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+2*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm2, %zmm27, %zmm26
+	vpermpd			%zmm26, %zmm27, %zmm26
 	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
 	jbe				5f
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 6:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm2
+	vfnmadd231pd	%zmm9, %zmm27, %zmm10
+	vfnmadd231pd	%zmm17, %zmm27, %zmm18
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
 	vbroadcastsd	.LC05+3*8(%rip), %zmm27
 #elif defined(OS_MAC)
@@ -1400,15 +1404,8 @@ NAME:
 	vmulpd			%zmm18, %zmm26, %zmm18
 	cmpl			$ 4, %r11d
 	jl				0f // ret
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+3*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+3*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm2, %zmm27, %zmm27
-	vfnmadd231pd	%zmm2, %zmm27, %zmm3
-	vfnmadd231pd	%zmm10, %zmm27, %zmm11
-	vfnmadd231pd	%zmm18, %zmm27, %zmm19
+	vmovapd			%zmm3, %zmm26
+	vfnmadd231pd	%zmm2, %zmm2, %zmm26
 
 	// 3
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -1416,12 +1413,21 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+3*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm3, %zmm27, %zmm26
+	vpermpd			%zmm26, %zmm27, %zmm26
 	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
 	jbe				7f
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 8:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm27
+	vfnmadd231pd	%zmm2, %zmm27, %zmm3
+	vfnmadd231pd	%zmm10, %zmm27, %zmm11
+	vfnmadd231pd	%zmm18, %zmm27, %zmm19
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
 	vbroadcastsd	.LC05+4*8(%rip), %zmm27
 #elif defined(OS_MAC)
@@ -1465,15 +1471,8 @@ NAME:
 	vmulpd			%zmm19, %zmm26, %zmm19
 	cmpl			$ 5, %r11d
 	jl				0f // ret
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+4*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+4*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm3, %zmm27, %zmm27
-	vfnmadd231pd	%zmm3, %zmm27, %zmm4
-	vfnmadd231pd	%zmm11, %zmm27, %zmm12
-	vfnmadd231pd	%zmm19, %zmm27, %zmm20
+	vmovapd			%zmm4, %zmm26
+	vfnmadd231pd	%zmm3, %zmm3, %zmm26
 
 	// 4
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -1481,12 +1480,21 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+4*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm4, %zmm27, %zmm26
+	vpermpd			%zmm26, %zmm27, %zmm26
 	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
 	jbe				9f
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 10:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm3, %zmm27, %zmm27
+	vfnmadd231pd	%zmm3, %zmm27, %zmm4
+	vfnmadd231pd	%zmm11, %zmm27, %zmm12
+	vfnmadd231pd	%zmm19, %zmm27, %zmm20
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
 	vbroadcastsd	.LC05+5*8(%rip), %zmm27
 #elif defined(OS_MAC)
@@ -1521,15 +1529,8 @@ NAME:
 	vmulpd			%zmm20, %zmm26, %zmm20
 	cmpl			$ 6, %r11d
 	jl				0f // ret
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+5*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+5*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm4, %zmm27, %zmm27
-	vfnmadd231pd	%zmm4, %zmm27, %zmm5
-	vfnmadd231pd	%zmm12, %zmm27, %zmm13
-	vfnmadd231pd	%zmm20, %zmm27, %zmm21
+	vmovapd			%zmm5, %zmm26
+	vfnmadd231pd	%zmm4, %zmm4, %zmm26
 
 	// 5
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -1537,12 +1538,21 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+5*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm5, %zmm27, %zmm26
+	vpermpd			%zmm26, %zmm27, %zmm26
 	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
 	jbe				11f
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 12:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm4, %zmm27, %zmm27
+	vfnmadd231pd	%zmm4, %zmm27, %zmm5
+	vfnmadd231pd	%zmm12, %zmm27, %zmm13
+	vfnmadd231pd	%zmm20, %zmm27, %zmm21
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
 	vbroadcastsd	.LC05+6*8(%rip), %zmm27
 #elif defined(OS_MAC)
@@ -1568,15 +1578,8 @@ NAME:
 	vmulpd			%zmm21, %zmm26, %zmm21
 	cmpl			$ 7, %r11d
 	jl				0f // ret
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+6*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+6*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm5, %zmm27, %zmm27
-	vfnmadd231pd	%zmm5, %zmm27, %zmm6
-	vfnmadd231pd	%zmm13, %zmm27, %zmm14
-	vfnmadd231pd	%zmm21, %zmm27, %zmm22
+	vmovapd			%zmm6, %zmm26
+	vfnmadd231pd	%zmm5, %zmm5, %zmm26
 
 	// 6
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -1584,12 +1587,21 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+6*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm6, %zmm27, %zmm26
+	vpermpd			%zmm26, %zmm27, %zmm26
 	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
 	jbe				13f
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 14:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm5, %zmm27, %zmm27
+	vfnmadd231pd	%zmm5, %zmm27, %zmm6
+	vfnmadd231pd	%zmm13, %zmm27, %zmm14
+	vfnmadd231pd	%zmm21, %zmm27, %zmm22
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
 	vbroadcastsd	.LC05+7*8(%rip), %zmm27
 #elif defined(OS_MAC)
@@ -1606,15 +1618,8 @@ NAME:
 	vmulpd			%zmm22, %zmm26, %zmm22
 	cmpl			$ 8, %r11d
 	jl				0f // ret
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+7*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+7*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm6, %zmm27, %zmm27
-	vfnmadd231pd	%zmm6, %zmm27, %zmm7
-	vfnmadd231pd	%zmm14, %zmm27, %zmm15
-	vfnmadd231pd	%zmm22, %zmm27, %zmm23
+	vmovapd			%zmm7, %zmm26
+	vfnmadd231pd	%zmm6, %zmm6, %zmm26
 
 	// 7
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -1622,12 +1627,21 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+7*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm7, %zmm27, %zmm26
+	vpermpd			%zmm26, %zmm27, %zmm26
 	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
 	jbe				15f
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 16:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm6, %zmm27, %zmm27
+	vfnmadd231pd	%zmm6, %zmm27, %zmm7
+	vfnmadd231pd	%zmm14, %zmm27, %zmm15
+	vfnmadd231pd	%zmm22, %zmm27, %zmm23
 	vmovsd			%xmm26, 56(%r10)
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm7, %zmm26, %zmm7

--- a/kernel/avx512/kernel_dgemm_24x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_24x8_lib8.S
@@ -787,6 +787,2991 @@ NAME:
 
 // common inner routine with file scope
 //
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B
+// zmm0  <- []
+// ...
+// zmm23  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// zmm0  <- []
+// ...
+// zmm23  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_3VX8_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_3vx8_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 // A0
+	vmovapd 		0(%r11, %r12), %zmm27 // A1
+	vmovapd 		0(%r11, %r12, 2), %zmm29 {%k1}{z} // A1
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			64(%r11, %r12), %zmm28 // A
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			64(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vfmadd231pd		%zmm29, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vfmadd231pd		%zmm29, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+	vfmadd231pd		%zmm29, %zmm24, %zmm22
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	vfmadd231pd		%zmm29, %zmm24, %zmm23
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+	vmovapd			128(%r11, %r12), %zmm27 // A
+	vbroadcastsd	16+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vfmadd231pd		%zmm30, %zmm24, %zmm18
+	vmovapd			128(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+	vbroadcastsd	24+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vfmadd231pd		%zmm30, %zmm24, %zmm19
+	vbroadcastsd	32+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vfmadd231pd		%zmm30, %zmm24, %zmm20
+	vbroadcastsd	40+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vfmadd231pd		%zmm30, %zmm24, %zmm21
+	vbroadcastsd	48+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+	vfmadd231pd		%zmm30, %zmm24, %zmm22
+	vbroadcastsd	56+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	vfmadd231pd		%zmm28, %zmm24, %zmm15
+	vfmadd231pd		%zmm30, %zmm24, %zmm23
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			192(%r11, %r12), %zmm28 // A
+	vbroadcastsd	16+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			192(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+	vbroadcastsd	24+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	vbroadcastsd	32+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vfmadd231pd		%zmm29, %zmm24, %zmm20
+	vbroadcastsd	40+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vfmadd231pd		%zmm29, %zmm24, %zmm21
+	vbroadcastsd	48+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+	vfmadd231pd		%zmm29, %zmm24, %zmm22
+	vbroadcastsd	56+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	vfmadd231pd		%zmm29, %zmm24, %zmm23
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+	vmovapd			0(%r11, %r12), %zmm27 // A
+	vbroadcastsd	16+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vfmadd231pd		%zmm30, %zmm24, %zmm18
+	vmovapd			0(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+	vbroadcastsd	24+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vfmadd231pd		%zmm30, %zmm24, %zmm19
+	vbroadcastsd	32+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vfmadd231pd		%zmm30, %zmm24, %zmm20
+	vbroadcastsd	40+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vfmadd231pd		%zmm30, %zmm24, %zmm21
+	vbroadcastsd	48+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+	vfmadd231pd		%zmm30, %zmm24, %zmm22
+	vbroadcastsd	56+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	vfmadd231pd		%zmm28, %zmm24, %zmm15
+	vfmadd231pd		%zmm30, %zmm24, %zmm23
+	addq	$ 256, %r13
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean4-up
+	
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			64(%r11, %r12), %zmm28 // A
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			64(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vfmadd231pd		%zmm29, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vfmadd231pd		%zmm29, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+	vfmadd231pd		%zmm29, %zmm24, %zmm22
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	vfmadd231pd		%zmm29, %zmm24, %zmm23
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+	vmovapd			128(%r11, %r12), %zmm27 // A
+	vbroadcastsd	16+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vfmadd231pd		%zmm30, %zmm24, %zmm18
+	vmovapd			128(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+	vbroadcastsd	24+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vfmadd231pd		%zmm30, %zmm24, %zmm19
+	vbroadcastsd	32+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vfmadd231pd		%zmm30, %zmm24, %zmm20
+	vbroadcastsd	40+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vfmadd231pd		%zmm30, %zmm24, %zmm21
+	vbroadcastsd	48+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+	vfmadd231pd		%zmm30, %zmm24, %zmm22
+	vbroadcastsd	56+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	vfmadd231pd		%zmm28, %zmm24, %zmm15
+	vfmadd231pd		%zmm30, %zmm24, %zmm23
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			192(%r11, %r12), %zmm28 // A
+	vbroadcastsd	16+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			192(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+	vbroadcastsd	24+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	vbroadcastsd	32+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vfmadd231pd		%zmm29, %zmm24, %zmm20
+	vbroadcastsd	40+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vfmadd231pd		%zmm29, %zmm24, %zmm21
+	vbroadcastsd	48+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+	vfmadd231pd		%zmm29, %zmm24, %zmm22
+	vbroadcastsd	56+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	vfmadd231pd		%zmm29, %zmm24, %zmm23
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+//	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+//	vmovapd			0(%r11, %r12), %zmm27 // A
+	vbroadcastsd	16+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vfmadd231pd		%zmm30, %zmm24, %zmm18
+//	vmovapd			0(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+	vbroadcastsd	24+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vfmadd231pd		%zmm30, %zmm24, %zmm19
+	vbroadcastsd	32+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vfmadd231pd		%zmm30, %zmm24, %zmm20
+	vbroadcastsd	40+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vfmadd231pd		%zmm30, %zmm24, %zmm21
+	vbroadcastsd	48+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+	vfmadd231pd		%zmm30, %zmm24, %zmm22
+	vbroadcastsd	56+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	vfmadd231pd		%zmm28, %zmm24, %zmm15
+	vfmadd231pd		%zmm30, %zmm24, %zmm23
+	addq	$ 256, %r13
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 // A
+	vmovapd			0(%r11, %r12), %zmm27 // A
+	vmovapd			0(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vfmadd231pd		%zmm29, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vfmadd231pd		%zmm29, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+	vfmadd231pd		%zmm29, %zmm24, %zmm22
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	vfmadd231pd		%zmm29, %zmm24, %zmm23
+
+	addq	$ 64, %r11
+	addq	$ 64, %r13
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_3vx8_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B
+// zmm0  <- []
+// ...
+// zmm23  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// zmm0  <- []
+// ...
+// zmm23  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_3VX7_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_3vx7_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 // A0
+	vmovapd 		0(%r11, %r12), %zmm27 // A1
+	vmovapd 		0(%r11, %r12, 2), %zmm29 {%k1}{z} // A1
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			64(%r11, %r12), %zmm28 // A
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			64(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vfmadd231pd		%zmm29, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vfmadd231pd		%zmm29, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+	vfmadd231pd		%zmm29, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+//	vfmadd231pd		%zmm29, %zmm24, %zmm23
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+	vmovapd			128(%r11, %r12), %zmm27 // A
+	vbroadcastsd	16+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vfmadd231pd		%zmm30, %zmm24, %zmm18
+	vmovapd			128(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+	vbroadcastsd	24+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vfmadd231pd		%zmm30, %zmm24, %zmm19
+	vbroadcastsd	32+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vfmadd231pd		%zmm30, %zmm24, %zmm20
+	vbroadcastsd	40+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vfmadd231pd		%zmm30, %zmm24, %zmm21
+	vbroadcastsd	48+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+	vfmadd231pd		%zmm30, %zmm24, %zmm22
+//	vbroadcastsd	56+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+//	vfmadd231pd		%zmm30, %zmm24, %zmm23
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			192(%r11, %r12), %zmm28 // A
+	vbroadcastsd	16+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			192(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+	vbroadcastsd	24+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	vbroadcastsd	32+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vfmadd231pd		%zmm29, %zmm24, %zmm20
+	vbroadcastsd	40+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vfmadd231pd		%zmm29, %zmm24, %zmm21
+	vbroadcastsd	48+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+	vfmadd231pd		%zmm29, %zmm24, %zmm22
+//	vbroadcastsd	56+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+//	vfmadd231pd		%zmm29, %zmm24, %zmm23
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+	vmovapd			0(%r11, %r12), %zmm27 // A
+	vbroadcastsd	16+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vfmadd231pd		%zmm30, %zmm24, %zmm18
+	vmovapd			0(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+	vbroadcastsd	24+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vfmadd231pd		%zmm30, %zmm24, %zmm19
+	vbroadcastsd	32+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vfmadd231pd		%zmm30, %zmm24, %zmm20
+	vbroadcastsd	40+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vfmadd231pd		%zmm30, %zmm24, %zmm21
+	vbroadcastsd	48+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+	vfmadd231pd		%zmm30, %zmm24, %zmm22
+//	vbroadcastsd	56+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+//	vfmadd231pd		%zmm30, %zmm24, %zmm23
+	addq	$ 256, %r13
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean4-up
+	
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			64(%r11, %r12), %zmm28 // A
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			64(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vfmadd231pd		%zmm29, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vfmadd231pd		%zmm29, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+	vfmadd231pd		%zmm29, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+//	vfmadd231pd		%zmm29, %zmm24, %zmm23
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+	vmovapd			128(%r11, %r12), %zmm27 // A
+	vbroadcastsd	16+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vfmadd231pd		%zmm30, %zmm24, %zmm18
+	vmovapd			128(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+	vbroadcastsd	24+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vfmadd231pd		%zmm30, %zmm24, %zmm19
+	vbroadcastsd	32+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vfmadd231pd		%zmm30, %zmm24, %zmm20
+	vbroadcastsd	40+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vfmadd231pd		%zmm30, %zmm24, %zmm21
+	vbroadcastsd	48+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+	vfmadd231pd		%zmm30, %zmm24, %zmm22
+//	vbroadcastsd	56+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+//	vfmadd231pd		%zmm30, %zmm24, %zmm23
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			192(%r11, %r12), %zmm28 // A
+	vbroadcastsd	16+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			192(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+	vbroadcastsd	24+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	vbroadcastsd	32+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vfmadd231pd		%zmm29, %zmm24, %zmm20
+	vbroadcastsd	40+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vfmadd231pd		%zmm29, %zmm24, %zmm21
+	vbroadcastsd	48+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+	vfmadd231pd		%zmm29, %zmm24, %zmm22
+//	vbroadcastsd	56+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+//	vfmadd231pd		%zmm29, %zmm24, %zmm23
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+//	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+//	vmovapd			0(%r11, %r12), %zmm27 // A
+	vbroadcastsd	16+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vfmadd231pd		%zmm30, %zmm24, %zmm18
+//	vmovapd			0(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+	vbroadcastsd	24+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vfmadd231pd		%zmm30, %zmm24, %zmm19
+	vbroadcastsd	32+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vfmadd231pd		%zmm30, %zmm24, %zmm20
+	vbroadcastsd	40+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vfmadd231pd		%zmm30, %zmm24, %zmm21
+	vbroadcastsd	48+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+	vfmadd231pd		%zmm30, %zmm24, %zmm22
+//	vbroadcastsd	56+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+//	vfmadd231pd		%zmm30, %zmm24, %zmm23
+	addq	$ 256, %r13
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 // A
+	vmovapd			0(%r11, %r12), %zmm27 // A
+	vmovapd			0(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vfmadd231pd		%zmm29, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vfmadd231pd		%zmm29, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+	vfmadd231pd		%zmm29, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+//	vfmadd231pd		%zmm29, %zmm24, %zmm23
+
+	addq	$ 64, %r11
+	addq	$ 64, %r13
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_3vx7_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B
+// zmm0  <- []
+// ...
+// zmm23  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// zmm0  <- []
+// ...
+// zmm23  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_3VX6_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_3vx6_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 // A0
+	vmovapd 		0(%r11, %r12), %zmm27 // A1
+	vmovapd 		0(%r11, %r12, 2), %zmm29 {%k1}{z} // A1
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			64(%r11, %r12), %zmm28 // A
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			64(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vfmadd231pd		%zmm29, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vfmadd231pd		%zmm29, %zmm24, %zmm21
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vfmadd231pd		%zmm29, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+//	vfmadd231pd		%zmm29, %zmm24, %zmm23
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+	vmovapd			128(%r11, %r12), %zmm27 // A
+	vbroadcastsd	16+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vfmadd231pd		%zmm30, %zmm24, %zmm18
+	vmovapd			128(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+	vbroadcastsd	24+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vfmadd231pd		%zmm30, %zmm24, %zmm19
+	vbroadcastsd	32+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vfmadd231pd		%zmm30, %zmm24, %zmm20
+	vbroadcastsd	40+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vfmadd231pd		%zmm30, %zmm24, %zmm21
+//	vbroadcastsd	48+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vfmadd231pd		%zmm30, %zmm24, %zmm22
+//	vbroadcastsd	56+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+//	vfmadd231pd		%zmm30, %zmm24, %zmm23
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			192(%r11, %r12), %zmm28 // A
+	vbroadcastsd	16+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			192(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+	vbroadcastsd	24+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	vbroadcastsd	32+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vfmadd231pd		%zmm29, %zmm24, %zmm20
+	vbroadcastsd	40+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vfmadd231pd		%zmm29, %zmm24, %zmm21
+//	vbroadcastsd	48+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vfmadd231pd		%zmm29, %zmm24, %zmm22
+//	vbroadcastsd	56+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+//	vfmadd231pd		%zmm29, %zmm24, %zmm23
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+	vmovapd			0(%r11, %r12), %zmm27 // A
+	vbroadcastsd	16+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vfmadd231pd		%zmm30, %zmm24, %zmm18
+	vmovapd			0(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+	vbroadcastsd	24+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vfmadd231pd		%zmm30, %zmm24, %zmm19
+	vbroadcastsd	32+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vfmadd231pd		%zmm30, %zmm24, %zmm20
+	vbroadcastsd	40+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vfmadd231pd		%zmm30, %zmm24, %zmm21
+//	vbroadcastsd	48+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vfmadd231pd		%zmm30, %zmm24, %zmm22
+//	vbroadcastsd	56+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+//	vfmadd231pd		%zmm30, %zmm24, %zmm23
+	addq	$ 256, %r13
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean4-up
+	
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			64(%r11, %r12), %zmm28 // A
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			64(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vfmadd231pd		%zmm29, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vfmadd231pd		%zmm29, %zmm24, %zmm21
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vfmadd231pd		%zmm29, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+//	vfmadd231pd		%zmm29, %zmm24, %zmm23
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+	vmovapd			128(%r11, %r12), %zmm27 // A
+	vbroadcastsd	16+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vfmadd231pd		%zmm30, %zmm24, %zmm18
+	vmovapd			128(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+	vbroadcastsd	24+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vfmadd231pd		%zmm30, %zmm24, %zmm19
+	vbroadcastsd	32+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vfmadd231pd		%zmm30, %zmm24, %zmm20
+	vbroadcastsd	40+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vfmadd231pd		%zmm30, %zmm24, %zmm21
+//	vbroadcastsd	48+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vfmadd231pd		%zmm30, %zmm24, %zmm22
+//	vbroadcastsd	56+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+//	vfmadd231pd		%zmm30, %zmm24, %zmm23
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			192(%r11, %r12), %zmm28 // A
+	vbroadcastsd	16+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			192(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+	vbroadcastsd	24+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	vbroadcastsd	32+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vfmadd231pd		%zmm29, %zmm24, %zmm20
+	vbroadcastsd	40+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vfmadd231pd		%zmm29, %zmm24, %zmm21
+//	vbroadcastsd	48+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vfmadd231pd		%zmm29, %zmm24, %zmm22
+//	vbroadcastsd	56+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+//	vfmadd231pd		%zmm29, %zmm24, %zmm23
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+//	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+//	vmovapd			0(%r11, %r12), %zmm27 // A
+	vbroadcastsd	16+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vfmadd231pd		%zmm30, %zmm24, %zmm18
+//	vmovapd			0(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+	vbroadcastsd	24+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vfmadd231pd		%zmm30, %zmm24, %zmm19
+	vbroadcastsd	32+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vfmadd231pd		%zmm30, %zmm24, %zmm20
+	vbroadcastsd	40+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vfmadd231pd		%zmm30, %zmm24, %zmm21
+//	vbroadcastsd	48+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vfmadd231pd		%zmm30, %zmm24, %zmm22
+//	vbroadcastsd	56+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+//	vfmadd231pd		%zmm30, %zmm24, %zmm23
+	addq	$ 256, %r13
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 // A
+	vmovapd			0(%r11, %r12), %zmm27 // A
+	vmovapd			0(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vfmadd231pd		%zmm29, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vfmadd231pd		%zmm29, %zmm24, %zmm21
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vfmadd231pd		%zmm29, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+//	vfmadd231pd		%zmm29, %zmm24, %zmm23
+
+	addq	$ 64, %r11
+	addq	$ 64, %r13
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_3vx6_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B
+// zmm0  <- []
+// ...
+// zmm23  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// zmm0  <- []
+// ...
+// zmm23  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_3VX5_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_3vx5_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 // A0
+	vmovapd 		0(%r11, %r12), %zmm27 // A1
+	vmovapd 		0(%r11, %r12, 2), %zmm29 {%k1}{z} // A1
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			64(%r11, %r12), %zmm28 // A
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			64(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vfmadd231pd		%zmm29, %zmm24, %zmm20
+//	vbroadcastsd	40(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vfmadd231pd		%zmm29, %zmm24, %zmm21
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vfmadd231pd		%zmm29, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+//	vfmadd231pd		%zmm29, %zmm24, %zmm23
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+	vmovapd			128(%r11, %r12), %zmm27 // A
+	vbroadcastsd	16+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vfmadd231pd		%zmm30, %zmm24, %zmm18
+	vmovapd			128(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+	vbroadcastsd	24+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vfmadd231pd		%zmm30, %zmm24, %zmm19
+	vbroadcastsd	32+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vfmadd231pd		%zmm30, %zmm24, %zmm20
+//	vbroadcastsd	40+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vfmadd231pd		%zmm28, %zmm24, %zmm13
+//	vfmadd231pd		%zmm30, %zmm24, %zmm21
+//	vbroadcastsd	48+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vfmadd231pd		%zmm30, %zmm24, %zmm22
+//	vbroadcastsd	56+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+//	vfmadd231pd		%zmm30, %zmm24, %zmm23
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			192(%r11, %r12), %zmm28 // A
+	vbroadcastsd	16+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			192(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+	vbroadcastsd	24+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	vbroadcastsd	32+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vfmadd231pd		%zmm29, %zmm24, %zmm20
+//	vbroadcastsd	40+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vfmadd231pd		%zmm29, %zmm24, %zmm21
+//	vbroadcastsd	48+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vfmadd231pd		%zmm29, %zmm24, %zmm22
+//	vbroadcastsd	56+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+//	vfmadd231pd		%zmm29, %zmm24, %zmm23
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+	vmovapd			0(%r11, %r12), %zmm27 // A
+	vbroadcastsd	16+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vfmadd231pd		%zmm30, %zmm24, %zmm18
+	vmovapd			0(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+	vbroadcastsd	24+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vfmadd231pd		%zmm30, %zmm24, %zmm19
+	vbroadcastsd	32+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vfmadd231pd		%zmm30, %zmm24, %zmm20
+//	vbroadcastsd	40+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vfmadd231pd		%zmm28, %zmm24, %zmm13
+//	vfmadd231pd		%zmm30, %zmm24, %zmm21
+//	vbroadcastsd	48+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vfmadd231pd		%zmm30, %zmm24, %zmm22
+//	vbroadcastsd	56+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+//	vfmadd231pd		%zmm30, %zmm24, %zmm23
+	addq	$ 256, %r13
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean4-up
+	
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			64(%r11, %r12), %zmm28 // A
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			64(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vfmadd231pd		%zmm29, %zmm24, %zmm20
+//	vbroadcastsd	40(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vfmadd231pd		%zmm29, %zmm24, %zmm21
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vfmadd231pd		%zmm29, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+//	vfmadd231pd		%zmm29, %zmm24, %zmm23
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+	vmovapd			128(%r11, %r12), %zmm27 // A
+	vbroadcastsd	16+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vfmadd231pd		%zmm30, %zmm24, %zmm18
+	vmovapd			128(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+	vbroadcastsd	24+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vfmadd231pd		%zmm30, %zmm24, %zmm19
+	vbroadcastsd	32+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vfmadd231pd		%zmm30, %zmm24, %zmm20
+//	vbroadcastsd	40+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vfmadd231pd		%zmm28, %zmm24, %zmm13
+//	vfmadd231pd		%zmm30, %zmm24, %zmm21
+//	vbroadcastsd	48+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vfmadd231pd		%zmm30, %zmm24, %zmm22
+//	vbroadcastsd	56+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+//	vfmadd231pd		%zmm30, %zmm24, %zmm23
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			192(%r11, %r12), %zmm28 // A
+	vbroadcastsd	16+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			192(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+	vbroadcastsd	24+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	vbroadcastsd	32+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vfmadd231pd		%zmm29, %zmm24, %zmm20
+//	vbroadcastsd	40+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vfmadd231pd		%zmm29, %zmm24, %zmm21
+//	vbroadcastsd	48+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vfmadd231pd		%zmm29, %zmm24, %zmm22
+//	vbroadcastsd	56+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+//	vfmadd231pd		%zmm29, %zmm24, %zmm23
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+//	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+//	vmovapd			0(%r11, %r12), %zmm27 // A
+	vbroadcastsd	16+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vfmadd231pd		%zmm30, %zmm24, %zmm18
+//	vmovapd			0(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+	vbroadcastsd	24+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vfmadd231pd		%zmm30, %zmm24, %zmm19
+	vbroadcastsd	32+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vfmadd231pd		%zmm30, %zmm24, %zmm20
+//	vbroadcastsd	40+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vfmadd231pd		%zmm28, %zmm24, %zmm13
+//	vfmadd231pd		%zmm30, %zmm24, %zmm21
+//	vbroadcastsd	48+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vfmadd231pd		%zmm28, %zmm24, %zmm14
+//	vfmadd231pd		%zmm30, %zmm24, %zmm22
+//	vbroadcastsd	56+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+//	vfmadd231pd		%zmm28, %zmm24, %zmm15
+//	vfmadd231pd		%zmm30, %zmm24, %zmm23
+	addq	$ 256, %r13
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 // A
+	vmovapd			0(%r11, %r12), %zmm27 // A
+	vmovapd			0(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vfmadd231pd		%zmm29, %zmm24, %zmm20
+//	vbroadcastsd	40(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vfmadd231pd		%zmm27, %zmm24, %zmm13
+//	vfmadd231pd		%zmm29, %zmm24, %zmm21
+//	vbroadcastsd	48(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vfmadd231pd		%zmm27, %zmm24, %zmm14
+//	vfmadd231pd		%zmm29, %zmm24, %zmm22
+//	vbroadcastsd	56(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+//	vfmadd231pd		%zmm27, %zmm24, %zmm15
+//	vfmadd231pd		%zmm29, %zmm24, %zmm23
+
+	addq	$ 64, %r11
+	addq	$ 64, %r13
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_3vx5_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B
+// zmm0  <- []
+// ...
+// zmm23  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// zmm0  <- []
+// ...
+// zmm23  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_3VX4_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_3vx4_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 // A0
+	vmovapd 		0(%r11, %r12), %zmm27 // A1
+	vmovapd 		0(%r11, %r12, 2), %zmm29 {%k1}{z} // A1
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			64(%r11, %r12), %zmm28 // A
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			64(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+	vmovapd			128(%r11, %r12), %zmm27 // A
+	vbroadcastsd	16+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vfmadd231pd		%zmm30, %zmm24, %zmm18
+	vmovapd			128(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+	vbroadcastsd	24+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vfmadd231pd		%zmm30, %zmm24, %zmm19
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			192(%r11, %r12), %zmm28 // A
+	vbroadcastsd	16+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			192(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+	vbroadcastsd	24+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+	vmovapd			0(%r11, %r12), %zmm27 // A
+	vbroadcastsd	16+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vfmadd231pd		%zmm30, %zmm24, %zmm18
+	vmovapd			0(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+	vbroadcastsd	24+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vfmadd231pd		%zmm30, %zmm24, %zmm19
+	addq	$ 256, %r13
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean4-up
+	
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			64(%r11, %r12), %zmm28 // A
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			64(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+	vmovapd			128(%r11, %r12), %zmm27 // A
+	vbroadcastsd	16+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vfmadd231pd		%zmm30, %zmm24, %zmm18
+	vmovapd			128(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+	vbroadcastsd	24+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vfmadd231pd		%zmm30, %zmm24, %zmm19
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			192(%r11, %r12), %zmm28 // A
+	vbroadcastsd	16+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			192(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+	vbroadcastsd	24+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+//	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+//	vmovapd			0(%r11, %r12), %zmm27 // A
+	vbroadcastsd	16+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vfmadd231pd		%zmm30, %zmm24, %zmm18
+//	vmovapd			0(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+	vbroadcastsd	24+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vfmadd231pd		%zmm30, %zmm24, %zmm19
+	addq	$ 256, %r13
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 // A
+	vmovapd			0(%r11, %r12), %zmm27 // A
+	vmovapd			0(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+
+	addq	$ 64, %r11
+	addq	$ 64, %r13
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_3vx4_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B
+// zmm0  <- []
+// ...
+// zmm23  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// zmm0  <- []
+// ...
+// zmm23  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_3VX3_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_3vx3_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 // A0
+	vmovapd 		0(%r11, %r12), %zmm27 // A1
+	vmovapd 		0(%r11, %r12, 2), %zmm29 {%k1}{z} // A1
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			64(%r11, %r12), %zmm28 // A
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			64(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+//	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+	vmovapd			128(%r11, %r12), %zmm27 // A
+	vbroadcastsd	16+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vfmadd231pd		%zmm30, %zmm24, %zmm18
+	vmovapd			128(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+//	vbroadcastsd	24+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+//	vfmadd231pd		%zmm30, %zmm24, %zmm19
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			192(%r11, %r12), %zmm28 // A
+	vbroadcastsd	16+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			192(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+//	vbroadcastsd	24+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+//	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+	vmovapd			0(%r11, %r12), %zmm27 // A
+	vbroadcastsd	16+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vfmadd231pd		%zmm30, %zmm24, %zmm18
+	vmovapd			0(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+//	vbroadcastsd	24+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+//	vfmadd231pd		%zmm30, %zmm24, %zmm19
+	addq	$ 256, %r13
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean4-up
+	
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			64(%r11, %r12), %zmm28 // A
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			64(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+//	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+	vmovapd			128(%r11, %r12), %zmm27 // A
+	vbroadcastsd	16+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vfmadd231pd		%zmm30, %zmm24, %zmm18
+	vmovapd			128(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+//	vbroadcastsd	24+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+//	vfmadd231pd		%zmm30, %zmm24, %zmm19
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			192(%r11, %r12), %zmm28 // A
+	vbroadcastsd	16+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			192(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+//	vbroadcastsd	24+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+//	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+//	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+//	vmovapd			0(%r11, %r12), %zmm27 // A
+	vbroadcastsd	16+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vfmadd231pd		%zmm30, %zmm24, %zmm18
+//	vmovapd			0(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+//	vbroadcastsd	24+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+//	vfmadd231pd		%zmm30, %zmm24, %zmm19
+	addq	$ 256, %r13
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 // A
+	vmovapd			0(%r11, %r12), %zmm27 // A
+	vmovapd			0(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+//	vfmadd231pd		%zmm29, %zmm24, %zmm19
+
+	addq	$ 64, %r11
+	addq	$ 64, %r13
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_3vx3_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B
+// zmm0  <- []
+// ...
+// zmm23  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// zmm0  <- []
+// ...
+// zmm23  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_3VX2_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_3vx2_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 // A0
+	vmovapd 		0(%r11, %r12), %zmm27 // A1
+	vmovapd 		0(%r11, %r12, 2), %zmm29 {%k1}{z} // A1
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			64(%r11, %r12), %zmm28 // A
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			64(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+//	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+	vmovapd			128(%r11, %r12), %zmm27 // A
+//	vbroadcastsd	16+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vfmadd231pd		%zmm30, %zmm24, %zmm18
+	vmovapd			128(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+//	vbroadcastsd	24+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+//	vfmadd231pd		%zmm30, %zmm24, %zmm19
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			192(%r11, %r12), %zmm28 // A
+//	vbroadcastsd	16+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			192(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+//	vbroadcastsd	24+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+//	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+	vmovapd			0(%r11, %r12), %zmm27 // A
+//	vbroadcastsd	16+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vfmadd231pd		%zmm30, %zmm24, %zmm18
+	vmovapd			0(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+//	vbroadcastsd	24+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+//	vfmadd231pd		%zmm30, %zmm24, %zmm19
+	addq	$ 256, %r13
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean4-up
+	
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			64(%r11, %r12), %zmm28 // A
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			64(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+//	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+	vmovapd			128(%r11, %r12), %zmm27 // A
+//	vbroadcastsd	16+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vfmadd231pd		%zmm30, %zmm24, %zmm18
+	vmovapd			128(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+//	vbroadcastsd	24+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+//	vfmadd231pd		%zmm30, %zmm24, %zmm19
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			192(%r11, %r12), %zmm28 // A
+//	vbroadcastsd	16+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			192(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+//	vbroadcastsd	24+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+//	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+//	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+//	vmovapd			0(%r11, %r12), %zmm27 // A
+//	vbroadcastsd	16+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vfmadd231pd		%zmm30, %zmm24, %zmm18
+//	vmovapd			0(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+//	vbroadcastsd	24+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+//	vfmadd231pd		%zmm30, %zmm24, %zmm19
+	addq	$ 256, %r13
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 // A
+	vmovapd			0(%r11, %r12), %zmm27 // A
+	vmovapd			0(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vfmadd231pd		%zmm29, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+//	vfmadd231pd		%zmm29, %zmm24, %zmm19
+
+	addq	$ 64, %r11
+	addq	$ 64, %r13
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_3vx2_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B
+// zmm0  <- []
+// ...
+// zmm23  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// zmm0  <- []
+// ...
+// zmm23  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_3VX1_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_3vx1_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 // A0
+	vmovapd 		0(%r11, %r12), %zmm27 // A1
+	vmovapd 		0(%r11, %r12, 2), %zmm29 {%k1}{z} // A1
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			64(%r11), %zmm26 // A
+//	vbroadcastsd	8(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm27, %zmm24, %zmm9
+//	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			64(%r11, %r12), %zmm28 // A
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			64(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+//	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+	vmovapd			128(%r11), %zmm25 // A
+//	vbroadcastsd	8+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm1
+//	vfmadd231pd		%zmm28, %zmm24, %zmm9
+//	vfmadd231pd		%zmm30, %zmm24, %zmm17
+	vmovapd			128(%r11, %r12), %zmm27 // A
+//	vbroadcastsd	16+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vfmadd231pd		%zmm30, %zmm24, %zmm18
+	vmovapd			128(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+//	vbroadcastsd	24+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+//	vfmadd231pd		%zmm30, %zmm24, %zmm19
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			192(%r11), %zmm26 // A
+//	vbroadcastsd	8+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm27, %zmm24, %zmm9
+//	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			192(%r11, %r12), %zmm28 // A
+//	vbroadcastsd	16+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			192(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+//	vbroadcastsd	24+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+//	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+	vmovapd			0(%r11), %zmm25 // A
+//	vbroadcastsd	8+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm1
+//	vfmadd231pd		%zmm28, %zmm24, %zmm9
+//	vfmadd231pd		%zmm30, %zmm24, %zmm17
+	vmovapd			0(%r11, %r12), %zmm27 // A
+//	vbroadcastsd	16+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vfmadd231pd		%zmm30, %zmm24, %zmm18
+	vmovapd			0(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+//	vbroadcastsd	24+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+//	vfmadd231pd		%zmm30, %zmm24, %zmm19
+	addq	$ 256, %r13
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean4-up
+	
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			64(%r11), %zmm26 // A
+//	vbroadcastsd	8(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm27, %zmm24, %zmm9
+//	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			64(%r11, %r12), %zmm28 // A
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			64(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+//	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+	vmovapd			128(%r11), %zmm25 // A
+//	vbroadcastsd	8+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm1
+//	vfmadd231pd		%zmm28, %zmm24, %zmm9
+//	vfmadd231pd		%zmm30, %zmm24, %zmm17
+	vmovapd			128(%r11, %r12), %zmm27 // A
+//	vbroadcastsd	16+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vfmadd231pd		%zmm30, %zmm24, %zmm18
+	vmovapd			128(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+//	vbroadcastsd	24+64(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+//	vfmadd231pd		%zmm30, %zmm24, %zmm19
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			192(%r11), %zmm26 // A
+//	vbroadcastsd	8+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm27, %zmm24, %zmm9
+//	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			192(%r11, %r12), %zmm28 // A
+//	vbroadcastsd	16+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			192(%r11, %r12, 2), %zmm30 {%k1}{z} // A
+//	vbroadcastsd	24+128(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+//	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+//	vmovapd			0(%r11), %zmm25 // A
+//	vbroadcastsd	8+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm1
+//	vfmadd231pd		%zmm28, %zmm24, %zmm9
+//	vfmadd231pd		%zmm30, %zmm24, %zmm17
+//	vmovapd			0(%r11, %r12), %zmm27 // A
+//	vbroadcastsd	16+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm2
+//	vfmadd231pd		%zmm28, %zmm24, %zmm10
+//	vfmadd231pd		%zmm30, %zmm24, %zmm18
+//	vmovapd			0(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+//	vbroadcastsd	24+192(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm3
+//	vfmadd231pd		%zmm28, %zmm24, %zmm11
+//	vfmadd231pd		%zmm30, %zmm24, %zmm19
+	addq	$ 256, %r13
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 // A
+	vmovapd			0(%r11, %r12), %zmm27 // A
+	vmovapd			0(%r11, %r12, 2), %zmm29 {%k1}{z} // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+//	vbroadcastsd	8(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vfmadd231pd		%zmm27, %zmm24, %zmm9
+//	vfmadd231pd		%zmm29, %zmm24, %zmm17
+//	vbroadcastsd	16(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vfmadd231pd		%zmm27, %zmm24, %zmm10
+//	vfmadd231pd		%zmm29, %zmm24, %zmm18
+//	vbroadcastsd	24(%r13), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+//	vfmadd231pd		%zmm27, %zmm24, %zmm11
+//	vfmadd231pd		%zmm29, %zmm24, %zmm19
+
+	addq	$ 64, %r11
+	addq	$ 64, %r13
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_3vx1_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B
+// r14   <- m1
+// r15   <- n1
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// r14   <- m1
+// r15   <- n1
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_24X8_VS_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_24x8_vs_lib8)
+#endif
+
+	// compute mask for rows
+	vcvtsi2sd	%r14d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC02(%rip), %zmm24
+#elif defined(OS_MAC)
+	vmovupd		LC02(%rip), %zmm24
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm24, %zmm25
+	vpmovq2m	%zmm25, %k1
+
+	cmpl	$ 1, %r15d
+	jg		100f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_3VX1_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_3vx1_lib8)
+#endif
+	
+	jmp		107f
+
+100:
+
+	cmpl	$ 2, %r15d
+	jg		101f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_3VX2_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_3vx2_lib8)
+#endif
+	
+	jmp		107f
+
+101:
+
+	cmpl	$ 3, %r15d
+	jg		102f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_3VX3_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_3vx3_lib8)
+#endif
+	
+	jmp		107f
+
+102:
+
+	cmpl	$ 4, %r15d
+	jg		103f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_3VX4_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_3vx4_lib8)
+#endif
+	
+	jmp		107f
+
+103:
+
+	cmpl	$ 5, %r15d
+	jg		104f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_3VX5_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_3vx5_lib8)
+#endif
+	
+	jmp		107f
+
+104:
+
+	cmpl	$ 6, %r15d
+	jg		105f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_3VX6_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_3vx6_lib8)
+#endif
+	
+	jmp		107f
+
+105:
+
+	cmpl	$ 7, %r15d
+	jg		106f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_3VX7_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_3vx7_lib8)
+#endif
+	
+	jmp		107f
+
+106:
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_3VX8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_3vx8_lib8)
+#endif
+
+107:
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_24x8_vs_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
 // triangular substitution:
 // side = right
 // uplo = lower
@@ -2809,11 +5794,13 @@ NAME:
 	movq	ARG4, %r12 // sda
 	sall	$ 6, %r12d // 8*sda*sizeof(double)
 	movq	ARG5, %r13 // B
+	movq	ARG11, %r14 // m1
+	movq	ARG12, %r15 // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_24X8_LIB8
+	INNER_KERNEL_DGEMM_NT_24X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_24x8_lib8)
+	CALL(inner_kernel_dgemm_nt_24x8_vs_lib8)
 #endif
 
 
@@ -2955,11 +5942,13 @@ NAME:
 	movq	ARG3, %r12 // sda
 	sall	$ 6, %r12d // 4*sda*sizeof(double)
 	movq	ARG4, %r13 // B
+	movq	ARG12, %r14 // m1
+	movq	ARG13, %r15 // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_24X8_LIB8
+	INNER_KERNEL_DGEMM_NT_24X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_24x8_lib8)
+	CALL(inner_kernel_dgemm_nt_24x8_vs_lib8)
 #endif
 
 
@@ -3131,11 +6120,13 @@ NAME:
 	movq	ARG3, %r12 // sdap
 	sall	$ 6, %r12d   // 4*sdap*sizeof(double)
 	movq	ARG4, %r13  // Bp
+	movq	ARG15, %r14 // m1
+	movq	ARG16, %r15 // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_24X8_LIB8
+	INNER_KERNEL_DGEMM_NT_24X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_24x8_lib8)
+	CALL(inner_kernel_dgemm_nt_24x8_vs_lib8)
 #endif
 
 
@@ -3150,11 +6141,13 @@ NAME:
 	movq	ARG7, %r12 // sdam
 	sall	$ 6, %r12d // 4*sda*sizeof(double)
 	movq	ARG8, %r13  // Bm
+	movq	ARG15, %r14 // m1
+	movq	ARG16, %r15 // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_24X8_LIB8
+	INNER_KERNEL_DGEMM_NT_24X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_24x8_lib8)
+	CALL(inner_kernel_dgemm_nt_24x8_vs_lib8)
 #endif
 
 
@@ -3306,11 +6299,13 @@ NAME:
 	movq	ARG3, %r12
 	sall	$ 6, %r12d // 8*sda*sizeof(double)
 	movq	ARG4, %r13
+	movq	ARG10, %r14 // m1
+	movq	ARG11, %r15 // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_24X8_LIB8
+	INNER_KERNEL_DGEMM_NT_24X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_24x8_lib8)
+	CALL(inner_kernel_dgemm_nt_24x8_vs_lib8)
 #endif
 
 
@@ -3480,11 +6475,13 @@ NAME:
 	movq	ARG3, %r12 // sdap
 	sall	$ 6, %r12d   // 4*sdap*sizeof(double)
 	movq	ARG4, %r13  // Bp
+	movq	ARG14, %r14 // m1
+	movq	ARG15, %r15 // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_24X8_LIB8
+	INNER_KERNEL_DGEMM_NT_24X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_24x8_lib8)
+	CALL(inner_kernel_dgemm_nt_24x8_vs_lib8)
 #endif
 
 
@@ -3499,11 +6496,13 @@ NAME:
 	movq	ARG7, %r12 // sdam
 	sall	$ 6, %r12d // 4*sdam*sizeof(double)
 	movq	ARG8, %r13  // Bm
+	movq	ARG14, %r14 // m1
+	movq	ARG15, %r15 // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_24X8_LIB8
+	INNER_KERNEL_DGEMM_NT_24X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_24x8_lib8)
+	CALL(inner_kernel_dgemm_nt_24x8_vs_lib8)
 #endif
 
 

--- a/kernel/avx512/kernel_dgemm_24x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_24x8_lib8.S
@@ -5710,6 +5710,137 @@ NAME:
 
 
 
+// common inner routine with file scope
+//
+// transpose
+//
+// input arguments:
+// zmm0  <- []
+// ...
+// zmm15  <- []
+//
+// output arguments:
+
+#if MACRO_LEVEL>=1
+	.macro INNER_TRAN_24X8_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_tran_24x8_lib8)
+#endif
+
+	movl	$ 0xcc, %r10d
+	kmovd	%r10d, %k1
+	movl	$ 0x33, %r10d
+	kmovd	%r10d, %k2
+
+
+	vunpcklpd	%zmm1, %zmm0, %zmm24
+	vunpckhpd	%zmm1, %zmm0, %zmm25
+	vunpcklpd	%zmm3, %zmm2, %zmm26
+	vunpckhpd	%zmm3, %zmm2, %zmm27
+	vunpcklpd	%zmm5, %zmm4, %zmm28
+	vunpckhpd	%zmm5, %zmm4, %zmm29
+	vunpcklpd	%zmm7, %zmm6, %zmm30
+	vunpckhpd	%zmm7, %zmm6, %zmm31
+
+	vmovapd		%zmm24, %zmm0
+	vpermq		$ 0x40, %zmm26, %zmm24 {%k1}
+	vpermq		$ 0x0e, %zmm0, %zmm26 {%k2}
+	vmovapd		%zmm25, %zmm0
+	vpermq		$ 0x40, %zmm27, %zmm25 {%k1}
+	vpermq		$ 0x0e, %zmm0, %zmm27 {%k2}
+	vmovapd		%zmm28, %zmm0
+	vpermq		$ 0x40, %zmm30, %zmm28 {%k1}
+	vpermq		$ 0x0e, %zmm0, %zmm30 {%k2}
+	vmovapd		%zmm29, %zmm0
+	vpermq		$ 0x40, %zmm31, %zmm29 {%k1}
+	vpermq		$ 0x0e, %zmm0, %zmm31 {%k2}
+
+	vshuff64x2	$ 0x44, %zmm28, %zmm24, %zmm0
+	vshuff64x2	$ 0xee, %zmm28, %zmm24, %zmm4
+	vshuff64x2	$ 0x44, %zmm29, %zmm25, %zmm1
+	vshuff64x2	$ 0xee, %zmm29, %zmm25, %zmm5
+	vshuff64x2	$ 0x44, %zmm30, %zmm26, %zmm2
+	vshuff64x2	$ 0xee, %zmm30, %zmm26, %zmm6
+	vshuff64x2	$ 0x44, %zmm31, %zmm27, %zmm3
+	vshuff64x2	$ 0xee, %zmm31, %zmm27, %zmm7
+
+
+	vunpcklpd	%zmm9, %zmm8, %zmm24
+	vunpckhpd	%zmm9, %zmm8, %zmm25
+	vunpcklpd	%zmm11, %zmm10, %zmm26
+	vunpckhpd	%zmm11, %zmm10, %zmm27
+	vunpcklpd	%zmm13, %zmm12, %zmm28
+	vunpckhpd	%zmm13, %zmm12, %zmm29
+	vunpcklpd	%zmm15, %zmm14, %zmm30
+	vunpckhpd	%zmm15, %zmm14, %zmm31
+
+	vmovapd		%zmm24, %zmm8
+	vpermq		$ 0x40, %zmm26, %zmm24 {%k1}
+	vpermq		$ 0x0e, %zmm8, %zmm26 {%k2}
+	vmovapd		%zmm25, %zmm8
+	vpermq		$ 0x40, %zmm27, %zmm25 {%k1}
+	vpermq		$ 0x0e, %zmm8, %zmm27 {%k2}
+	vmovapd		%zmm28, %zmm8
+	vpermq		$ 0x40, %zmm30, %zmm28 {%k1}
+	vpermq		$ 0x0e, %zmm8, %zmm30 {%k2}
+	vmovapd		%zmm29, %zmm8
+	vpermq		$ 0x40, %zmm31, %zmm29 {%k1}
+	vpermq		$ 0x0e, %zmm8, %zmm31 {%k2}
+
+	vshuff64x2	$ 0x44, %zmm28, %zmm24, %zmm8
+	vshuff64x2	$ 0xee, %zmm28, %zmm24, %zmm12
+	vshuff64x2	$ 0x44, %zmm29, %zmm25, %zmm9
+	vshuff64x2	$ 0xee, %zmm29, %zmm25, %zmm13
+	vshuff64x2	$ 0x44, %zmm30, %zmm26, %zmm10
+	vshuff64x2	$ 0xee, %zmm30, %zmm26, %zmm14
+	vshuff64x2	$ 0x44, %zmm31, %zmm27, %zmm11
+	vshuff64x2	$ 0xee, %zmm31, %zmm27, %zmm15
+
+
+	vunpcklpd	%zmm17, %zmm16, %zmm24
+	vunpckhpd	%zmm17, %zmm16, %zmm25
+	vunpcklpd	%zmm19, %zmm18, %zmm26
+	vunpckhpd	%zmm19, %zmm18, %zmm27
+	vunpcklpd	%zmm21, %zmm20, %zmm28
+	vunpckhpd	%zmm21, %zmm20, %zmm29
+	vunpcklpd	%zmm23, %zmm22, %zmm30
+	vunpckhpd	%zmm23, %zmm22, %zmm31
+
+	vmovapd		%zmm24, %zmm16
+	vpermq		$ 0x40, %zmm26, %zmm24 {%k1}
+	vpermq		$ 0x0e, %zmm16, %zmm26 {%k2}
+	vmovapd		%zmm25, %zmm16
+	vpermq		$ 0x40, %zmm27, %zmm25 {%k1}
+	vpermq		$ 0x0e, %zmm16, %zmm27 {%k2}
+	vmovapd		%zmm28, %zmm16
+	vpermq		$ 0x40, %zmm30, %zmm28 {%k1}
+	vpermq		$ 0x0e, %zmm16, %zmm30 {%k2}
+	vmovapd		%zmm29, %zmm16
+	vpermq		$ 0x40, %zmm31, %zmm29 {%k1}
+	vpermq		$ 0x0e, %zmm16, %zmm31 {%k2}
+
+	vshuff64x2	$ 0x44, %zmm28, %zmm24, %zmm16
+	vshuff64x2	$ 0xee, %zmm28, %zmm24, %zmm20
+	vshuff64x2	$ 0x44, %zmm29, %zmm25, %zmm17
+	vshuff64x2	$ 0xee, %zmm29, %zmm25, %zmm21
+	vshuff64x2	$ 0x44, %zmm30, %zmm26, %zmm18
+	vshuff64x2	$ 0xee, %zmm30, %zmm26, %zmm22
+	vshuff64x2	$ 0x44, %zmm31, %zmm27, %zmm19
+	vshuff64x2	$ 0xee, %zmm31, %zmm27, %zmm23
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_tran_24x8_lib8)
+#endif
+
+
+
+
+
 //                                1      2              3          4        5          6             7          8        9          10
 // void kernel_dgemm_nt_24x8_lib8(int k, double *alpha, double *A, int sda, double *B, double *beta, double *C, int sdc, double *D, int sdd);
 

--- a/kernel/avx512/kernel_dgemm_24x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_24x8_lib8.S
@@ -1247,64 +1247,10 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+1*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm0, %zmm27, %zmm26
-	vfnmadd231pd	%zmm0, %zmm26, %zmm1
-	vfnmadd231pd	%zmm8, %zmm26, %zmm9
-	vfnmadd231pd	%zmm16, %zmm26, %zmm17
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+2*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+2*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm0, %zmm27, %zmm26
-	vfnmadd231pd	%zmm0, %zmm26, %zmm2
-	vfnmadd231pd	%zmm8, %zmm26, %zmm10
-	vfnmadd231pd	%zmm16, %zmm26, %zmm18
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+3*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+3*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm0, %zmm27, %zmm26
-	vfnmadd231pd	%zmm0, %zmm26, %zmm3
-	vfnmadd231pd	%zmm8, %zmm26, %zmm11
-	vfnmadd231pd	%zmm16, %zmm26, %zmm19
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+4*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+4*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm0, %zmm27, %zmm26
-	vfnmadd231pd	%zmm0, %zmm26, %zmm4
-	vfnmadd231pd	%zmm8, %zmm26, %zmm12
-	vfnmadd231pd	%zmm16, %zmm26, %zmm20
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+5*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+5*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm0, %zmm27, %zmm26
-	vfnmadd231pd	%zmm0, %zmm26, %zmm5
-	vfnmadd231pd	%zmm8, %zmm26, %zmm13
-	vfnmadd231pd	%zmm16, %zmm26, %zmm21
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+6*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+6*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm0, %zmm27, %zmm26
-	vfnmadd231pd	%zmm0, %zmm26, %zmm6
-	vfnmadd231pd	%zmm8, %zmm26, %zmm14
-	vfnmadd231pd	%zmm16, %zmm26, %zmm22
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+7*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+7*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm0, %zmm27, %zmm26
-	vfnmadd231pd	%zmm0, %zmm26, %zmm7
-	vfnmadd231pd	%zmm8, %zmm26, %zmm15
-	vfnmadd231pd	%zmm16, %zmm26, %zmm23
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm1
+	vfnmadd231pd	%zmm8, %zmm27, %zmm9
+	vfnmadd231pd	%zmm16, %zmm27, %zmm17
 
 	// 1
 //	vpermilpd		$ 0x3, %xmm1, %xmm26
@@ -1319,6 +1265,60 @@ NAME:
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 4:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm2
+	vfnmadd231pd	%zmm8, %zmm27, %zmm10
+	vfnmadd231pd	%zmm16, %zmm27, %zmm18
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm3
+	vfnmadd231pd	%zmm8, %zmm27, %zmm11
+	vfnmadd231pd	%zmm16, %zmm27, %zmm19
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm4
+	vfnmadd231pd	%zmm8, %zmm27, %zmm12
+	vfnmadd231pd	%zmm16, %zmm27, %zmm20
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm5
+	vfnmadd231pd	%zmm8, %zmm27, %zmm13
+	vfnmadd231pd	%zmm16, %zmm27, %zmm21
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm6
+	vfnmadd231pd	%zmm8, %zmm27, %zmm14
+	vfnmadd231pd	%zmm16, %zmm27, %zmm22
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm7
+	vfnmadd231pd	%zmm8, %zmm27, %zmm15
+	vfnmadd231pd	%zmm16, %zmm27, %zmm23
 	vmovsd			%xmm26, 8(%r10)
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm1, %zmm26, %zmm1
@@ -1331,55 +1331,10 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+2*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm1, %zmm27, %zmm26
-	vfnmadd231pd	%zmm1, %zmm26, %zmm2
-	vfnmadd231pd	%zmm9, %zmm26, %zmm10
-	vfnmadd231pd	%zmm17, %zmm26, %zmm18
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+3*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+3*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm1, %zmm27, %zmm26
-	vfnmadd231pd	%zmm1, %zmm26, %zmm3
-	vfnmadd231pd	%zmm9, %zmm26, %zmm11
-	vfnmadd231pd	%zmm17, %zmm26, %zmm19
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+4*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+4*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm1, %zmm27, %zmm26
-	vfnmadd231pd	%zmm1, %zmm26, %zmm4
-	vfnmadd231pd	%zmm9, %zmm26, %zmm12
-	vfnmadd231pd	%zmm17, %zmm26, %zmm20
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+5*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+5*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm1, %zmm27, %zmm26
-	vfnmadd231pd	%zmm1, %zmm26, %zmm5
-	vfnmadd231pd	%zmm9, %zmm26, %zmm13
-	vfnmadd231pd	%zmm17, %zmm26, %zmm21
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+6*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+6*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm1, %zmm27, %zmm26
-	vfnmadd231pd	%zmm1, %zmm26, %zmm6
-	vfnmadd231pd	%zmm9, %zmm26, %zmm14
-	vfnmadd231pd	%zmm17, %zmm26, %zmm22
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+7*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+7*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm1, %zmm27, %zmm26
-	vfnmadd231pd	%zmm1, %zmm26, %zmm7
-	vfnmadd231pd	%zmm9, %zmm26, %zmm15
-	vfnmadd231pd	%zmm17, %zmm26, %zmm23
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm2
+	vfnmadd231pd	%zmm9, %zmm27, %zmm10
+	vfnmadd231pd	%zmm17, %zmm27, %zmm18
 
 	// 2
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -1393,6 +1348,51 @@ NAME:
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 6:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm3
+	vfnmadd231pd	%zmm9, %zmm27, %zmm11
+	vfnmadd231pd	%zmm17, %zmm27, %zmm19
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm4
+	vfnmadd231pd	%zmm9, %zmm27, %zmm12
+	vfnmadd231pd	%zmm17, %zmm27, %zmm20
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm5
+	vfnmadd231pd	%zmm9, %zmm27, %zmm13
+	vfnmadd231pd	%zmm17, %zmm27, %zmm21
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm6
+	vfnmadd231pd	%zmm9, %zmm27, %zmm14
+	vfnmadd231pd	%zmm17, %zmm27, %zmm22
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm7
+	vfnmadd231pd	%zmm9, %zmm27, %zmm15
+	vfnmadd231pd	%zmm17, %zmm27, %zmm23
 	vmovsd			%xmm26, 16(%r10)
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm2, %zmm26, %zmm2
@@ -1405,46 +1405,10 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+3*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm2, %zmm27, %zmm26
-	vfnmadd231pd	%zmm2, %zmm26, %zmm3
-	vfnmadd231pd	%zmm10, %zmm26, %zmm11
-	vfnmadd231pd	%zmm18, %zmm26, %zmm19
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+4*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+4*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm2, %zmm27, %zmm26
-	vfnmadd231pd	%zmm2, %zmm26, %zmm4
-	vfnmadd231pd	%zmm10, %zmm26, %zmm12
-	vfnmadd231pd	%zmm18, %zmm26, %zmm20
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+5*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+5*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm2, %zmm27, %zmm26
-	vfnmadd231pd	%zmm2, %zmm26, %zmm5
-	vfnmadd231pd	%zmm10, %zmm26, %zmm13
-	vfnmadd231pd	%zmm18, %zmm26, %zmm21
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+6*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+6*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm2, %zmm27, %zmm26
-	vfnmadd231pd	%zmm2, %zmm26, %zmm6
-	vfnmadd231pd	%zmm10, %zmm26, %zmm14
-	vfnmadd231pd	%zmm18, %zmm26, %zmm22
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+7*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+7*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm2, %zmm27, %zmm26
-	vfnmadd231pd	%zmm2, %zmm26, %zmm7
-	vfnmadd231pd	%zmm10, %zmm26, %zmm15
-	vfnmadd231pd	%zmm18, %zmm26, %zmm23
+	vpermpd			%zmm2, %zmm27, %zmm27
+	vfnmadd231pd	%zmm2, %zmm27, %zmm3
+	vfnmadd231pd	%zmm10, %zmm27, %zmm11
+	vfnmadd231pd	%zmm18, %zmm27, %zmm19
 
 	// 3
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -1458,6 +1422,42 @@ NAME:
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 8:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm27
+	vfnmadd231pd	%zmm2, %zmm27, %zmm4
+	vfnmadd231pd	%zmm10, %zmm27, %zmm12
+	vfnmadd231pd	%zmm18, %zmm27, %zmm20
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm27
+	vfnmadd231pd	%zmm2, %zmm27, %zmm5
+	vfnmadd231pd	%zmm10, %zmm27, %zmm13
+	vfnmadd231pd	%zmm18, %zmm27, %zmm21
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm27
+	vfnmadd231pd	%zmm2, %zmm27, %zmm6
+	vfnmadd231pd	%zmm10, %zmm27, %zmm14
+	vfnmadd231pd	%zmm18, %zmm27, %zmm22
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm27
+	vfnmadd231pd	%zmm2, %zmm27, %zmm7
+	vfnmadd231pd	%zmm10, %zmm27, %zmm15
+	vfnmadd231pd	%zmm18, %zmm27, %zmm23
 	vmovsd			%xmm26, 24(%r10)
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm3, %zmm26, %zmm3
@@ -1470,37 +1470,10 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+4*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm3, %zmm27, %zmm26
-	vfnmadd231pd	%zmm3, %zmm26, %zmm4
-	vfnmadd231pd	%zmm11, %zmm26, %zmm12
-	vfnmadd231pd	%zmm19, %zmm26, %zmm20
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+5*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+5*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm3, %zmm27, %zmm26
-	vfnmadd231pd	%zmm3, %zmm26, %zmm5
-	vfnmadd231pd	%zmm11, %zmm26, %zmm13
-	vfnmadd231pd	%zmm19, %zmm26, %zmm21
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+6*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+6*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm3, %zmm27, %zmm26
-	vfnmadd231pd	%zmm3, %zmm26, %zmm6
-	vfnmadd231pd	%zmm11, %zmm26, %zmm14
-	vfnmadd231pd	%zmm19, %zmm26, %zmm22
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+7*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+7*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm3, %zmm27, %zmm26
-	vfnmadd231pd	%zmm3, %zmm26, %zmm7
-	vfnmadd231pd	%zmm11, %zmm26, %zmm15
-	vfnmadd231pd	%zmm19, %zmm26, %zmm23
+	vpermpd			%zmm3, %zmm27, %zmm27
+	vfnmadd231pd	%zmm3, %zmm27, %zmm4
+	vfnmadd231pd	%zmm11, %zmm27, %zmm12
+	vfnmadd231pd	%zmm19, %zmm27, %zmm20
 
 	// 4
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -1514,6 +1487,33 @@ NAME:
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 10:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm3, %zmm27, %zmm27
+	vfnmadd231pd	%zmm3, %zmm27, %zmm5
+	vfnmadd231pd	%zmm11, %zmm27, %zmm13
+	vfnmadd231pd	%zmm19, %zmm27, %zmm21
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm3, %zmm27, %zmm27
+	vfnmadd231pd	%zmm3, %zmm27, %zmm6
+	vfnmadd231pd	%zmm11, %zmm27, %zmm14
+	vfnmadd231pd	%zmm19, %zmm27, %zmm22
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm3, %zmm27, %zmm27
+	vfnmadd231pd	%zmm3, %zmm27, %zmm7
+	vfnmadd231pd	%zmm11, %zmm27, %zmm15
+	vfnmadd231pd	%zmm19, %zmm27, %zmm23
 	vmovsd			%xmm26, 32(%r10)
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm4, %zmm26, %zmm4
@@ -1526,28 +1526,10 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+5*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm4, %zmm27, %zmm26
-	vfnmadd231pd	%zmm4, %zmm26, %zmm5
-	vfnmadd231pd	%zmm12, %zmm26, %zmm13
-	vfnmadd231pd	%zmm20, %zmm26, %zmm21
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+6*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+6*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm4, %zmm27, %zmm26
-	vfnmadd231pd	%zmm4, %zmm26, %zmm6
-	vfnmadd231pd	%zmm12, %zmm26, %zmm14
-	vfnmadd231pd	%zmm20, %zmm26, %zmm22
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+7*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+7*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm4, %zmm27, %zmm26
-	vfnmadd231pd	%zmm4, %zmm26, %zmm7
-	vfnmadd231pd	%zmm12, %zmm26, %zmm15
-	vfnmadd231pd	%zmm20, %zmm26, %zmm23
+	vpermpd			%zmm4, %zmm27, %zmm27
+	vfnmadd231pd	%zmm4, %zmm27, %zmm5
+	vfnmadd231pd	%zmm12, %zmm27, %zmm13
+	vfnmadd231pd	%zmm20, %zmm27, %zmm21
 
 	// 5
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -1561,6 +1543,24 @@ NAME:
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 12:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm4, %zmm27, %zmm27
+	vfnmadd231pd	%zmm4, %zmm27, %zmm6
+	vfnmadd231pd	%zmm12, %zmm27, %zmm14
+	vfnmadd231pd	%zmm20, %zmm27, %zmm22
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm4, %zmm27, %zmm27
+	vfnmadd231pd	%zmm4, %zmm27, %zmm7
+	vfnmadd231pd	%zmm12, %zmm27, %zmm15
+	vfnmadd231pd	%zmm20, %zmm27, %zmm23
 	vmovsd			%xmm26, 40(%r10)
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm5, %zmm26, %zmm5
@@ -1573,19 +1573,10 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+6*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm5, %zmm27, %zmm26
-	vfnmadd231pd	%zmm5, %zmm26, %zmm6
-	vfnmadd231pd	%zmm13, %zmm26, %zmm14
-	vfnmadd231pd	%zmm21, %zmm26, %zmm22
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+7*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+7*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm5, %zmm27, %zmm26
-	vfnmadd231pd	%zmm5, %zmm26, %zmm7
-	vfnmadd231pd	%zmm13, %zmm26, %zmm15
-	vfnmadd231pd	%zmm21, %zmm26, %zmm23
+	vpermpd			%zmm5, %zmm27, %zmm27
+	vfnmadd231pd	%zmm5, %zmm27, %zmm6
+	vfnmadd231pd	%zmm13, %zmm27, %zmm14
+	vfnmadd231pd	%zmm21, %zmm27, %zmm22
 
 	// 6
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -1599,6 +1590,15 @@ NAME:
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 14:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm5, %zmm27, %zmm27
+	vfnmadd231pd	%zmm5, %zmm27, %zmm7
+	vfnmadd231pd	%zmm13, %zmm27, %zmm15
+	vfnmadd231pd	%zmm21, %zmm27, %zmm23
 	vmovsd			%xmm26, 48(%r10)
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm6, %zmm26, %zmm6
@@ -1611,10 +1611,10 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+7*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm6, %zmm27, %zmm26
-	vfnmadd231pd	%zmm6, %zmm26, %zmm7
-	vfnmadd231pd	%zmm14, %zmm26, %zmm15
-	vfnmadd231pd	%zmm22, %zmm26, %zmm23
+	vpermpd			%zmm6, %zmm27, %zmm27
+	vfnmadd231pd	%zmm6, %zmm27, %zmm7
+	vfnmadd231pd	%zmm14, %zmm27, %zmm15
+	vfnmadd231pd	%zmm22, %zmm27, %zmm23
 
 	// 7
 #if defined(OS_LINUX) | defined(OS_WINDOWS)

--- a/kernel/avx512/kernel_dgemm_24x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_24x8_lib8.S
@@ -1,0 +1,1493 @@
+/**************************************************************************************************
+*                                                                                                 *
+* This file is part of BLASFEO.                                                                   *
+*                                                                                                 *
+* BLASFEO -- BLAS For Embedded Optimization.                                                      *
+* Copyright (C) 2021 by Gianluca Frison.                                                          *
+* Developed at IMTEK (University of Freiburg) under the supervision of Moritz Diehl.              *
+* All rights reserved.                                                                            *
+*                                                                                                 *
+* The 2-Clause BSD License                                                                        *
+*                                                                                                 *
+* Redistribution and use in source and binary forms, with or without                              *
+* modification, are permitted provided that the following conditions are met:                     *
+*                                                                                                 *
+* 1. Redistributions of source code must retain the above copyright notice, this                  *
+*    list of conditions and the following disclaimer.                                             *
+* 2. Redistributions in binary form must reproduce the above copyright notice,                    *
+*    this list of conditions and the following disclaimer in the documentation                    *
+*    and/or other materials provided with the distribution.                                       *
+*                                                                                                 *
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND                 *
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED                   *
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE                          *
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR                 *
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES                  *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;                    *
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND                     *
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT                      *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS                   *
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                                    *
+*                                                                                                 *
+* Author: Gianluca Frison, gianluca.frison (at) imtek.uni-freiburg.de                             *
+*                                                                                                 *
+**************************************************************************************************/
+
+#if defined(OS_LINUX) | defined(OS_MAC)
+
+//#define STACKSIZE 96
+#define STACKSIZE 64
+#define ARG1  %rdi
+#define ARG2  %rsi
+#define ARG3  %rdx
+#define ARG4  %rcx
+#define ARG5  %r8
+#define ARG6  %r9
+#define ARG7  STACKSIZE +  8(%rsp)
+#define ARG8  STACKSIZE + 16(%rsp)
+#define ARG9  STACKSIZE + 24(%rsp)
+#define ARG10 STACKSIZE + 32(%rsp)
+#define ARG11 STACKSIZE + 40(%rsp)
+#define ARG12 STACKSIZE + 48(%rsp)
+#define ARG13 STACKSIZE + 56(%rsp)
+#define ARG14 STACKSIZE + 64(%rsp)
+#define ARG15 STACKSIZE + 72(%rsp)
+#define ARG16 STACKSIZE + 80(%rsp)
+#define ARG17 STACKSIZE + 88(%rsp)
+#define ARG18 STACKSIZE + 96(%rsp)
+#define ARG19 STACKSIZE + 104(%rsp)
+#define PROLOGUE \
+	subq	$STACKSIZE, %rsp; \
+	movq	%rbx,   (%rsp); \
+	movq	%rbp,  8(%rsp); \
+	movq	%r12, 16(%rsp); \
+	movq	%r13, 24(%rsp); \
+	movq	%r14, 32(%rsp); \
+	movq	%r15, 40(%rsp); \
+	vzeroupper;
+#define EPILOGUE \
+	vzeroupper; \
+	movq	  (%rsp), %rbx; \
+	movq	 8(%rsp), %rbp; \
+	movq	16(%rsp), %r12; \
+	movq	24(%rsp), %r13; \
+	movq	32(%rsp), %r14; \
+	movq	40(%rsp), %r15; \
+	addq	$STACKSIZE, %rsp;
+
+#if defined(OS_LINUX)
+
+#define GLOB_FUN_START(NAME) \
+	.globl NAME; \
+	.type NAME, @function; \
+NAME:
+#define FUN_START(NAME) \
+	.type NAME, @function; \
+NAME:
+#define FUN_END(NAME) \
+	.size	NAME, .-NAME
+#define CALL(NAME) \
+	call NAME
+#define ZERO_ACC \
+	vpxord	%zmm0, %zmm0, %zmm0; \
+	vmovapd	%zmm0, %zmm1; \
+	vmovapd	%zmm0, %zmm2; \
+	vmovapd	%zmm0, %zmm3; \
+	vmovapd	%zmm0, %zmm4; \
+	vmovapd	%zmm0, %zmm5; \
+	vmovapd	%zmm0, %zmm6; \
+	vmovapd	%zmm0, %zmm7; \
+	vmovapd	%zmm0, %zmm8; \
+	vmovapd	%zmm0, %zmm9; \
+	vmovapd	%zmm0, %zmm10; \
+	vmovapd	%zmm0, %zmm11; \
+	vmovapd	%zmm0, %zmm12; \
+	vmovapd	%zmm0, %zmm13; \
+	vmovapd	%zmm0, %zmm14; \
+	vmovapd	%zmm0, %zmm15; \
+	vmovapd	%zmm0, %zmm16; \
+	vmovapd	%zmm0, %zmm17; \
+	vmovapd	%zmm0, %zmm18; \
+	vmovapd	%zmm0, %zmm19; \
+	vmovapd	%zmm0, %zmm20; \
+	vmovapd	%zmm0, %zmm21; \
+	vmovapd	%zmm0, %zmm22; \
+	vmovapd	%zmm0, %zmm23;
+#define NEG_ACC \
+	vmovapd		.LC03(%rip), %zmm24; \
+	vxorpd		%zmm24, %zmm0, %zmm0; \
+	vxorpd		%zmm24, %zmm1, %zmm1; \
+	vxorpd		%zmm24, %zmm2, %zmm2; \
+	vxorpd		%zmm24, %zmm3, %zmm3; \
+	vxorpd		%zmm24, %zmm4, %zmm4; \
+	vxorpd		%zmm24, %zmm5, %zmm5; \
+	vxorpd		%zmm24, %zmm6, %zmm6; \
+	vxorpd		%zmm24, %zmm7, %zmm7; \
+	vxorpd		%zmm24, %zmm8, %zmm8; \
+	vxorpd		%zmm24, %zmm9, %zmm9; \
+	vxorpd		%zmm24, %zmm10, %zmm10; \
+	vxorpd		%zmm24, %zmm11, %zmm11; \
+	vxorpd		%zmm24, %zmm12, %zmm12; \
+	vxorpd		%zmm24, %zmm13, %zmm13; \
+	vxorpd		%zmm24, %zmm14, %zmm14; \
+	vxorpd		%zmm24, %zmm15, %zmm15; \
+	vxorpd		%zmm24, %zmm16, %zmm16; \
+	vxorpd		%zmm24, %zmm17, %zmm17; \
+	vxorpd		%zmm24, %zmm18, %zmm18; \
+	vxorpd		%zmm24, %zmm19, %zmm19; \
+	vxorpd		%zmm24, %zmm20, %zmm20; \
+	vxorpd		%zmm24, %zmm21, %zmm21; \
+	vxorpd		%zmm24, %zmm22, %zmm22; \
+	vxorpd		%zmm24, %zmm23, %zmm23;
+
+#else // defined(OS_MAC)
+
+#define GLOB_FUN_START(NAME) \
+	.globl _ ## NAME; \
+_ ## NAME:
+#define FUN_START(NAME) \
+_ ## NAME:
+#define FUN_END(NAME)
+#define CALL(NAME) \
+	callq _ ## NAME
+#define ZERO_ACC \
+	vpxord	%zmm0, %zmm0, %zmm0; \
+	vmovapd	%zmm0, %zmm1; \
+	vmovapd	%zmm0, %zmm2; \
+	vmovapd	%zmm0, %zmm3; \
+	vmovapd	%zmm0, %zmm4; \
+	vmovapd	%zmm0, %zmm5; \
+	vmovapd	%zmm0, %zmm6; \
+	vmovapd	%zmm0, %zmm7; \
+	vmovapd	%zmm0, %zmm8; \
+	vmovapd	%zmm0, %zmm9; \
+	vmovapd	%zmm0, %zmm10; \
+	vmovapd	%zmm0, %zmm11; \
+	vmovapd	%zmm0, %zmm12; \
+	vmovapd	%zmm0, %zmm13; \
+	vmovapd	%zmm0, %zmm14; \
+	vmovapd	%zmm0, %zmm15; \
+	vmovapd	%zmm0, %zmm16; \
+	vmovapd	%zmm0, %zmm17; \
+	vmovapd	%zmm0, %zmm18; \
+	vmovapd	%zmm0, %zmm19; \
+	vmovapd	%zmm0, %zmm20; \
+	vmovapd	%zmm0, %zmm21; \
+	vmovapd	%zmm0, %zmm22; \
+	vmovapd	%zmm0, %zmm23;
+#define NEG_ACC \
+	vmovapd		LC03(%rip), %zmm24; \
+	vxorpd		%zmm24, %zmm0, %zmm0; \
+	vxorpd		%zmm24, %zmm1, %zmm1; \
+	vxorpd		%zmm24, %zmm2, %zmm2; \
+	vxorpd		%zmm24, %zmm3, %zmm3; \
+	vxorpd		%zmm24, %zmm4, %zmm4; \
+	vxorpd		%zmm24, %zmm5, %zmm5; \
+	vxorpd		%zmm24, %zmm6, %zmm6; \
+	vxorpd		%zmm24, %zmm7, %zmm7; \
+	vxorpd		%zmm24, %zmm8, %zmm8; \
+	vxorpd		%zmm24, %zmm9, %zmm9; \
+	vxorpd		%zmm24, %zmm10, %zmm10; \
+	vxorpd		%zmm24, %zmm11, %zmm11; \
+	vxorpd		%zmm24, %zmm12, %zmm12; \
+	vxorpd		%zmm24, %zmm13, %zmm13; \
+	vxorpd		%zmm24, %zmm14, %zmm14; \
+	vxorpd		%zmm24, %zmm15, %zmm15; \
+	vxorpd		%zmm24, %zmm16, %zmm16; \
+	vxorpd		%zmm24, %zmm17, %zmm17; \
+	vxorpd		%zmm24, %zmm18, %zmm18; \
+	vxorpd		%zmm24, %zmm19, %zmm19; \
+	vxorpd		%zmm24, %zmm20, %zmm20; \
+	vxorpd		%zmm24, %zmm21, %zmm21; \
+	vxorpd		%zmm24, %zmm22, %zmm22; \
+	vxorpd		%zmm24, %zmm23, %zmm23;
+
+#endif
+
+#elif defined(OS_WINDOWS)
+
+#define STACKSIZE 256
+#define ARG1  %rcx
+#define ARG2  %rdx
+#define ARG3  %r8
+#define ARG4  %r9
+#define ARG5  STACKSIZE + 40(%rsp)
+#define ARG6  STACKSIZE + 48(%rsp)
+#define ARG7  STACKSIZE + 56(%rsp)
+#define ARG8  STACKSIZE + 64(%rsp)
+#define ARG9  STACKSIZE + 72(%rsp)
+#define ARG10 STACKSIZE + 80(%rsp)
+#define ARG11 STACKSIZE + 88(%rsp)
+#define ARG12 STACKSIZE + 96(%rsp)
+#define ARG13 STACKSIZE + 104(%rsp)
+#define ARG14 STACKSIZE + 112(%rsp)
+#define ARG15 STACKSIZE + 120(%rsp)
+#define ARG16 STACKSIZE + 128(%rsp)
+#define ARG17 STACKSIZE + 136(%rsp)
+#define ARG18 STACKSIZE + 144(%rsp)
+#define ARG19 STACKSIZE + 152(%rsp)
+#define PROLOGUE \
+	subq	$STACKSIZE, %rsp; \
+	movq	%rbx,   (%rsp); \
+	movq	%rbp,  8(%rsp); \
+	movq	%r12, 16(%rsp); \
+	movq	%r13, 24(%rsp); \
+	movq	%r14, 32(%rsp); \
+	movq	%r15, 40(%rsp); \
+	movq	%rdi, 48(%rsp); \
+	movq	%rsi, 56(%rsp); \
+	vmovups	%xmm6, 64(%rsp); \
+	vmovups	%xmm7, 80(%rsp); \
+	vmovups	%xmm8, 96(%rsp); \
+	vmovups	%xmm9, 112(%rsp); \
+	vmovups	%xmm10, 128(%rsp); \
+	vmovups	%xmm11, 144(%rsp); \
+	vmovups	%xmm12, 160(%rsp); \
+	vmovups	%xmm13, 176(%rsp); \
+	vmovups	%xmm14, 192(%rsp); \
+	vmovups	%xmm15, 208(%rsp); \
+	vzeroupper;
+#define EPILOGUE \
+	vzeroupper; \
+	movq	  (%rsp), %rbx; \
+	movq	 8(%rsp), %rbp; \
+	movq	16(%rsp), %r12; \
+	movq	24(%rsp), %r13; \
+	movq	32(%rsp), %r14; \
+	movq	40(%rsp), %r15; \
+	movq	48(%rsp), %rdi; \
+	movq	56(%rsp), %rsi; \
+	vmovups	64(%rsp), %xmm6; \
+	vmovups	80(%rsp), %xmm7; \
+	vmovups	96(%rsp), %xmm8; \
+	vmovups	112(%rsp), %xmm9; \
+	vmovups	128(%rsp), %xmm10; \
+	vmovups	144(%rsp), %xmm11; \
+	vmovups	160(%rsp), %xmm12; \
+	vmovups	176(%rsp), %xmm13; \
+	vmovups	192(%rsp), %xmm14; \
+	vmovups	208(%rsp), %xmm15; \
+	addq	$STACKSIZE, %rsp;
+
+#define GLOB_FUN_START(NAME) \
+	.globl NAME; \
+	.def NAME; .scl 2; .type 32; .endef; \
+NAME:
+#define FUN_START(NAME) \
+	.def NAME; .scl 2; .type 32; .endef; \
+NAME:
+#define FUN_END(NAME)
+#define CALL(NAME) \
+	call NAME
+#define ZERO_ACC \
+	vpxord	%zmm0, %zmm0, %zmm0; \
+	vmovapd	%zmm0, %zmm1; \
+	vmovapd	%zmm0, %zmm2; \
+	vmovapd	%zmm0, %zmm3; \
+	vmovapd	%zmm0, %zmm4; \
+	vmovapd	%zmm0, %zmm5; \
+	vmovapd	%zmm0, %zmm6; \
+	vmovapd	%zmm0, %zmm7; \
+	vmovapd	%zmm0, %zmm8; \
+	vmovapd	%zmm0, %zmm9; \
+	vmovapd	%zmm0, %zmm10; \
+	vmovapd	%zmm0, %zmm11; \
+	vmovapd	%zmm0, %zmm12; \
+	vmovapd	%zmm0, %zmm13; \
+	vmovapd	%zmm0, %zmm14; \
+	vmovapd	%zmm0, %zmm15; \
+	vmovapd	%zmm0, %zmm16; \
+	vmovapd	%zmm0, %zmm17; \
+	vmovapd	%zmm0, %zmm18; \
+	vmovapd	%zmm0, %zmm19; \
+	vmovapd	%zmm0, %zmm20; \
+	vmovapd	%zmm0, %zmm21; \
+	vmovapd	%zmm0, %zmm22; \
+	vmovapd	%zmm0, %zmm23;
+#define NEG_ACC \
+	vmovapd		.LC03(%rip), %zmm24; \
+	vxorpd		%zmm24, %zmm0, %zmm0; \
+	vxorpd		%zmm24, %zmm1, %zmm1; \
+	vxorpd		%zmm24, %zmm2, %zmm2; \
+	vxorpd		%zmm24, %zmm3, %zmm3; \
+	vxorpd		%zmm24, %zmm4, %zmm4; \
+	vxorpd		%zmm24, %zmm5, %zmm5; \
+	vxorpd		%zmm24, %zmm6, %zmm6; \
+	vxorpd		%zmm24, %zmm7, %zmm7; \
+	vxorpd		%zmm24, %zmm8, %zmm8; \
+	vxorpd		%zmm24, %zmm9, %zmm9; \
+	vxorpd		%zmm24, %zmm10, %zmm10; \
+	vxorpd		%zmm24, %zmm11, %zmm11; \
+	vxorpd		%zmm24, %zmm12, %zmm12; \
+	vxorpd		%zmm24, %zmm13, %zmm13; \
+	vxorpd		%zmm24, %zmm14, %zmm14; \
+	vxorpd		%zmm24, %zmm15, %zmm15; \
+	vxorpd		%zmm24, %zmm16, %zmm16; \
+	vxorpd		%zmm24, %zmm17, %zmm17; \
+	vxorpd		%zmm24, %zmm18, %zmm18; \
+	vxorpd		%zmm24, %zmm19, %zmm19; \
+	vxorpd		%zmm24, %zmm20, %zmm20; \
+	vxorpd		%zmm24, %zmm21, %zmm21; \
+	vxorpd		%zmm24, %zmm22, %zmm22; \
+	vxorpd		%zmm24, %zmm23, %zmm23;
+
+#else
+
+#error wrong OS
+
+#endif
+
+
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	.text
+#elif defined(OS_MAC)
+	.section	__TEXT,__text,regular,pure_instructions
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B
+// zmm0  <- []
+// ...
+// zmm15  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- 4*sda*sizeof(double)
+// r13   <- B+8*k*sizeof(double)
+// zmm0  <- []
+// ...
+// zmm15  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_24X8_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_24x8_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+//	prefetcht0	0(%r13) // software prefetch
+//	prefetcht0	0+64(%r13) // software prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 // A0
+	vmovapd 		0(%r11, %r12), %zmm27 // A1
+	vmovapd 		0(%r11, %r12, 2), %zmm29 // A1
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			64(%r11, %r12), %zmm28 // A
+//	prefetcht0	128(%r13) // software prefetch
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			64(%r11, %r12, 2), %zmm30 // A
+//	prefetcht0	128+64(%r13) // software prefetch
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vfmadd231pd		%zmm29, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vfmadd231pd		%zmm29, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+	vfmadd231pd		%zmm29, %zmm24, %zmm22
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	vfmadd231pd		%zmm29, %zmm24, %zmm23
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+	vmovapd			128(%r11, %r12), %zmm27 // A
+	vbroadcastsd	16+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vfmadd231pd		%zmm30, %zmm24, %zmm18
+	vmovapd			128(%r11, %r12, 2), %zmm29 // A
+	vbroadcastsd	24+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vfmadd231pd		%zmm30, %zmm24, %zmm19
+	vbroadcastsd	32+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vfmadd231pd		%zmm30, %zmm24, %zmm20
+	vbroadcastsd	40+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vfmadd231pd		%zmm30, %zmm24, %zmm21
+	vbroadcastsd	48+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+	vfmadd231pd		%zmm30, %zmm24, %zmm22
+	vbroadcastsd	56+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	vfmadd231pd		%zmm28, %zmm24, %zmm15
+	vfmadd231pd		%zmm30, %zmm24, %zmm23
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			192(%r11, %r12), %zmm28 // A
+//	prefetcht0	128(%r13) // software prefetch
+	vbroadcastsd	16+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			192(%r11, %r12, 2), %zmm30 // A
+//	prefetcht0	128+64(%r13) // software prefetch
+	vbroadcastsd	24+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	vbroadcastsd	32+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vfmadd231pd		%zmm29, %zmm24, %zmm20
+	vbroadcastsd	40+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vfmadd231pd		%zmm29, %zmm24, %zmm21
+	vbroadcastsd	48+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+	vfmadd231pd		%zmm29, %zmm24, %zmm22
+	vbroadcastsd	56+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	vfmadd231pd		%zmm29, %zmm24, %zmm23
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+	vmovapd			0(%r11, %r12), %zmm27 // A
+	vbroadcastsd	16+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vfmadd231pd		%zmm30, %zmm24, %zmm18
+	vmovapd			0(%r11, %r12, 2), %zmm29 // A
+	vbroadcastsd	24+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vfmadd231pd		%zmm30, %zmm24, %zmm19
+	vbroadcastsd	32+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vfmadd231pd		%zmm30, %zmm24, %zmm20
+	vbroadcastsd	40+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vfmadd231pd		%zmm30, %zmm24, %zmm21
+	vbroadcastsd	48+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+	vfmadd231pd		%zmm30, %zmm24, %zmm22
+	vbroadcastsd	56+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	vfmadd231pd		%zmm28, %zmm24, %zmm15
+	vfmadd231pd		%zmm30, %zmm24, %zmm23
+	addq	$ 256, %r13
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean4-up
+	
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			64(%r11), %zmm26 // A
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			64(%r11, %r12), %zmm28 // A
+//	prefetcht0	128(%r13) // software prefetch
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			64(%r11, %r12, 2), %zmm30 // A
+//	prefetcht0	128+64(%r13) // software prefetch
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vfmadd231pd		%zmm29, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vfmadd231pd		%zmm29, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+	vfmadd231pd		%zmm29, %zmm24, %zmm22
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	vfmadd231pd		%zmm29, %zmm24, %zmm23
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+	vmovapd			128(%r11), %zmm25 // A
+	vbroadcastsd	8+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+	vmovapd			128(%r11, %r12), %zmm27 // A
+	vbroadcastsd	16+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vfmadd231pd		%zmm30, %zmm24, %zmm18
+	vmovapd			128(%r11, %r12, 2), %zmm29 // A
+	vbroadcastsd	24+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vfmadd231pd		%zmm30, %zmm24, %zmm19
+	vbroadcastsd	32+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vfmadd231pd		%zmm30, %zmm24, %zmm20
+	vbroadcastsd	40+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vfmadd231pd		%zmm30, %zmm24, %zmm21
+	vbroadcastsd	48+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+	vfmadd231pd		%zmm30, %zmm24, %zmm22
+	vbroadcastsd	56+64(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	vfmadd231pd		%zmm28, %zmm24, %zmm15
+	vfmadd231pd		%zmm30, %zmm24, %zmm23
+
+	// unroll 0
+	vbroadcastsd	0+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vmovapd			192(%r11), %zmm26 // A
+	vbroadcastsd	8+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vmovapd			192(%r11, %r12), %zmm28 // A
+//	prefetcht0	128(%r13) // software prefetch
+	vbroadcastsd	16+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vmovapd			192(%r11, %r12, 2), %zmm30 // A
+//	prefetcht0	128+64(%r13) // software prefetch
+	vbroadcastsd	24+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	vbroadcastsd	32+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vfmadd231pd		%zmm29, %zmm24, %zmm20
+	vbroadcastsd	40+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vfmadd231pd		%zmm29, %zmm24, %zmm21
+	vbroadcastsd	48+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+	vfmadd231pd		%zmm29, %zmm24, %zmm22
+	vbroadcastsd	56+128(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	vfmadd231pd		%zmm29, %zmm24, %zmm23
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vfmadd231pd		%zmm28, %zmm24, %zmm8
+	vfmadd231pd		%zmm30, %zmm24, %zmm16
+//	vmovapd			0(%r11), %zmm25 // A
+	vbroadcastsd	8+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vfmadd231pd		%zmm28, %zmm24, %zmm9
+	vfmadd231pd		%zmm30, %zmm24, %zmm17
+//	vmovapd			0(%r11, %r12), %zmm27 // A
+	vbroadcastsd	16+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vfmadd231pd		%zmm28, %zmm24, %zmm10
+	vfmadd231pd		%zmm30, %zmm24, %zmm18
+//	vmovapd			0(%r11, %r12, 2), %zmm29 // A
+	vbroadcastsd	24+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vfmadd231pd		%zmm28, %zmm24, %zmm11
+	vfmadd231pd		%zmm30, %zmm24, %zmm19
+	vbroadcastsd	32+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vfmadd231pd		%zmm28, %zmm24, %zmm12
+	vfmadd231pd		%zmm30, %zmm24, %zmm20
+	vbroadcastsd	40+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vfmadd231pd		%zmm28, %zmm24, %zmm13
+	vfmadd231pd		%zmm30, %zmm24, %zmm21
+	vbroadcastsd	48+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vfmadd231pd		%zmm28, %zmm24, %zmm14
+	vfmadd231pd		%zmm30, %zmm24, %zmm22
+	vbroadcastsd	56+192(%r13), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	vfmadd231pd		%zmm28, %zmm24, %zmm15
+	vfmadd231pd		%zmm30, %zmm24, %zmm23
+	addq	$ 256, %r13
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 // A
+	vmovapd			0(%r11, %r12), %zmm27 // A
+	vmovapd			0(%r11, %r12, 2), %zmm29 // A
+	vbroadcastsd	0(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vfmadd231pd		%zmm27, %zmm24, %zmm8
+	vfmadd231pd		%zmm29, %zmm24, %zmm16
+	vbroadcastsd	8(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vfmadd231pd		%zmm27, %zmm24, %zmm9
+	vfmadd231pd		%zmm29, %zmm24, %zmm17
+	vbroadcastsd	16(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vfmadd231pd		%zmm27, %zmm24, %zmm10
+	vfmadd231pd		%zmm29, %zmm24, %zmm18
+	vbroadcastsd	24(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vfmadd231pd		%zmm27, %zmm24, %zmm11
+	vfmadd231pd		%zmm29, %zmm24, %zmm19
+	vbroadcastsd	32(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vfmadd231pd		%zmm27, %zmm24, %zmm12
+	vfmadd231pd		%zmm29, %zmm24, %zmm20
+	vbroadcastsd	40(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vfmadd231pd		%zmm27, %zmm24, %zmm13
+	vfmadd231pd		%zmm29, %zmm24, %zmm21
+	vbroadcastsd	48(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vfmadd231pd		%zmm27, %zmm24, %zmm14
+	vfmadd231pd		%zmm29, %zmm24, %zmm22
+	vbroadcastsd	56(%r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vfmadd231pd		%zmm27, %zmm24, %zmm15
+	vfmadd231pd		%zmm29, %zmm24, %zmm23
+
+	addq	$ 64, %r11
+	addq	$ 64, %r13
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_24x8_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// scale for generic alpha and beta
+//
+// input arguments:
+// r10   <- alpha
+// r11   <- beta
+// r12   <- C
+// r13   <- 8*sdc*sizeof(double)
+// zmm0 <- []
+// ...
+// zmm15 <- []
+//
+// output arguments:
+// r10   <- alpha
+// r11   <- beta
+// r10   <- C
+// r13   <- 8*sdc*sizeof(double)
+// zmm0 <- []
+// ...
+// zmm15 <- []
+
+#if MACRO_LEVEL>=1
+	.macro INNER_SCALE_AB_24X8_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_scale_ab_24x8_lib8)
+#endif
+	
+	// alpha
+	vbroadcastsd	0(%r10), %zmm25
+
+	vmulpd		%zmm0, %zmm25, %zmm0
+	vmulpd		%zmm1, %zmm25, %zmm1
+	vmulpd		%zmm2, %zmm25, %zmm2
+	vmulpd		%zmm3, %zmm25, %zmm3
+	vmulpd		%zmm4, %zmm25, %zmm4
+	vmulpd		%zmm5, %zmm25, %zmm5
+	vmulpd		%zmm6, %zmm25, %zmm6
+	vmulpd		%zmm7, %zmm25, %zmm7
+	vmulpd		%zmm8, %zmm25, %zmm8
+	vmulpd		%zmm9, %zmm25, %zmm9
+	vmulpd		%zmm10, %zmm25, %zmm10
+	vmulpd		%zmm11, %zmm25, %zmm11
+	vmulpd		%zmm12, %zmm25, %zmm12
+	vmulpd		%zmm13, %zmm25, %zmm13
+	vmulpd		%zmm14, %zmm25, %zmm14
+	vmulpd		%zmm15, %zmm25, %zmm15
+	vmulpd		%zmm16, %zmm25, %zmm16
+	vmulpd		%zmm17, %zmm25, %zmm17
+	vmulpd		%zmm18, %zmm25, %zmm18
+	vmulpd		%zmm19, %zmm25, %zmm19
+	vmulpd		%zmm20, %zmm25, %zmm20
+	vmulpd		%zmm21, %zmm25, %zmm21
+	vmulpd		%zmm22, %zmm25, %zmm22
+	vmulpd		%zmm23, %zmm25, %zmm23
+
+	// beta
+	vbroadcastsd	0(%r11), %zmm24
+
+	vxorpd		%zmm25, %zmm25, %zmm25 // 0.0
+
+	vucomisd	%xmm25, %xmm24 // beta==0.0 ?
+	je			0f // end
+
+	vmovapd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm0
+	vmovapd		64(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm1
+	vmovapd		128(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm2
+	vmovapd		192(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm3
+	vmovapd		0+256(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm4
+	vmovapd		64+256(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm5
+	vmovapd		128+256(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm6
+	vmovapd		192+256(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm7
+
+	vmovapd		0(%r12, %r13), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm8
+	vmovapd		64(%r12, %r13), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm9
+	vmovapd		128(%r12, %r13), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm10
+	vmovapd		192(%r12, %r13), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm11
+	vmovapd		0+256(%r12, %r13), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm12
+	vmovapd		64+256(%r12, %r13), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm13
+	vmovapd		128+256(%r12, %r13), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm14
+	vmovapd		192+256(%r12, %r13), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm15
+
+	vmovapd		0(%r12, %r13, 2), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm16
+	vmovapd		64(%r12, %r13, 2), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm17
+	vmovapd		128(%r12, %r13, 2), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm18
+	vmovapd		192(%r12, %r13, 2), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm19
+	vmovapd		0+256(%r12, %r13, 2), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm20
+	vmovapd		64+256(%r12, %r13, 2), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm21
+	vmovapd		128+256(%r12, %r13, 2), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm22
+	vmovapd		192+256(%r12, %r13, 2), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm23
+
+0:
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_scale_ab_24x8_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// scale for generic alpha and beta
+//
+// input arguments:
+// r10   <- alpha
+// r11   <- beta
+// r12   <- C
+// r13   <- 8*sdc*sizeof(double)
+// r14   <- n1
+// zmm0 <- []
+// ...
+// zmm15 <- []
+//
+// output arguments:
+// r10   <- alpha
+// r11   <- beta
+// r10   <- C
+// r13   <- 8*sdc*sizeof(double)
+// r14   <- n1
+// zmm0 <- []
+// ...
+// zmm15 <- []
+
+#if MACRO_LEVEL>=1
+	.macro INNER_SCALE_AB_24X8_VS_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_scale_ab_24x8_vs_lib8)
+#endif
+	
+	// alpha
+	vbroadcastsd	0(%r10), %zmm25
+
+	vmulpd		%zmm0, %zmm25, %zmm0
+	vmulpd		%zmm1, %zmm25, %zmm1
+	vmulpd		%zmm2, %zmm25, %zmm2
+	vmulpd		%zmm3, %zmm25, %zmm3
+	vmulpd		%zmm4, %zmm25, %zmm4
+	vmulpd		%zmm5, %zmm25, %zmm5
+	vmulpd		%zmm6, %zmm25, %zmm6
+	vmulpd		%zmm7, %zmm25, %zmm7
+	vmulpd		%zmm8, %zmm25, %zmm8
+	vmulpd		%zmm9, %zmm25, %zmm9
+	vmulpd		%zmm10, %zmm25, %zmm10
+	vmulpd		%zmm11, %zmm25, %zmm11
+	vmulpd		%zmm12, %zmm25, %zmm12
+	vmulpd		%zmm13, %zmm25, %zmm13
+	vmulpd		%zmm14, %zmm25, %zmm14
+	vmulpd		%zmm15, %zmm25, %zmm15
+	vmulpd		%zmm16, %zmm25, %zmm16
+	vmulpd		%zmm17, %zmm25, %zmm17
+	vmulpd		%zmm18, %zmm25, %zmm18
+	vmulpd		%zmm19, %zmm25, %zmm19
+	vmulpd		%zmm20, %zmm25, %zmm20
+	vmulpd		%zmm21, %zmm25, %zmm21
+	vmulpd		%zmm22, %zmm25, %zmm22
+	vmulpd		%zmm23, %zmm25, %zmm23
+
+	// beta
+	vbroadcastsd	0(%r11), %zmm24
+
+	vxorpd		%zmm25, %zmm25, %zmm25 // 0.0
+
+	vucomisd	%xmm25, %xmm24 // beta==0.0 ?
+	je			0f // end
+
+	vmovapd		0(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm0
+	vmovapd		0(%r12, %r13), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm8
+	vmovapd		0(%r12, %r13, 2), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm16
+	cmpl	$ 2, %r14d
+	jl		0f // end
+	vmovapd		64(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm1
+	vmovapd		64(%r12, %r13), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm9
+	vmovapd		64(%r12, %r13, 2), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm17
+	cmpl	$ 3, %r14d
+	jl		0f // end
+	vmovapd		128(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm2
+	vmovapd		128(%r12, %r13), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm10
+	vmovapd		128(%r12, %r13, 2), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm18
+	cmpl	$ 4, %r14d
+	jl		0f // end
+	vmovapd		192(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm3
+	vmovapd		192(%r12, %r13), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm11
+	vmovapd		192(%r12, %r13, 2), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm19
+	cmpl	$ 5, %r14d
+	jl		0f // end
+	vmovapd		0+256(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm4
+	vmovapd		0+256(%r12, %r13), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm12
+	vmovapd		0+256(%r12, %r13, 2), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm20
+	cmpl	$ 6, %r14d
+	jl		0f // end
+	vmovapd		64+256(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm5
+	vmovapd		64+256(%r12, %r13), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm13
+	vmovapd		64+256(%r12, %r13, 2), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm21
+	cmpl	$ 7, %r14d
+	jl		0f // end
+	vmovapd		128+256(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm6
+	vmovapd		128+256(%r12, %r13), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm14
+	vmovapd		128+256(%r12, %r13, 2), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm22
+	je		0f // end
+	vmovapd		192+256(%r12), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm7
+	vmovapd		192+256(%r12, %r13), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm15
+	vmovapd		192+256(%r12, %r13, 2), %zmm25
+	vfmadd231pd	%zmm24, %zmm25, %zmm23
+
+0:
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_scale_ab_24x8_vs_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// store n
+//
+// input arguments:
+// r10  <- D
+// r11  <- 8*sdd*sizeof(double)
+// zmm0 <- []
+// ...
+// zmm15 <- []
+//
+// output arguments:
+// r10  <- D
+// r11  <- 8*sdd*sizeof(double)
+// zmm0 <- []
+// ...
+// zmm15 <- []
+
+#if MACRO_LEVEL>=1
+	.macro INNER_STORE_24X8_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_store_24x8_lib8)
+#endif
+	
+	vmovapd %zmm0,   0(%r10)
+	vmovapd %zmm1,  64(%r10)
+	vmovapd %zmm2, 128(%r10)
+	vmovapd %zmm3, 192(%r10)
+	vmovapd %zmm4,   0+256(%r10)
+	vmovapd %zmm5,  64+256(%r10)
+	vmovapd %zmm6, 128+256(%r10)
+	vmovapd %zmm7, 192+256(%r10)
+
+	vmovapd %zmm8,   0(%r10, %r11)
+	vmovapd %zmm9,  64(%r10, %r11)
+	vmovapd %zmm10, 128(%r10, %r11)
+	vmovapd %zmm11, 192(%r10, %r11)
+	vmovapd %zmm12,   0+256(%r10, %r11)
+	vmovapd %zmm13,  64+256(%r10, %r11)
+	vmovapd %zmm14, 128+256(%r10, %r11)
+	vmovapd %zmm15, 192+256(%r10, %r11)
+
+	vmovapd %zmm16,   0(%r10, %r11, 2)
+	vmovapd %zmm17,  64(%r10, %r11, 2)
+	vmovapd %zmm18, 128(%r10, %r11, 2)
+	vmovapd %zmm19, 192(%r10, %r11, 2)
+	vmovapd %zmm20,   0+256(%r10, %r11, 2)
+	vmovapd %zmm21,  64+256(%r10, %r11, 2)
+	vmovapd %zmm22, 128+256(%r10, %r11, 2)
+	vmovapd %zmm23, 192+256(%r10, %r11, 2)
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_store_24x8_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// store n
+//
+// input arguments:
+// r10  <- D
+// r11  <- 8*sdd*sizeof(double)
+// r12  <- m1
+// r13  <- n1
+// zmm0 <- []
+// ...
+// zmm15 <- []
+//
+// output arguments:
+// r10  <- D
+// r11  <- 8*sdd*sizeof(double)
+// r12  <- m1
+// r13  <- n1
+// zmm0 <- []
+// ...
+// zmm15 <- []
+
+#if MACRO_LEVEL>=1
+	.macro INNER_STORE_24X8_VS_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_store_24x8_vs_lib8)
+#endif
+	
+	// compute mask for rows
+	vcvtsi2sd	%r12d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC02(%rip), %zmm24
+#elif defined(OS_MAC)
+	vmovupd		LC02(%rip), %zmm24
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm24, %zmm25
+
+	vpmovq2m	%zmm25, %k1
+
+	vmovapd %zmm0,   0(%r10)
+	vmovapd %zmm8,   0(%r10, %r11)
+	vmovapd %zmm16,  0(%r10, %r11, 2) {%k1}
+	cmpl	$ 2, %r13d
+	jl		0f // end
+	vmovapd %zmm1,  64(%r10)
+	vmovapd %zmm9,  64(%r10, %r11)
+	vmovapd %zmm17, 64(%r10, %r11, 2) {%k1}
+	cmpl	$ 3, %r13d
+	jl		0f // end
+	vmovapd %zmm2, 128(%r10)
+	vmovapd %zmm10, 128(%r10, %r11)
+	vmovapd %zmm18, 128(%r10, %r11, 2) {%k1}
+	cmpl	$ 4, %r13d
+	jl		0f // end
+	vmovapd %zmm3, 192(%r10)
+	vmovapd %zmm11, 192(%r10, %r11)
+	vmovapd %zmm19, 192(%r10, %r11, 2) {%k1}
+	cmpl	$ 5, %r13d
+	jl		0f // end
+	vmovapd %zmm4,   0+256(%r10)
+	vmovapd %zmm12,   0+256(%r10, %r11)
+	vmovapd %zmm20,   0+256(%r10, %r11, 2) {%k1}
+	cmpl	$ 6, %r13d
+	jl		0f // end
+	vmovapd %zmm5,  64+256(%r10)
+	vmovapd %zmm13,  64+256(%r10, %r11)
+	vmovapd %zmm21,  64+256(%r10, %r11, 2) {%k1}
+	cmpl	$ 7, %r13d
+	jl		0f // end
+	vmovapd %zmm6, 128+256(%r10)
+	vmovapd %zmm14, 128+256(%r10, %r11)
+	vmovapd %zmm22, 128+256(%r10, %r11, 2) {%k1}
+	je		0f // end
+	vmovapd %zmm7, 192+256(%r10)
+	vmovapd %zmm15, 192+256(%r10, %r11)
+	vmovapd %zmm23, 192+256(%r10, %r11, 2) {%k1}
+
+0:
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_store_24x8_vs_lib8)
+#endif
+
+
+
+
+
+//                                1      2              3          4        5          6             7          8        9          10
+// void kernel_dgemm_nt_24x8_lib8(int k, double *alpha, double *A, int sda, double *B, double *beta, double *C, int sdc, double *D, int sdd);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dgemm_nt_24x8_lib8)
+	
+	PROLOGUE
+
+	// zero accumulation registers
+
+	ZERO_ACC
+
+
+	// call inner dgemm kernel nt
+
+	movq	ARG1, %r10 // k
+	movq	ARG3, %r11 // A
+	movq	ARG4, %r12 // sda
+	sall	$ 6, %r12d // 8*sda*sizeof(double)
+	movq	ARG5, %r13 // B
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_24X8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_24x8_lib8)
+#endif
+
+
+	// call inner blend scale
+
+	movq	ARG2, %r10 // alpha
+	movq	ARG6, %r11 // beta
+	movq	ARG7, %r12 // C
+	movq	ARG8, %r13 // sdc
+	sall	$ 6, %r13d // 8*sdc*sizeof(double)
+
+#if MACRO_LEVEL>=1
+	INNER_SCALE_AB_24X8_LIB8
+#else
+	CALL(inner_scale_ab_24x8_lib8)
+#endif
+
+
+	// store n
+
+	movq	ARG9, %r10 // D
+	movq	ARG10, %r11 // sdd
+	sall	$ 6, %r11d // 8*sdd*sizeof(double)
+
+#if MACRO_LEVEL>=1
+	INNER_STORE_24X8_LIB8
+#else
+	CALL(inner_store_24x8_lib8)
+#endif
+
+
+	EPILOGUE
+	
+	ret
+
+	FUN_END(kernel_dgemm_nt_24x8_lib8)
+
+
+
+
+
+//                                   1      2              3          4        5          6             7          8        9          10       11      12
+// void kernel_dgemm_nt_24x8_vs_lib8(int k, double *alpha, double *A, int sda, double *B, double *beta, double *C, int sdc, double *D, int sdd, int m1, int n1);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dgemm_nt_24x8_vs_lib8)
+	
+	PROLOGUE
+
+	// zero accumulation registers
+
+	ZERO_ACC
+
+
+	// call inner dgemm kernel nt
+
+	movq	ARG1, %r10 // k
+	movq	ARG3, %r11 // A
+	movq	ARG4, %r12 // sda
+	sall	$ 6, %r12d // 8*sda*sizeof(double)
+	movq	ARG5, %r13 // B
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_24X8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_24x8_lib8)
+#endif
+
+
+	// call inner blend scale
+
+	movq	ARG2, %r10 // alpha
+	movq	ARG6, %r11 // beta
+	movq	ARG7, %r12 // C
+	movq	ARG8, %r13 // sdc
+	sall	$ 6, %r13d // 8*sdc*sizeof(double)
+	movq	ARG12, %r14 // n1
+
+#if MACRO_LEVEL>=1
+	INNER_SCALE_AB_24X8_VS_LIB8
+#else
+	CALL(inner_scale_ab_24x8_vs_lib8)
+#endif
+
+
+	// store n
+
+	movq	ARG9, %r10 // D
+	movq	ARG10, %r11 // sdd
+	sall	$ 6, %r11d // 8*sdd*sizeof(double)
+	movq	ARG11, %r12 // m1
+	movq	ARG12, %r13 // n1
+
+#if MACRO_LEVEL>=1
+	INNER_STORE_24X8_VS_LIB8
+#else
+	CALL(inner_store_24x8_vs_lib8)
+#endif
+
+
+	EPILOGUE
+	
+	ret
+
+	FUN_END(kernel_dgemm_nt_24x8_vs_lib8)
+
+
+
+
+
+//#if defined(BLAS_API)
+#if ( defined(BLAS_API) | ( defined(LA_HIGH_PERFORMANCE) & defined(MF_COLMAJ) ) )
+
+//#include "kernel_dgemm_24x8_lib.S"
+
+#endif
+
+
+
+
+
+	// read-only data
+#if defined(OS_LINUX)
+	.section	.rodata.cst32,"aM",@progbits,32
+#elif defined(OS_MAC)
+	.section	__TEXT,__const
+#elif defined(OS_WINDOWS)
+	.section .rdata,"dr"
+#endif
+
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	.align 64
+.LC00:
+#elif defined(OS_MAC)
+	.align 6
+LC00:
+#endif
+	.double 0.5
+	.double 1.5
+	.double 2.5
+	.double 3.5
+	.double 4.5
+	.double 5.5
+	.double 6.5
+	.double 7.5
+
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	.align 64
+.LC01:
+#elif defined(OS_MAC)
+	.align 6
+LC01:
+#endif
+	.double 8.5
+	.double 9.5
+	.double 10.5
+	.double 11.5
+	.double 12.5
+	.double 13.5
+	.double 14.5
+	.double 15.5
+
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	.align 64
+.LC02:
+#elif defined(OS_MAC)
+	.align 6
+LC02:
+#endif
+	.double 16.5
+	.double 17.5
+	.double 18.5
+	.double 19.5
+	.double 20.5
+	.double 21.5
+	.double 22.5
+	.double 23.5
+
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	.align 64
+.LC03:
+#elif defined(OS_MAC)
+	.align 6
+LC03:
+#endif
+	.long	0x0
+	.long	0x80000000
+	.long	0x0
+	.long	0x80000000
+	.long	0x0
+	.long	0x80000000
+	.long	0x0
+	.long	0x80000000
+	.long	0x0
+	.long	0x80000000
+	.long	0x0
+	.long	0x80000000
+	.long	0x0
+	.long	0x80000000
+	.long	0x0
+	.long	0x80000000
+	.long	0x0
+	.long	0x80000000
+	.long	0x0
+	.long	0x80000000
+
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	.align 64
+.LC04:
+#elif defined(OS_MAC)
+	.align 6
+LC04:
+#endif
+	.double 1.0
+	.double 1.0
+	.double 1.0
+	.double 1.0
+	.double 1.0
+	.double 1.0
+	.double 1.0
+	.double 1.0
+
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	.align 64
+.LC05:
+#elif defined(OS_MAC)
+	.align 6
+LC05:
+#endif
+	.quad 0x0
+	.quad 0x1
+	.quad 0x2
+	.quad 0x3
+	.quad 0x4
+	.quad 0x5
+	.quad 0x6
+	.quad 0x7
+
+
+#if defined(OS_LINUX)
+	.section	.note.GNU-stack,"",@progbits
+#elif defined(OS_MAC)
+	.subsections_via_symbols
+#endif
+

--- a/kernel/avx512/kernel_dgemm_8x8_lib.S
+++ b/kernel/avx512/kernel_dgemm_8x8_lib.S
@@ -60,6 +60,16 @@
 
 	// preload
 
+	prefetcht0		0(%r13)
+	prefetcht0		63(%r13)
+	prefetcht0		0(%r13, %r14)
+	prefetcht0		63(%r13, %r14)
+	prefetcht0		0(%r13, %r14, 2)
+	prefetcht0		63(%r13, %r14, 2)
+	leaq			0(%r14, %r14, 2), %r15
+	prefetcht0		0(%r13, %r15)
+	prefetcht0		63(%r13, %r15)
+
 
 	cmpl	$ 4, %r10d
 	jle		0f // consider clean-up loop
@@ -69,7 +79,8 @@
 1: // main loop
 
 	// unroll 0
-//	prefetcht0		0(%r12, %r13, 8)
+	prefetcht0		0(%r12, %r13, 4)
+	prefetcht0		63(%r12, %r13, 4)
 	vmovapd			0*64(%r11), %zmm25 // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
@@ -90,7 +101,8 @@
 	addq	%r13, %r12
 
 	// unroll 1
-//	prefetcht0		0(%r12, %r13, 8)
+	prefetcht0		0(%r12, %r13, 4)
+	prefetcht0		63(%r12, %r13, 4)
 	vmovapd			1*64(%r11), %zmm25 // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
@@ -111,7 +123,8 @@
 	addq	%r13, %r12
 
 	// unroll 2
-//	prefetcht0		0(%r12, %r13, 8)
+	prefetcht0		0(%r12, %r13, 4)
+	prefetcht0		63(%r12, %r13, 4)
 	vmovapd			2*64(%r11), %zmm25 // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
@@ -132,7 +145,8 @@
 	addq	%r13, %r12
 
 	// unroll 3
-//	prefetcht0		0(%r12, %r13, 8)
+	prefetcht0		0(%r12, %r13, 4)
+	prefetcht0		63(%r12, %r13, 4)
 	vmovapd			3*64(%r11), %zmm25 // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0

--- a/kernel/avx512/kernel_dgemm_8x8_lib.S
+++ b/kernel/avx512/kernel_dgemm_8x8_lib.S
@@ -4935,6 +4935,55 @@
 
 
 
+// common inner routine with file scope
+//
+// prefetch
+//
+// input arguments:
+// r10  <- D
+// r11  <- ldd
+//
+// output arguments:
+
+#if MACRO_LEVEL>=1
+	.macro INNER_PREFETCH0_8X8_LIB
+#else
+	.p2align 4,,15
+	FUN_START(inner_prefetch0_8x8_lib)
+#endif
+
+	leaq		0(%r11, %r11, 2), %r12
+	leaq		0(%r10, %r11, 4), %r13
+
+	prefetcht0	0(%r10)
+	prefetcht0	63(%r10)
+	prefetcht0	0(%r10, %r11)
+	prefetcht0	63(%r10, %r11)
+	prefetcht0	0(%r10, %r11, 2)
+	prefetcht0	63(%r10, %r11, 2)
+	prefetcht0	0(%r10, %r12)
+	prefetcht0	63(%r10, %r12)
+	prefetcht0	0(%r13)
+	prefetcht0	63(%r13)
+	prefetcht0	0(%r13, %r11)
+	prefetcht0	63(%r13, %r11)
+	prefetcht0	0(%r13, %r11, 2)
+	prefetcht0	63(%r13, %r11, 2)
+	prefetcht0	0(%r13, %r12)
+	prefetcht0	63(%r13, %r12)
+
+#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_prefetch0_8x8_lib)
+#endif
+
+
+
+
+
 //                                  1      2              3          4          5        6             7          8        9          10
 // void kernel_dgemm_nt_8x8_lib8ccc(int k, double *alpha, double *A, double *B, int ldb, double *beta, double *C, int ldc, double *D, int ldd);
 
@@ -5115,23 +5164,23 @@
 
 	// prefetch C
 
-//	movq		ARG5, %r10 // beta
-//	vmovsd		0(%r10), %xmm14
-//	vxorpd		%xmm15, %xmm15, %xmm15 // 0.0
-//	vucomisd	%xmm15, %xmm14 // beta==0.0 ?
-//	je			100f // end
+	movq		ARG5, %r10 // beta
+	vmovsd		0(%r10), %xmm14
+	vxorpd		%xmm15, %xmm15, %xmm15 // 0.0
+	vucomisd	%xmm15, %xmm14 // beta==0.0 ?
+	je			100f // end
 
-//	movq	ARG6, %r10 // C
-//	movq	ARG7, %r11 // ldc
-//	sall	$ 3, %r11d
+	movq	ARG6, %r10 // C
+	movq	ARG7, %r11 // ldc
+	sall	$ 3, %r11d
 
 #if MACRO_LEVEL>=1
-//	INNER_PREFETCH0_4X4_LIB
+	INNER_PREFETCH0_8X8_LIB
 #else
-//	CALL(inner_prefetch0_4x4_lib)
+	CALL(inner_prefetch0_8x8_lib)
 #endif
 
-//100:
+100:
 
 
 	// call inner dgemm kernel nn

--- a/kernel/avx512/kernel_dgemm_8x8_lib.S
+++ b/kernel/avx512/kernel_dgemm_8x8_lib.S
@@ -5028,14 +5028,14 @@
 
 	// prefetch D
 
-//	movq	ARG9, %r10 // D
-//	movq	ARG10, %r11 // ldd
-//	sall	$ 3, %r11d
+	movq	ARG9, %r10 // D
+	movq	ARG10, %r11 // ldd
+	sall	$ 3, %r11d
 
 #if MACRO_LEVEL>=1
-//	INNER_PREFETCH0_8X8_LIB
+	INNER_PREFETCH0_8X8_LIB
 #else
-//	CALL(inner_prefetch0_8x8_lib)
+	CALL(inner_prefetch0_8x8_lib)
 #endif
 
 
@@ -5179,9 +5179,9 @@
 	// prefetch C
 
 	movq		ARG5, %r10 // beta
-	vmovsd		0(%r10), %xmm14
-	vxorpd		%xmm15, %xmm15, %xmm15 // 0.0
-	vucomisd	%xmm15, %xmm14 // beta==0.0 ?
+	vmovsd		0(%r10), %xmm24
+	vxorpd		%xmm25, %xmm25, %xmm25 // 0.0
+	vucomisd	%xmm25, %xmm24 // beta==0.0 ?
 	je			100f // end
 
 	movq	ARG6, %r10 // C
@@ -5512,14 +5512,14 @@
 
 	// prefetch D
 
-//	movq	ARG9, %r10 // D
-//	movq	ARG10, %r11 // ldd
-//	sall	$ 3, %r11d
+	movq	ARG9, %r10 // D
+	movq	ARG10, %r11 // ldd
+	sall	$ 3, %r11d
 
 #if MACRO_LEVEL>=1
-//	INNER_PREFETCH0_8X8_LIB
+	INNER_PREFETCH0_8X8_LIB
 #else
-//	CALL(inner_prefetch0_8x8_lib)
+	CALL(inner_prefetch0_8x8_lib)
 #endif
 
 

--- a/kernel/avx512/kernel_dgemm_8x8_lib.S
+++ b/kernel/avx512/kernel_dgemm_8x8_lib.S
@@ -306,6 +306,7 @@
 // r11   <- A
 // r12   <- B
 // r13   <- ldb
+// k1    <- m_mask
 // zmm0  <- []
 // ...
 // zmm7  <- []
@@ -313,10 +314,10 @@
 // output arguments:
 
 #if MACRO_LEVEL>=2
-	.macro INNER_KERNEL_DGEMM_NT_8X7_LIB8C
+	.macro INNER_KERNEL_DGEMM_NT_VX8_LIB8C
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_dgemm_nt_8x7_lib8c)
+	FUN_START(inner_kernel_dgemm_nt_vx8_lib8c)
 #endif
 
 	cmpl	$ 0, %r10d
@@ -334,7 +335,7 @@
 
 	// unroll 0
 //	prefetcht0		0(%r12, %r13, 8)
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -349,13 +350,13 @@
 	vfmadd231pd		%zmm25, %zmm24, %zmm5
 	vbroadcastsd	48(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm6
-//	vbroadcastsd	56(%r12), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vbroadcastsd	56(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
 	addq	%r13, %r12
 
 	// unroll 1
 //	prefetcht0		0(%r12, %r13, 8)
-	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -370,13 +371,13 @@
 	vfmadd231pd		%zmm25, %zmm24, %zmm5
 	vbroadcastsd	48(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm6
-//	vbroadcastsd	56(%r12), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vbroadcastsd	56(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
 	addq	%r13, %r12
 
 	// unroll 2
 //	prefetcht0		0(%r12, %r13, 8)
-	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -391,13 +392,13 @@
 	vfmadd231pd		%zmm25, %zmm24, %zmm5
 	vbroadcastsd	48(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm6
-//	vbroadcastsd	56(%r12), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vbroadcastsd	56(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
 	addq	%r13, %r12
 
 	// unroll 3
 //	prefetcht0		0(%r12, %r13, 8)
-	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -412,8 +413,8 @@
 	vfmadd231pd		%zmm25, %zmm24, %zmm5
 	vbroadcastsd	48(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm6
-//	vbroadcastsd	56(%r12), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vbroadcastsd	56(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
 	addq	%r13, %r12
 
 	subl	$ 4, %r10d
@@ -429,7 +430,7 @@
 	jle		4f // clean1
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -444,12 +445,12 @@
 	vfmadd231pd		%zmm25, %zmm24, %zmm5
 	vbroadcastsd	48(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm6
-//	vbroadcastsd	56(%r12), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vbroadcastsd	56(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
 	addq	%r13, %r12
 
 	// unroll 1
-	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -464,12 +465,12 @@
 	vfmadd231pd		%zmm25, %zmm24, %zmm5
 	vbroadcastsd	48(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm6
-//	vbroadcastsd	56(%r12), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vbroadcastsd	56(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
 	addq	%r13, %r12
 
 	// unroll 2
-	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -484,12 +485,12 @@
 	vfmadd231pd		%zmm25, %zmm24, %zmm5
 	vbroadcastsd	48(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm6
-//	vbroadcastsd	56(%r12), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vbroadcastsd	56(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
 	addq	%r13, %r12
 
 	// unroll 3
-	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -504,8 +505,8 @@
 	vfmadd231pd		%zmm25, %zmm24, %zmm5
 	vbroadcastsd	48(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm6
-//	vbroadcastsd	56(%r12), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vbroadcastsd	56(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
 	addq	%r13, %r12
 
 	subl	$ 4, %r10d
@@ -523,7 +524,7 @@
 3: // clean up loop
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -538,8 +539,8 @@
 	vfmadd231pd		%zmm25, %zmm24, %zmm5
 	vbroadcastsd	48(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm6
-//	vbroadcastsd	56(%r12), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	vbroadcastsd	56(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
 	addq	%r13, %r12
 
 	subl	$ 1, %r10d
@@ -556,7 +557,7 @@
 #else
 	ret
 
-	FUN_END(inner_kernel_dgemm_nt_8x7_lib8c)
+	FUN_END(inner_kernel_dgemm_nt_vx8_lib8c)
 #endif
 
 
@@ -577,10 +578,10 @@
 // output arguments:
 
 #if MACRO_LEVEL>=2
-	.macro INNER_KERNEL_DGEMM_NT_8X6_LIB8C
+	.macro INNER_KERNEL_DGEMM_NT_VX7_LIB8C
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_dgemm_nt_8x6_lib8c)
+	FUN_START(inner_kernel_dgemm_nt_vx7_lib8c)
 #endif
 
 	cmpl	$ 0, %r10d
@@ -598,7 +599,7 @@
 
 	// unroll 0
 //	prefetcht0		0(%r12, %r13, 8)
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -611,15 +612,15 @@
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	40(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm5
-//	vbroadcastsd	48(%r12), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	48(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
 //	vbroadcastsd	56(%r12), %zmm24 // B
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 	addq	%r13, %r12
 
 	// unroll 1
 //	prefetcht0		0(%r12, %r13, 8)
-	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -632,15 +633,15 @@
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	40(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm5
-//	vbroadcastsd	48(%r12), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	48(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
 //	vbroadcastsd	56(%r12), %zmm24 // B
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 	addq	%r13, %r12
 
 	// unroll 2
 //	prefetcht0		0(%r12, %r13, 8)
-	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -653,15 +654,15 @@
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	40(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm5
-//	vbroadcastsd	48(%r12), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	48(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
 //	vbroadcastsd	56(%r12), %zmm24 // B
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 	addq	%r13, %r12
 
 	// unroll 3
 //	prefetcht0		0(%r12, %r13, 8)
-	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -674,8 +675,8 @@
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	40(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm5
-//	vbroadcastsd	48(%r12), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	48(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
 //	vbroadcastsd	56(%r12), %zmm24 // B
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 	addq	%r13, %r12
@@ -693,7 +694,7 @@
 	jle		4f // clean1
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -706,14 +707,14 @@
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	40(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm5
-//	vbroadcastsd	48(%r12), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	48(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
 //	vbroadcastsd	56(%r12), %zmm24 // B
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 	addq	%r13, %r12
 
 	// unroll 1
-	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -726,14 +727,14 @@
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	40(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm5
-//	vbroadcastsd	48(%r12), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	48(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
 //	vbroadcastsd	56(%r12), %zmm24 // B
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 	addq	%r13, %r12
 
 	// unroll 2
-	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -746,14 +747,14 @@
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	40(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm5
-//	vbroadcastsd	48(%r12), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	48(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
 //	vbroadcastsd	56(%r12), %zmm24 // B
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 	addq	%r13, %r12
 
 	// unroll 3
-	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -766,8 +767,8 @@
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	40(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm5
-//	vbroadcastsd	48(%r12), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	48(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
 //	vbroadcastsd	56(%r12), %zmm24 // B
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 	addq	%r13, %r12
@@ -787,7 +788,7 @@
 3: // clean up loop
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -800,8 +801,8 @@
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	40(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm5
-//	vbroadcastsd	48(%r12), %zmm24 // B
-//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	48(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
 //	vbroadcastsd	56(%r12), %zmm24 // B
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 	addq	%r13, %r12
@@ -820,7 +821,7 @@
 #else
 	ret
 
-	FUN_END(inner_kernel_dgemm_nt_8x6_lib8c)
+	FUN_END(inner_kernel_dgemm_nt_vx7_lib8c)
 #endif
 
 
@@ -841,10 +842,10 @@
 // output arguments:
 
 #if MACRO_LEVEL>=2
-	.macro INNER_KERNEL_DGEMM_NT_8X5_LIB8C
+	.macro INNER_KERNEL_DGEMM_NT_VX6_LIB8C
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_dgemm_nt_8x5_lib8c)
+	FUN_START(inner_kernel_dgemm_nt_vx6_lib8c)
 #endif
 
 	cmpl	$ 0, %r10d
@@ -862,7 +863,271 @@
 
 	// unroll 0
 //	prefetcht0		0(%r12, %r13, 8)
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	48(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	56(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	addq	%r13, %r12
+
+	// unroll 1
+//	prefetcht0		0(%r12, %r13, 8)
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	48(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	56(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	addq	%r13, %r12
+
+	// unroll 2
+//	prefetcht0		0(%r12, %r13, 8)
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	48(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	56(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	addq	%r13, %r12
+
+	// unroll 3
+//	prefetcht0		0(%r12, %r13, 8)
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	48(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	56(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	addq	%r13, %r12
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean4-up
+
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	48(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	56(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	addq	%r13, %r12
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	48(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	56(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	addq	%r13, %r12
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	48(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	56(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	addq	%r13, %r12
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	48(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	56(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	addq	%r13, %r12
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	48(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	56(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	addq	%r13, %r12
+
+	subl	$ 1, %r10d
+	addq	$ 1*64, %r11
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_vx6_lib8c)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- B
+// r13   <- ldb
+// zmm0  <- []
+// ...
+// zmm7  <- []
+//
+// output arguments:
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_VX5_LIB8C
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_vx5_lib8c)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// preload
+
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+//	prefetcht0		0(%r12, %r13, 8)
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -883,7 +1148,7 @@
 
 	// unroll 1
 //	prefetcht0		0(%r12, %r13, 8)
-	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -904,7 +1169,7 @@
 
 	// unroll 2
 //	prefetcht0		0(%r12, %r13, 8)
-	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -925,7 +1190,7 @@
 
 	// unroll 3
 //	prefetcht0		0(%r12, %r13, 8)
-	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -957,7 +1222,7 @@
 	jle		4f // clean1
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -977,7 +1242,7 @@
 	addq	%r13, %r12
 
 	// unroll 1
-	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -997,7 +1262,7 @@
 	addq	%r13, %r12
 
 	// unroll 2
-	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1017,7 +1282,7 @@
 	addq	%r13, %r12
 
 	// unroll 3
-	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1051,7 +1316,7 @@
 3: // clean up loop
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1084,7 +1349,7 @@
 #else
 	ret
 
-	FUN_END(inner_kernel_dgemm_nt_8x5_lib8c)
+	FUN_END(inner_kernel_dgemm_nt_vx5_lib8c)
 #endif
 
 
@@ -1106,10 +1371,10 @@
 // output arguments:
 
 #if MACRO_LEVEL>=2
-	.macro INNER_KERNEL_DGEMM_NT_8X4_LIB8C
+	.macro INNER_KERNEL_DGEMM_NT_VX4_LIB8C
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_dgemm_nt_8x4_lib8c)
+	FUN_START(inner_kernel_dgemm_nt_vx4_lib8c)
 #endif
 
 	cmpl	$ 0, %r10d
@@ -1131,7 +1396,7 @@
 
 	// unroll 0
 //	prefetcht0		0(%r12, %r13, 8)
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1144,7 +1409,7 @@
 
 	// unroll 1
 //	prefetcht0		0(%r12, %r13, 8)
-	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1157,7 +1422,7 @@
 
 	// unroll 2
 //	prefetcht0		0(%r12, %r13, 8)
-	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1170,7 +1435,7 @@
 
 	// unroll 3
 //	prefetcht0		0(%r12, %r13, 8)
-	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1194,7 +1459,7 @@
 	jle		4f // clean1
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1206,7 +1471,7 @@
 	addq	%r13, %r12
 
 	// unroll 1
-	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1218,7 +1483,7 @@
 	addq	%r13, %r12
 
 	// unroll 2
-	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1230,7 +1495,7 @@
 	addq	%r13, %r12
 
 	// unroll 3
-	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1256,7 +1521,7 @@
 3: // clean up loop
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1288,7 +1553,7 @@
 #else
 	ret
 
-	FUN_END(inner_kernel_dgemm_nt_8x4_lib8c)
+	FUN_END(inner_kernel_dgemm_nt_vx4_lib8c)
 #endif
 
 
@@ -1310,10 +1575,10 @@
 // output arguments:
 
 #if MACRO_LEVEL>=2
-	.macro INNER_KERNEL_DGEMM_NT_8X3_LIB8C
+	.macro INNER_KERNEL_DGEMM_NT_VX3_LIB8C
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_dgemm_nt_8x3_lib8c)
+	FUN_START(inner_kernel_dgemm_nt_vx3_lib8c)
 #endif
 
 	cmpl	$ 0, %r10d
@@ -1335,7 +1600,7 @@
 
 	// unroll 0
 //	prefetcht0		0(%r12, %r13, 8)
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1348,7 +1613,7 @@
 
 	// unroll 1
 //	prefetcht0		0(%r12, %r13, 8)
-	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1361,7 +1626,7 @@
 
 	// unroll 2
 //	prefetcht0		0(%r12, %r13, 8)
-	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1374,7 +1639,7 @@
 
 	// unroll 3
 //	prefetcht0		0(%r12, %r13, 8)
-	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1398,7 +1663,7 @@
 	jle		4f // clean1
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1410,7 +1675,7 @@
 	addq	%r13, %r12
 
 	// unroll 1
-	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1422,7 +1687,7 @@
 	addq	%r13, %r12
 
 	// unroll 2
-	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1434,7 +1699,7 @@
 	addq	%r13, %r12
 
 	// unroll 3
-	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1460,7 +1725,7 @@
 3: // clean up loop
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1492,7 +1757,7 @@
 #else
 	ret
 
-	FUN_END(inner_kernel_dgemm_nt_8x3_lib8c)
+	FUN_END(inner_kernel_dgemm_nt_vx3_lib8c)
 #endif
 
 
@@ -1514,10 +1779,10 @@
 // output arguments:
 
 #if MACRO_LEVEL>=2
-	.macro INNER_KERNEL_DGEMM_NT_8X2_LIB8C
+	.macro INNER_KERNEL_DGEMM_NT_VX2_LIB8C
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_dgemm_nt_8x2_lib8c)
+	FUN_START(inner_kernel_dgemm_nt_vx2_lib8c)
 #endif
 
 	cmpl	$ 0, %r10d
@@ -1539,7 +1804,7 @@
 
 	// unroll 0
 //	prefetcht0		0(%r12, %r13, 8)
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1552,7 +1817,7 @@
 
 	// unroll 1
 //	prefetcht0		0(%r12, %r13, 8)
-	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1565,7 +1830,7 @@
 
 	// unroll 2
 //	prefetcht0		0(%r12, %r13, 8)
-	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1578,7 +1843,7 @@
 
 	// unroll 3
 //	prefetcht0		0(%r12, %r13, 8)
-	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1602,7 +1867,7 @@
 	jle		4f // clean1
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1614,7 +1879,7 @@
 	addq	%r13, %r12
 
 	// unroll 1
-	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1626,7 +1891,7 @@
 	addq	%r13, %r12
 
 	// unroll 2
-	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1638,7 +1903,7 @@
 	addq	%r13, %r12
 
 	// unroll 3
-	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1664,7 +1929,7 @@
 3: // clean up loop
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1696,7 +1961,7 @@
 #else
 	ret
 
-	FUN_END(inner_kernel_dgemm_nt_8x2_lib8c)
+	FUN_END(inner_kernel_dgemm_nt_vx2_lib8c)
 #endif
 
 
@@ -1718,10 +1983,10 @@
 // output arguments:
 
 #if MACRO_LEVEL>=2
-	.macro INNER_KERNEL_DGEMM_NT_8X1_LIB8C
+	.macro INNER_KERNEL_DGEMM_NT_VX1_LIB8C
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_dgemm_nt_8x1_lib8c)
+	FUN_START(inner_kernel_dgemm_nt_vx1_lib8c)
 #endif
 
 	cmpl	$ 0, %r10d
@@ -1743,7 +2008,7 @@
 
 	// unroll 0
 //	prefetcht0		0(%r12, %r13, 8)
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 //	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1756,7 +2021,7 @@
 
 	// unroll 1
 //	prefetcht0		0(%r12, %r13, 8)
-	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 //	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1769,7 +2034,7 @@
 
 	// unroll 2
 //	prefetcht0		0(%r12, %r13, 8)
-	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 //	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1782,7 +2047,7 @@
 
 	// unroll 3
 //	prefetcht0		0(%r12, %r13, 8)
-	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 //	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1806,7 +2071,7 @@
 	jle		4f // clean1
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 //	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1818,7 +2083,7 @@
 	addq	%r13, %r12
 
 	// unroll 1
-	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 //	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1830,7 +2095,7 @@
 	addq	%r13, %r12
 
 	// unroll 2
-	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 //	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1842,7 +2107,7 @@
 	addq	%r13, %r12
 
 	// unroll 3
-	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 //	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1868,7 +2133,7 @@
 3: // clean up loop
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 //	vbroadcastsd	8(%r12), %zmm24 // B
@@ -1900,7 +2165,161 @@
 #else
 	ret
 
-	FUN_END(inner_kernel_dgemm_nt_8x1_lib8c)
+	FUN_END(inner_kernel_dgemm_nt_vx1_lib8c)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- B
+// r13   <- ldb
+// r14   <- m1
+// r15   <- n1
+// zmm0  <- []
+// ...
+// zmm15 <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- B+8*k*sizeof(double)
+// r13   <- ldb
+// r14   <- m1
+// r15   <- n1
+// zmm0  <- []
+// ...
+// zmm15 <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_8X8_VS_LIB8C
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_8x8_vs_lib8c)
+#endif
+
+	// compute mask for rows
+	vcvtsi2sd	%r14d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC00(%rip), %zmm24
+#elif defined(OS_MAC)
+	vmovupd		LC00(%rip), %zmm24
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm24, %zmm25
+	vpmovq2m	%zmm25, %k1
+
+	cmpl	$ 1, %r15d
+	jg		100f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_VX1_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nt_vx1_lib8c)
+#endif
+	
+	jmp		107f
+
+100:
+
+	cmpl	$ 2, %r15d
+	jg		101f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_VX2_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nt_vx2_lib8c)
+#endif
+	
+	jmp		107f
+
+101:
+
+	cmpl	$ 3, %r15d
+	jg		102f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_VX3_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nt_vx3_lib8c)
+#endif
+	
+	jmp		107f
+
+102:
+
+	cmpl	$ 4, %r15d
+	jg		103f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_VX4_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nt_vx4_lib8c)
+#endif
+	
+	jmp		107f
+
+103:
+
+	cmpl	$ 5, %r15d
+	jg		104f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_VX5_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nt_vx5_lib8c)
+#endif
+	
+	jmp		107f
+
+104:
+
+	cmpl	$ 6, %r15d
+	jg		105f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_VX6_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nt_vx6_lib8c)
+#endif
+	
+	jmp		107f
+
+105:
+
+	cmpl	$ 7, %r15d
+	jg		106f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_VX7_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nt_vx7_lib8c)
+#endif
+	
+	jmp		107f
+
+106:
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_VX8_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nt_vx8_lib8c)
+#endif
+
+107:
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_8x8_vs_lib8c)
 #endif
 
 
@@ -2184,10 +2603,10 @@
 // output arguments:
 
 #if MACRO_LEVEL>=2
-	.macro INNER_KERNEL_DGEMM_NN_8X7_LIB8C
+	.macro INNER_KERNEL_DGEMM_NN_VX8_LIB8C
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_dgemm_nn_8x7_lib8c)
+	FUN_START(inner_kernel_dgemm_nn_vx8_lib8c)
 #endif
 
 	cmpl	$ 0, %r10d
@@ -2210,7 +2629,270 @@
 //	...
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	0*8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	0*8(%r12, %r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	0*8(%r12, %r13, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	0*8(%r12, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	0*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	0*8(%r15, %r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	0*8(%r15, %r13, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	0*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	1*8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	1*8(%r12, %r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	1*8(%r12, %r13, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	1*8(%r12, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	1*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	1*8(%r15, %r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	1*8(%r15, %r13, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	1*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	2*8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	2*8(%r12, %r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	2*8(%r12, %r13, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	2*8(%r12, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	2*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	2*8(%r15, %r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	2*8(%r15, %r13, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	2*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	3*8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	3*8(%r12, %r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	3*8(%r12, %r13, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	3*8(%r12, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	3*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	3*8(%r15, %r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	3*8(%r15, %r13, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	3*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+	addq	$ 4*8, %r12
+	addq	$ 4*8, %r15
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean4-up
+
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	0*8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	0*8(%r12, %r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	0*8(%r12, %r13, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	0*8(%r12, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	0*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	0*8(%r15, %r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	0*8(%r15, %r13, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	0*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	// unroll 1
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	1*8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	1*8(%r12, %r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	1*8(%r12, %r13, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	1*8(%r12, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	1*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	1*8(%r15, %r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	1*8(%r15, %r13, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	1*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	// unroll 2
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	2*8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	2*8(%r12, %r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	2*8(%r12, %r13, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	2*8(%r12, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	2*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	2*8(%r15, %r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	2*8(%r15, %r13, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	2*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	// unroll 3
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	3*8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	3*8(%r12, %r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	3*8(%r12, %r13, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	3*8(%r12, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	3*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	3*8(%r15, %r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	3*8(%r15, %r13, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	3*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r11
+	addq	$ 4*8, %r12
+	addq	$ 4*8, %r15
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	0*8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	0*8(%r12, %r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	0*8(%r12, %r13, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	0*8(%r12, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	0*8(%r15), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	0*8(%r15, %r13), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	0*8(%r15, %r13, 2), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	0*8(%r15, %rax), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	subl	$ 1, %r10d
+	addq	$ 1*64, %r11
+	addq	$ 1*8, %r12
+	addq	$ 1*8, %r15
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_vx8_lib8c)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- B
+// r13   <- ldb
+// zmm0  <- []
+// ...
+// zmm7  <- []
+//
+// output arguments:
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_VX7_LIB8C
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_vx7_lib8c)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	leaq	0(%r12, %r13, 4), %r15
+	leaq	0(%r13, %r13, 2), %rax
+
+	// preload
+
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+//	prefetcht0		32(%r12)
+//	...
+
+	// unroll 0
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	0*8(%r12, %r13), %zmm24 // B
@@ -2229,7 +2911,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 
 	// unroll 1
-	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	1*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	1*8(%r12, %r13), %zmm24 // B
@@ -2248,7 +2930,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 
 	// unroll 2
-	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	2*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	2*8(%r12, %r13), %zmm24 // B
@@ -2267,7 +2949,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 
 	// unroll 3
-	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	3*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	3*8(%r12, %r13), %zmm24 // B
@@ -2300,7 +2982,7 @@
 	jle		4f // clean1
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	0*8(%r12, %r13), %zmm24 // B
@@ -2319,7 +3001,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 
 	// unroll 1
-	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	1*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	1*8(%r12, %r13), %zmm24 // B
@@ -2338,7 +3020,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 
 	// unroll 2
-	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	2*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	2*8(%r12, %r13), %zmm24 // B
@@ -2357,7 +3039,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 
 	// unroll 3
-	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	3*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	3*8(%r12, %r13), %zmm24 // B
@@ -2392,7 +3074,7 @@
 3: // clean up loop
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	0*8(%r12, %r13), %zmm24 // B
@@ -2426,7 +3108,7 @@
 #else
 	ret
 
-	FUN_END(inner_kernel_dgemm_nn_8x7_lib8c)
+	FUN_END(inner_kernel_dgemm_nn_vx7_lib8c)
 #endif
 
 
@@ -2447,10 +3129,10 @@
 // output arguments:
 
 #if MACRO_LEVEL>=2
-	.macro INNER_KERNEL_DGEMM_NN_8X6_LIB8C
+	.macro INNER_KERNEL_DGEMM_NN_VX6_LIB8C
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_dgemm_nn_8x6_lib8c)
+	FUN_START(inner_kernel_dgemm_nn_vx6_lib8c)
 #endif
 
 	cmpl	$ 0, %r10d
@@ -2473,7 +3155,7 @@
 //	...
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	0*8(%r12, %r13), %zmm24 // B
@@ -2492,7 +3174,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 
 	// unroll 1
-	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	1*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	1*8(%r12, %r13), %zmm24 // B
@@ -2511,7 +3193,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 
 	// unroll 2
-	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	2*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	2*8(%r12, %r13), %zmm24 // B
@@ -2530,7 +3212,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 
 	// unroll 3
-	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	3*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	3*8(%r12, %r13), %zmm24 // B
@@ -2563,7 +3245,7 @@
 	jle		4f // clean1
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	0*8(%r12, %r13), %zmm24 // B
@@ -2582,7 +3264,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 
 	// unroll 1
-	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	1*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	1*8(%r12, %r13), %zmm24 // B
@@ -2601,7 +3283,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 
 	// unroll 2
-	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	2*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	2*8(%r12, %r13), %zmm24 // B
@@ -2620,7 +3302,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 
 	// unroll 3
-	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	3*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	3*8(%r12, %r13), %zmm24 // B
@@ -2655,7 +3337,7 @@
 3: // clean up loop
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	0*8(%r12, %r13), %zmm24 // B
@@ -2689,7 +3371,7 @@
 #else
 	ret
 
-	FUN_END(inner_kernel_dgemm_nn_8x6_lib8c)
+	FUN_END(inner_kernel_dgemm_nn_vx6_lib8c)
 #endif
 
 
@@ -2710,10 +3392,10 @@
 // output arguments:
 
 #if MACRO_LEVEL>=2
-	.macro INNER_KERNEL_DGEMM_NN_8X5_LIB8C
+	.macro INNER_KERNEL_DGEMM_NN_VX5_LIB8C
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_dgemm_nn_8x5_lib8c)
+	FUN_START(inner_kernel_dgemm_nn_vx5_lib8c)
 #endif
 
 	cmpl	$ 0, %r10d
@@ -2736,7 +3418,7 @@
 //	...
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	0*8(%r12, %r13), %zmm24 // B
@@ -2755,7 +3437,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 
 	// unroll 1
-	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	1*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	1*8(%r12, %r13), %zmm24 // B
@@ -2774,7 +3456,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 
 	// unroll 2
-	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	2*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	2*8(%r12, %r13), %zmm24 // B
@@ -2793,7 +3475,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 
 	// unroll 3
-	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	3*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	3*8(%r12, %r13), %zmm24 // B
@@ -2826,7 +3508,7 @@
 	jle		4f // clean1
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	0*8(%r12, %r13), %zmm24 // B
@@ -2845,7 +3527,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 
 	// unroll 1
-	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	1*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	1*8(%r12, %r13), %zmm24 // B
@@ -2864,7 +3546,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 
 	// unroll 2
-	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	2*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	2*8(%r12, %r13), %zmm24 // B
@@ -2883,7 +3565,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 
 	// unroll 3
-	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	3*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	3*8(%r12, %r13), %zmm24 // B
@@ -2918,7 +3600,7 @@
 3: // clean up loop
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	0*8(%r12, %r13), %zmm24 // B
@@ -2952,7 +3634,7 @@
 #else
 	ret
 
-	FUN_END(inner_kernel_dgemm_nn_8x5_lib8c)
+	FUN_END(inner_kernel_dgemm_nn_vx5_lib8c)
 #endif
 
 
@@ -2974,10 +3656,10 @@
 // output arguments:
 
 #if MACRO_LEVEL>=2
-	.macro INNER_KERNEL_DGEMM_NN_8X4_LIB8C
+	.macro INNER_KERNEL_DGEMM_NN_VX4_LIB8C
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_dgemm_nn_8x4_lib8c)
+	FUN_START(inner_kernel_dgemm_nn_vx4_lib8c)
 #endif
 
 	cmpl	$ 0, %r10d
@@ -3003,7 +3685,7 @@
 //	...
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	0*8(%r12, %r13), %zmm24 // B
@@ -3014,7 +3696,7 @@
 	vfmadd231pd		%zmm25, %zmm24, %zmm3
 
 	// unroll 1
-	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	1*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	1*8(%r12, %r13), %zmm24 // B
@@ -3025,7 +3707,7 @@
 	vfmadd231pd		%zmm25, %zmm24, %zmm7
 
 	// unroll 2
-	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	2*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	2*8(%r12, %r13), %zmm24 // B
@@ -3036,7 +3718,7 @@
 	vfmadd231pd		%zmm25, %zmm24, %zmm3
 
 	// unroll 3
-	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	3*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	3*8(%r12, %r13), %zmm24 // B
@@ -3060,7 +3742,7 @@
 	jle		4f // clean1
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	0*8(%r12, %r13), %zmm24 // B
@@ -3071,7 +3753,7 @@
 	vfmadd231pd		%zmm25, %zmm24, %zmm3
 
 	// unroll 1
-	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	1*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	1*8(%r12, %r13), %zmm24 // B
@@ -3082,7 +3764,7 @@
 	vfmadd231pd		%zmm25, %zmm24, %zmm7
 
 	// unroll 2
-	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	2*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	2*8(%r12, %r13), %zmm24 // B
@@ -3093,7 +3775,7 @@
 	vfmadd231pd		%zmm25, %zmm24, %zmm3
 
 	// unroll 3
-	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	3*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	3*8(%r12, %r13), %zmm24 // B
@@ -3119,7 +3801,7 @@
 3: // clean up loop
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	0*8(%r12, %r13), %zmm24 // B
@@ -3151,7 +3833,7 @@
 #else
 	ret
 
-	FUN_END(inner_kernel_dgemm_nn_8x4_lib8c)
+	FUN_END(inner_kernel_dgemm_nn_vx4_lib8c)
 #endif
 
 
@@ -3173,10 +3855,10 @@
 // output arguments:
 
 #if MACRO_LEVEL>=2
-	.macro INNER_KERNEL_DGEMM_NN_8X3_LIB8C
+	.macro INNER_KERNEL_DGEMM_NN_VX3_LIB8C
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_dgemm_nn_8x3_lib8c)
+	FUN_START(inner_kernel_dgemm_nn_vx3_lib8c)
 #endif
 
 	cmpl	$ 0, %r10d
@@ -3202,7 +3884,7 @@
 //	...
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	0*8(%r12, %r13), %zmm24 // B
@@ -3213,7 +3895,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm3
 
 	// unroll 1
-	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	1*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	1*8(%r12, %r13), %zmm24 // B
@@ -3224,7 +3906,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 
 	// unroll 2
-	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	2*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	2*8(%r12, %r13), %zmm24 // B
@@ -3235,7 +3917,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm3
 
 	// unroll 3
-	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	3*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	3*8(%r12, %r13), %zmm24 // B
@@ -3259,7 +3941,7 @@
 	jle		4f // clean1
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	0*8(%r12, %r13), %zmm24 // B
@@ -3270,7 +3952,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm3
 
 	// unroll 1
-	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	1*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	1*8(%r12, %r13), %zmm24 // B
@@ -3281,7 +3963,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 
 	// unroll 2
-	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	2*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	2*8(%r12, %r13), %zmm24 // B
@@ -3292,7 +3974,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm3
 
 	// unroll 3
-	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	3*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	3*8(%r12, %r13), %zmm24 // B
@@ -3318,7 +4000,7 @@
 3: // clean up loop
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	0*8(%r12, %r13), %zmm24 // B
@@ -3350,7 +4032,7 @@
 #else
 	ret
 
-	FUN_END(inner_kernel_dgemm_nn_8x3_lib8c)
+	FUN_END(inner_kernel_dgemm_nn_vx3_lib8c)
 #endif
 
 
@@ -3372,10 +4054,10 @@
 // output arguments:
 
 #if MACRO_LEVEL>=2
-	.macro INNER_KERNEL_DGEMM_NN_8X2_LIB8C
+	.macro INNER_KERNEL_DGEMM_NN_VX2_LIB8C
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_dgemm_nn_8x2_lib8c)
+	FUN_START(inner_kernel_dgemm_nn_vx2_lib8c)
 #endif
 
 	cmpl	$ 0, %r10d
@@ -3401,7 +4083,7 @@
 //	...
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	0*8(%r12, %r13), %zmm24 // B
@@ -3412,7 +4094,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm3
 
 	// unroll 1
-	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	1*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	1*8(%r12, %r13), %zmm24 // B
@@ -3423,7 +4105,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 
 	// unroll 2
-	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	2*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	2*8(%r12, %r13), %zmm24 // B
@@ -3434,7 +4116,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm3
 
 	// unroll 3
-	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	3*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	3*8(%r12, %r13), %zmm24 // B
@@ -3458,7 +4140,7 @@
 	jle		4f // clean1
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	0*8(%r12, %r13), %zmm24 // B
@@ -3469,7 +4151,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm3
 
 	// unroll 1
-	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	1*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	1*8(%r12, %r13), %zmm24 // B
@@ -3480,7 +4162,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 
 	// unroll 2
-	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	2*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	2*8(%r12, %r13), %zmm24 // B
@@ -3491,7 +4173,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm3
 
 	// unroll 3
-	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	3*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	3*8(%r12, %r13), %zmm24 // B
@@ -3517,7 +4199,7 @@
 3: // clean up loop
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vbroadcastsd	0*8(%r12, %r13), %zmm24 // B
@@ -3549,7 +4231,7 @@
 #else
 	ret
 
-	FUN_END(inner_kernel_dgemm_nn_8x2_lib8c)
+	FUN_END(inner_kernel_dgemm_nn_vx2_lib8c)
 #endif
 
 
@@ -3571,10 +4253,10 @@
 // output arguments:
 
 #if MACRO_LEVEL>=2
-	.macro INNER_KERNEL_DGEMM_NN_8X1_LIB8C
+	.macro INNER_KERNEL_DGEMM_NN_VX1_LIB8C
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_dgemm_nn_8x1_lib8c)
+	FUN_START(inner_kernel_dgemm_nn_vx1_lib8c)
 #endif
 
 	cmpl	$ 0, %r10d
@@ -3600,7 +4282,7 @@
 //	...
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 //	vbroadcastsd	0*8(%r12, %r13), %zmm24 // B
@@ -3611,7 +4293,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm3
 
 	// unroll 1
-	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	1*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 //	vbroadcastsd	1*8(%r12, %r13), %zmm24 // B
@@ -3622,7 +4304,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 
 	// unroll 2
-	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	2*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 //	vbroadcastsd	2*8(%r12, %r13), %zmm24 // B
@@ -3633,7 +4315,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm3
 
 	// unroll 3
-	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	3*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 //	vbroadcastsd	3*8(%r12, %r13), %zmm24 // B
@@ -3657,7 +4339,7 @@
 	jle		4f // clean1
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 //	vbroadcastsd	0*8(%r12, %r13), %zmm24 // B
@@ -3668,7 +4350,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm3
 
 	// unroll 1
-	vmovapd			1*64(%r11), %zmm25 // A
+	vmovapd			1*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	1*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 //	vbroadcastsd	1*8(%r12, %r13), %zmm24 // B
@@ -3679,7 +4361,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm7
 
 	// unroll 2
-	vmovapd			2*64(%r11), %zmm25 // A
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	2*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 //	vbroadcastsd	2*8(%r12, %r13), %zmm24 // B
@@ -3690,7 +4372,7 @@
 //	vfmadd231pd		%zmm25, %zmm24, %zmm3
 
 	// unroll 3
-	vmovapd			3*64(%r11), %zmm25 // A
+	vmovapd			3*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	3*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 //	vbroadcastsd	3*8(%r12, %r13), %zmm24 // B
@@ -3716,7 +4398,7 @@
 3: // clean up loop
 
 	// unroll 0
-	vmovapd			0*64(%r11), %zmm25 // A
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
 	vbroadcastsd	0*8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 //	vbroadcastsd	0*8(%r12, %r13), %zmm24 // B
@@ -3748,7 +4430,161 @@
 #else
 	ret
 
-	FUN_END(inner_kernel_dgemm_nn_8x1_lib8c)
+	FUN_END(inner_kernel_dgemm_nn_vx1_lib8c)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- B
+// r13   <- ldb
+// r14   <- m1
+// r15   <- n1
+// zmm0  <- []
+// ...
+// zmm15 <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- B+8*k*sizeof(double)
+// r13   <- ldb
+// r14   <- m1
+// r15   <- n1
+// zmm0  <- []
+// ...
+// zmm15 <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_8X8_VS_LIB8C
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_8x8_vs_lib8c)
+#endif
+
+	// compute mask for rows
+	vcvtsi2sd	%r14d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC00(%rip), %zmm24
+#elif defined(OS_MAC)
+	vmovupd		LC00(%rip), %zmm24
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm24, %zmm25
+	vpmovq2m	%zmm25, %k1
+
+	cmpl	$ 1, %r15d
+	jg		100f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_VX1_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nn_vx1_lib8c)
+#endif
+	
+	jmp		107f
+
+100:
+
+	cmpl	$ 2, %r15d
+	jg		101f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_VX2_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nn_vx2_lib8c)
+#endif
+	
+	jmp		107f
+
+101:
+
+	cmpl	$ 3, %r15d
+	jg		102f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_VX3_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nn_vx3_lib8c)
+#endif
+	
+	jmp		107f
+
+102:
+
+	cmpl	$ 4, %r15d
+	jg		103f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_VX4_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nn_vx4_lib8c)
+#endif
+	
+	jmp		107f
+
+103:
+
+	cmpl	$ 5, %r15d
+	jg		104f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_VX5_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nn_vx5_lib8c)
+#endif
+	
+	jmp		107f
+
+104:
+
+	cmpl	$ 6, %r15d
+	jg		105f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_VX6_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nn_vx6_lib8c)
+#endif
+	
+	jmp		107f
+
+105:
+
+	cmpl	$ 7, %r15d
+	jg		106f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_VX7_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nn_vx7_lib8c)
+#endif
+	
+	jmp		107f
+
+106:
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_VX8_LIB8C
+#else
+	CALL(inner_kernel_dgemm_nn_vx8_lib8c)
+#endif
+
+107:
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_8x8_vs_lib8c)
 #endif
 
 
@@ -4198,113 +5034,14 @@
 	movq	ARG4, %r12  // B
 	movq	ARG5, %r13  // ldb
 	sall	$ 3, %r13d
-
-
-	movq	ARG12, %r14  // n1
-	cmpl	$ 1, %r14d
-	jg		100f
+	movq	ARG11, %r14 // m1
+	movq	ARG12, %r15 // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_8X1_LIB8C
+	INNER_KERNEL_DGEMM_NT_8X8_VS_LIB8C
 #else
-	CALL(inner_kernel_dgemm_nt_8x1_lib8c)
+	CALL(inner_kernel_dgemm_nt_8x8_vs_lib8c)
 #endif
-	
-	jmp		107f
-
-100:
-
-	movq	ARG12, %r14  // n1
-	cmpl	$ 2, %r14d
-	jg		101f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_8X2_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nt_8x2_lib8c)
-#endif
-
-	jmp		107f
-
-101:
-
-	movq	ARG12, %r14  // n1
-	cmpl	$ 3, %r14d
-	jg		102f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_8X3_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nt_8x3_lib8c)
-#endif
-
-	jmp		107f
-
-102:
-
-	movq	ARG12, %r14  // n1
-	cmpl	$ 4, %r14d
-	jg		103f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_8X4_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nt_8x4_lib8c)
-#endif
-
-	jmp		107f
-
-103:
-
-	movq	ARG12, %r14  // n1
-	cmpl	$ 5, %r14d
-	jg		104f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_8X5_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nt_8x5_lib8c)
-#endif
-
-	jmp		107f
-
-104:
-
-	movq	ARG12, %r14  // n1
-	cmpl	$ 6, %r14d
-	jg		105f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_8X6_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nt_8x6_lib8c)
-#endif
-
-	jmp		107f
-
-105:
-
-	movq	ARG12, %r14  // n1
-	cmpl	$ 7, %r14d
-	jg		106f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_8X7_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nt_8x7_lib8c)
-#endif
-
-	jmp		107f
-
-106:
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_8X8_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nt_8x8_lib8c)
-#endif
-
-107:
 
 
 	// prefetch D
@@ -4466,11 +5203,13 @@
 	movq	ARG1, %r10 // k
 	movq	ARG3, %r11  // A
 	movq	ARG4, %r12  // B
+	movq	ARG10, %r13 // m1
+	movq	ARG11, %r14 // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_8X8_LIB8
+	INNER_KERNEL_DGEMM_NT_8X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_8x8_lib8)
+	CALL(inner_kernel_dgemm_nt_8x8_vs_lib8)
 #endif
 
 
@@ -4608,113 +5347,14 @@
 	movq	ARG3, %r12  // A
 	movq	ARG4, %r13  // lda
 	sall	$ 3, %r13d
-
-
-	movq	ARG11, %r14  // m1
-	cmpl	$ 1, %r14d
-	jg		100f
+	movq	ARG12, %r14 // n1
+	movq	ARG11, %r15 // m1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_8X1_LIB8C
+	INNER_KERNEL_DGEMM_NT_8X8_VS_LIB8C
 #else
-	CALL(inner_kernel_dgemm_nt_8x1_lib8c)
+	CALL(inner_kernel_dgemm_nt_8x8_vs_lib8c)
 #endif
-	
-	jmp		107f
-
-100:
-
-	movq	ARG11, %r14  // m1
-	cmpl	$ 2, %r14d
-	jg		101f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_8X2_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nt_8x2_lib8c)
-#endif
-
-	jmp		107f
-
-101:
-
-	movq	ARG11, %r14  // m1
-	cmpl	$ 3, %r14d
-	jg		102f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_8X3_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nt_8x3_lib8c)
-#endif
-
-	jmp		107f
-
-102:
-
-	movq	ARG11, %r14  // m1
-	cmpl	$ 4, %r14d
-	jg		103f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_8X4_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nt_8x4_lib8c)
-#endif
-
-	jmp		107f
-
-103:
-
-	movq	ARG11, %r14  // m1
-	cmpl	$ 5, %r14d
-	jg		104f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_8X5_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nt_8x5_lib8c)
-#endif
-
-	jmp		107f
-
-104:
-
-	movq	ARG11, %r14  // m1
-	cmpl	$ 6, %r14d
-	jg		105f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_8X6_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nt_8x6_lib8c)
-#endif
-
-	jmp		107f
-
-105:
-
-	movq	ARG11, %r14  // m1
-	cmpl	$ 7, %r14d
-	jg		106f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_8X7_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nt_8x7_lib8c)
-#endif
-
-	jmp		107f
-
-106:
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_8X8_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nt_8x8_lib8c)
-#endif
-
-107:
 
 #if MACRO_LEVEL>=1
 	INNER_TRAN_8X8_LIB8
@@ -4878,113 +5518,14 @@
 	movq	ARG4, %r12  // B
 	movq	ARG5, %r13  // ldb
 	sall	$ 3, %r13d
-
-
-	movq	ARG12, %r14  // n1
-	cmpl	$ 1, %r14d
-	jg		100f
+	movq	ARG11, %r14 // m1
+	movq	ARG12, %r15 // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_8X1_LIB8C
+	INNER_KERNEL_DGEMM_NN_8X8_VS_LIB8C
 #else
-	CALL(inner_kernel_dgemm_nn_8x1_lib8c)
+	CALL(inner_kernel_dgemm_nn_8x8_vs_lib8c)
 #endif
-	
-	jmp		107f
-
-100:
-
-	movq	ARG12, %r14  // n1
-	cmpl	$ 2, %r14d
-	jg		101f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_8X2_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nn_8x2_lib8c)
-#endif
-
-	jmp		107f
-
-101:
-
-	movq	ARG12, %r14  // n1
-	cmpl	$ 3, %r14d
-	jg		102f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_8X3_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nn_8x3_lib8c)
-#endif
-
-	jmp		107f
-
-102:
-
-	movq	ARG12, %r14  // n1
-	cmpl	$ 4, %r14d
-	jg		103f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_8X4_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nn_8x4_lib8c)
-#endif
-
-	jmp		107f
-
-103:
-
-	movq	ARG12, %r14  // n1
-	cmpl	$ 5, %r14d
-	jg		104f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_8X5_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nn_8x5_lib8c)
-#endif
-
-	jmp		107f
-
-104:
-
-	movq	ARG12, %r14  // n1
-	cmpl	$ 6, %r14d
-	jg		105f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_8X6_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nn_8x6_lib8c)
-#endif
-
-	jmp		107f
-
-105:
-
-	movq	ARG12, %r14  // n1
-	cmpl	$ 7, %r14d
-	jg		106f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_8X7_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nn_8x7_lib8c)
-#endif
-
-	jmp		107f
-
-106:
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_8X8_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nn_8x8_lib8c)
-#endif
-
-107:
 
 
 	// prefetch D
@@ -5135,113 +5676,14 @@
 	movq	ARG3, %r12  // A
 	movq	ARG4, %r13  // lda
 	sall	$ 3, %r13d
-
-
-	movq	ARG11, %r14  // m1
-	cmpl	$ 1, %r14d
-	jg		100f
+	movq	ARG12, %r14 // n1
+	movq	ARG11, %r15 // m1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_8X1_LIB8C
+	INNER_KERNEL_DGEMM_NN_8X8_VS_LIB8C
 #else
-	CALL(inner_kernel_dgemm_nn_8x1_lib8c)
+	CALL(inner_kernel_dgemm_nn_8x8_vs_lib8c)
 #endif
-	
-	jmp		107f
-
-100:
-
-	movq	ARG11, %r14  // m1
-	cmpl	$ 2, %r14d
-	jg		101f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_8X2_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nn_8x2_lib8c)
-#endif
-
-	jmp		107f
-
-101:
-
-	movq	ARG11, %r14  // m1
-	cmpl	$ 3, %r14d
-	jg		102f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_8X3_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nn_8x3_lib8c)
-#endif
-
-	jmp		107f
-
-102:
-
-	movq	ARG11, %r14  // m1
-	cmpl	$ 4, %r14d
-	jg		103f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_8X4_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nn_8x4_lib8c)
-#endif
-
-	jmp		107f
-
-103:
-
-	movq	ARG11, %r14  // m1
-	cmpl	$ 5, %r14d
-	jg		104f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_8X5_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nn_8x5_lib8c)
-#endif
-
-	jmp		107f
-
-104:
-
-	movq	ARG11, %r14  // m1
-	cmpl	$ 6, %r14d
-	jg		105f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_8X6_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nn_8x6_lib8c)
-#endif
-
-	jmp		107f
-
-105:
-
-	movq	ARG11, %r14  // m1
-	cmpl	$ 7, %r14d
-	jg		106f
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_8X7_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nn_8x7_lib8c)
-#endif
-
-	jmp		107f
-
-106:
-
-#if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_8X8_LIB8C
-#else
-	CALL(inner_kernel_dgemm_nn_8x8_lib8c)
-#endif
-
-107:
 
 #if MACRO_LEVEL>=1
 	INNER_TRAN_8X8_LIB8

--- a/kernel/avx512/kernel_dgemm_8x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_8x8_lib8.S
@@ -3055,13 +3055,8 @@ NAME:
 	vmulpd			%zmm0, %zmm26, %zmm0
 	cmpl			$ 2, %r11d
 	jl				0f // ret
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+1*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+1*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm0, %zmm27, %zmm27
-	vfnmadd231pd	%zmm0, %zmm27, %zmm1
+	vmovapd			%zmm1, %zmm26
+	vfnmadd231pd	%zmm0, %zmm0, %zmm26
 
 	// 1
 //	vpermilpd		$ 0x3, %xmm1, %xmm26
@@ -3070,12 +3065,19 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+1*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm1, %zmm27, %zmm26
+	vpermpd			%zmm26, %zmm27, %zmm26
 	vucomisd		%xmm25, %xmm26 // d_11 > 0.0 ?
 	jbe				3f
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 4:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm1
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
 	vbroadcastsd	.LC05+2*8(%rip), %zmm27
 #elif defined(OS_MAC)
@@ -3123,13 +3125,8 @@ NAME:
 	vmulpd			%zmm1, %zmm26, %zmm1
 	cmpl			$ 3, %r11d
 	jl				0f // ret
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+2*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+2*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm1, %zmm27, %zmm27
-	vfnmadd231pd	%zmm1, %zmm27, %zmm2
+	vmovapd			%zmm2, %zmm26
+	vfnmadd231pd	%zmm1, %zmm1, %zmm26
 
 	// 2
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -3137,12 +3134,19 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+2*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm2, %zmm27, %zmm26
+	vpermpd			%zmm26, %zmm27, %zmm26
 	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
 	jbe				5f
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 6:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm2
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
 	vbroadcastsd	.LC05+3*8(%rip), %zmm27
 #elif defined(OS_MAC)
@@ -3183,13 +3187,8 @@ NAME:
 	vmulpd			%zmm2, %zmm26, %zmm2
 	cmpl			$ 4, %r11d
 	jl				0f // ret
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+3*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+3*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm2, %zmm27, %zmm27
-	vfnmadd231pd	%zmm2, %zmm27, %zmm3
+	vmovapd			%zmm3, %zmm26
+	vfnmadd231pd	%zmm2, %zmm2, %zmm26
 
 	// 3
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -3197,12 +3196,19 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+3*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm3, %zmm27, %zmm26
+	vpermpd			%zmm26, %zmm27, %zmm26
 	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
 	jbe				7f
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 8:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm27
+	vfnmadd231pd	%zmm2, %zmm27, %zmm3
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
 	vbroadcastsd	.LC05+4*8(%rip), %zmm27
 #elif defined(OS_MAC)
@@ -3236,13 +3242,8 @@ NAME:
 	vmulpd			%zmm3, %zmm26, %zmm3
 	cmpl			$ 5, %r11d
 	jl				0f // ret
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+4*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+4*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm3, %zmm27, %zmm27
-	vfnmadd231pd	%zmm3, %zmm27, %zmm4
+	vmovapd			%zmm4, %zmm26
+	vfnmadd231pd	%zmm3, %zmm3, %zmm26
 
 	// 4
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -3250,12 +3251,19 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+4*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm4, %zmm27, %zmm26
+	vpermpd			%zmm26, %zmm27, %zmm26
 	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
 	jbe				9f
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 10:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm3, %zmm27, %zmm27
+	vfnmadd231pd	%zmm3, %zmm27, %zmm4
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
 	vbroadcastsd	.LC05+5*8(%rip), %zmm27
 #elif defined(OS_MAC)
@@ -3282,13 +3290,8 @@ NAME:
 	vmulpd			%zmm4, %zmm26, %zmm4
 	cmpl			$ 6, %r11d
 	jl				0f // ret
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+5*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+5*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm4, %zmm27, %zmm27
-	vfnmadd231pd	%zmm4, %zmm27, %zmm5
+	vmovapd			%zmm5, %zmm26
+	vfnmadd231pd	%zmm4, %zmm4, %zmm26
 
 	// 5
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -3296,12 +3299,19 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+5*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm5, %zmm27, %zmm26
+	vpermpd			%zmm26, %zmm27, %zmm26
 	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
 	jbe				11f
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 12:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm4, %zmm27, %zmm27
+	vfnmadd231pd	%zmm4, %zmm27, %zmm5
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
 	vbroadcastsd	.LC05+6*8(%rip), %zmm27
 #elif defined(OS_MAC)
@@ -3321,13 +3331,8 @@ NAME:
 	vmulpd			%zmm5, %zmm26, %zmm5
 	cmpl			$ 7, %r11d
 	jl				0f // ret
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+6*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+6*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm5, %zmm27, %zmm27
-	vfnmadd231pd	%zmm5, %zmm27, %zmm6
+	vmovapd			%zmm6, %zmm26
+	vfnmadd231pd	%zmm5, %zmm5, %zmm26
 
 	// 6
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -3335,12 +3340,19 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+6*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm6, %zmm27, %zmm26
+	vpermpd			%zmm26, %zmm27, %zmm26
 	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
 	jbe				13f
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 14:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm5, %zmm27, %zmm27
+	vfnmadd231pd	%zmm5, %zmm27, %zmm6
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
 	vbroadcastsd	.LC05+7*8(%rip), %zmm27
 #elif defined(OS_MAC)
@@ -3353,13 +3365,8 @@ NAME:
 	vmulpd			%zmm6, %zmm26, %zmm6
 	cmpl			$ 8, %r11d
 	jl				0f // ret
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+7*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+7*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm6, %zmm27, %zmm26
-	vfnmadd231pd	%zmm6, %zmm26, %zmm7
+	vmovapd			%zmm7, %zmm26
+	vfnmadd231pd	%zmm6, %zmm6, %zmm26
 
 	// 7
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -3367,12 +3374,19 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+7*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm7, %zmm27, %zmm26
+	vpermpd			%zmm26, %zmm27, %zmm26
 	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
 	jbe				15f
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 16:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm6, %zmm27, %zmm27
+	vfnmadd231pd	%zmm6, %zmm27, %zmm7
 	vmovsd			%xmm26, 56(%r10)
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm7, %zmm26, %zmm7

--- a/kernel/avx512/kernel_dgemm_8x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_8x8_lib8.S
@@ -944,6 +944,175 @@ NAME:
 
 // common inner routine with file scope
 //
+// input arguments:
+// r10d  <- k
+// r11   <- B
+// r12   <- C
+// zmm0  <- [a00 ... a70]
+// ...
+// zmm7  <- [a07 ... a77]
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- ?
+// r12   <- ?
+// zmm0  <- [a00 ... a70]
+// ...
+// zmm7  <- [a07 ... a77]
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEBP_NN_8X8_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgebp_nn_8x8_lib8)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		0f // return
+
+	cmpl	$ 3, %r10d
+	jle		2f // cleanup loop
+
+	// main loop
+	.p2align 
+1:
+	// merged k-iter 0-3 to have more independent acc
+	vmovapd			0*64(%r12), %zmm28
+	vbroadcastsd	0+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm28
+	vmovapd			1*64(%r12), %zmm29
+	vbroadcastsd	0+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm29
+	vmovapd			2*64(%r12), %zmm30
+	vbroadcastsd	0+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm30
+	vmovapd			3*64(%r12), %zmm31
+	vbroadcastsd	0+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm31
+
+	vbroadcastsd	8+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm28
+	vbroadcastsd	8+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm29
+	vbroadcastsd	8+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm30
+	vbroadcastsd	8+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm31
+
+	vbroadcastsd	16+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm28
+	vbroadcastsd	16+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm29
+	vbroadcastsd	16+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm30
+	vbroadcastsd	16+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm31
+
+	vbroadcastsd	24+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm28
+	vbroadcastsd	24+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm29
+	vbroadcastsd	24+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm30
+	vbroadcastsd	24+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm31
+
+	vbroadcastsd	32+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm28
+	vbroadcastsd	32+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm29
+	vbroadcastsd	32+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm30
+	vbroadcastsd	32+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm31
+
+	vbroadcastsd	40+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm28
+	vbroadcastsd	40+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm29
+	vbroadcastsd	40+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm30
+	vbroadcastsd	40+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm31
+
+	vbroadcastsd	48+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm6, %zmm25, %zmm28
+	vbroadcastsd	48+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm6, %zmm25, %zmm29
+	vbroadcastsd	48+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm6, %zmm25, %zmm30
+	vbroadcastsd	48+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm6, %zmm25, %zmm31
+
+	vbroadcastsd	56+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm7, %zmm25, %zmm28
+	vmovapd			%zmm28, 0*64(%r12)
+	vbroadcastsd	56+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm7, %zmm25, %zmm29
+	vmovapd			%zmm29, 1*64(%r12)
+	vbroadcastsd	56+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm7, %zmm25, %zmm30
+	vmovapd			%zmm30, 2*64(%r12)
+	vbroadcastsd	56+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm7, %zmm25, %zmm31
+	vmovapd			%zmm31, 3*64(%r12)
+
+	addq	$ 256, %r11
+	addq	$ 256, %r12
+	subl	$ 4, %r10d
+
+	cmpl	$ 3, %r10d
+	jg		1b // main loop
+
+	cmpl	$ 0, %r10d
+	jle		0f // return
+
+	// cleanup loop
+2:
+	vmovapd			0*64(%r12), %zmm28
+	vbroadcastsd	0+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm28
+	vbroadcastsd	8+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm28
+	vbroadcastsd	16+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm28
+	vbroadcastsd	24+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm28
+	vbroadcastsd	32+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm28
+	vbroadcastsd	40+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm28
+	vbroadcastsd	48+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm6, %zmm25, %zmm28
+	vbroadcastsd	56+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm7, %zmm25, %zmm28
+	vmovapd			%zmm28, 0*64(%r12)
+
+	subl	$ 1, %r10d
+	addq	$ 64, %r11
+	addq	$ 64, %r12
+
+	cmpl	$ 0, %r10d
+	jg		2b // main loop
+
+	// return
+0:
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgebp_nn_8x8_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
 // edge for B unaligned
 //
 // input arguments:
@@ -6937,6 +7106,301 @@ NAME:
 	ret
 
 	FUN_END(kernel_dsyrk_dpotrf_nt_l_8x8_vs_lib8)
+
+
+
+
+
+//                               1         2           3           4
+// void kernel_dlarfb8_rn_8_lib8(int kmax, double *pV, double *pT, double *pD);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dlarfb8_rn_8_lib8)
+	
+	PROLOGUE
+
+	// zero accumulation registers
+
+//	ZERO_ACC
+
+	movq	ARG1, %r10 // k
+	movq	ARG4, %r11 // D
+	movq	ARG2, %r12 // V
+
+	//
+	vmovapd			0*64(%r11), %zmm0
+	//
+	vmovapd			1*64(%r11), %zmm1
+	vbroadcastsd	1*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm1, %zmm0
+	//
+	vmovapd			2*64(%r11), %zmm2
+	vbroadcastsd	0+2*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm2, %zmm0
+	vbroadcastsd	8+2*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm2, %zmm1
+	//
+	vmovapd			3*64(%r11), %zmm3
+	vbroadcastsd	0+3*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm3, %zmm0
+	vbroadcastsd	8+3*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm3, %zmm1
+	vbroadcastsd	16+3*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm3, %zmm2
+	//
+	vmovapd			4*64(%r11), %zmm4
+	vbroadcastsd	0+4*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm4, %zmm0
+	vbroadcastsd	8+4*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm4, %zmm1
+	vbroadcastsd	16+4*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm4, %zmm2
+	vbroadcastsd	24+4*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm4, %zmm3
+	//
+	vmovapd			5*64(%r11), %zmm5
+	vbroadcastsd	0+5*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm5, %zmm0
+	vbroadcastsd	8+5*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm5, %zmm1
+	vbroadcastsd	16+5*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm5, %zmm2
+	vbroadcastsd	24+5*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm5, %zmm3
+	vbroadcastsd	32+5*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm5, %zmm4
+	//
+	vmovapd			6*64(%r11), %zmm6
+	vbroadcastsd	0+6*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm6, %zmm0
+	vbroadcastsd	8+6*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm6, %zmm1
+	vbroadcastsd	16+6*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm6, %zmm2
+	vbroadcastsd	24+6*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm6, %zmm3
+	vbroadcastsd	32+6*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm6, %zmm4
+	vbroadcastsd	40+6*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm6, %zmm5
+	//
+	vmovapd			7*64(%r11), %zmm7
+	vbroadcastsd	0+7*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm7, %zmm0
+	vbroadcastsd	8+7*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm7, %zmm1
+	vbroadcastsd	16+7*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm7, %zmm2
+	vbroadcastsd	24+7*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm7, %zmm3
+	vbroadcastsd	32+7*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm7, %zmm4
+	vbroadcastsd	40+7*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm7, %zmm5
+	vbroadcastsd	48+7*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm7, %zmm6
+
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+	addq	$ 512, %r12
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_8X8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_8x8_lib8)
+#endif
+
+	movq	ARG3, %r10 // T
+
+	//
+	vbroadcastsd	56+7*64(%r10), %zmm24
+	vmulpd			%zmm7, %zmm24, %zmm7
+	//
+	vbroadcastsd	48+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm6, %zmm24, %zmm7
+	vbroadcastsd	48+6*64(%r10), %zmm24
+	vmulpd			%zmm6, %zmm24, %zmm6
+	//
+	vbroadcastsd	40+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm5, %zmm24, %zmm7
+	vbroadcastsd	40+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm5, %zmm24, %zmm6
+	vbroadcastsd	40+5*64(%r10), %zmm24
+	vmulpd			%zmm5, %zmm24, %zmm5
+	//
+	vbroadcastsd	32+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm7
+	vbroadcastsd	32+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm6
+	vbroadcastsd	32+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm5
+	vbroadcastsd	32+4*64(%r10), %zmm24
+	vmulpd			%zmm4, %zmm24, %zmm4
+	//
+	vbroadcastsd	24+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm7
+	vbroadcastsd	24+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm6
+	vbroadcastsd	24+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm5
+	vbroadcastsd	24+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm4
+	vbroadcastsd	24+3*64(%r10), %zmm24
+	vmulpd			%zmm3, %zmm24, %zmm3
+	//
+	vbroadcastsd	16+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm7
+	vbroadcastsd	16+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm6
+	vbroadcastsd	16+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm5
+	vbroadcastsd	16+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm4
+	vbroadcastsd	16+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm3
+	vbroadcastsd	16+2*64(%r10), %zmm24
+	vmulpd			%zmm2, %zmm24, %zmm2
+	//
+	vbroadcastsd	8+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm7
+	vbroadcastsd	8+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm6
+	vbroadcastsd	8+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm5
+	vbroadcastsd	8+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm4
+	vbroadcastsd	8+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm3
+	vbroadcastsd	8+2*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm2
+	vbroadcastsd	8+1*64(%r10), %zmm24
+	vmulpd			%zmm1, %zmm24, %zmm1
+	//
+	vbroadcastsd	0+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm7
+	vbroadcastsd	0+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm6
+	vbroadcastsd	0+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm5
+	vbroadcastsd	0+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm4
+	vbroadcastsd	0+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm3
+	vbroadcastsd	0+2*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm2
+	vbroadcastsd	0+1*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm1
+	vbroadcastsd	0+0*64(%r10), %zmm24
+	vmulpd			%zmm0, %zmm24, %zmm0
+
+	movq	ARG1, %r10 // k
+	movq	ARG2, %r11 // V
+	movq	ARG4, %r12 // D
+
+	//
+	vmovapd			0+0*64(%r12), %zmm24
+	vaddpd			%zmm24, %zmm0, %zmm24
+	vmovapd			%zmm24, 0+0*64(%r12)
+	//
+	vmovapd			0+1*64(%r12), %zmm24
+	vbroadcastsd	0+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm24
+	vaddpd			%zmm24, %zmm1, %zmm24
+	vmovapd			%zmm24, 0+1*64(%r12)
+	//
+	vmovapd			0+2*64(%r12), %zmm24
+	vbroadcastsd	0+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm24
+	vbroadcastsd	8+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm24
+	vaddpd			%zmm24, %zmm2, %zmm24
+	vmovapd			%zmm24, 0+2*64(%r12)
+	//
+	vmovapd			0+3*64(%r12), %zmm24
+	vbroadcastsd	0+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm24
+	vbroadcastsd	8+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm24
+	vbroadcastsd	16+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm24
+	vaddpd			%zmm24, %zmm3, %zmm24
+	vmovapd			%zmm24, 0+3*64(%r12)
+	//
+	vmovapd			0+4*64(%r12), %zmm24
+	vbroadcastsd	0+4*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm24
+	vbroadcastsd	8+4*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm24
+	vbroadcastsd	16+4*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm24
+	vbroadcastsd	24+4*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm24
+	vaddpd			%zmm24, %zmm4, %zmm24
+	vmovapd			%zmm24, 0+4*64(%r12)
+	//
+	vmovapd			0+5*64(%r12), %zmm24
+	vbroadcastsd	0+5*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm24
+	vbroadcastsd	8+5*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm24
+	vbroadcastsd	16+5*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm24
+	vbroadcastsd	24+5*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm24
+	vbroadcastsd	32+5*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm24
+	vaddpd			%zmm24, %zmm5, %zmm24
+	vmovapd			%zmm24, 0+5*64(%r12)
+	//
+	vmovapd			0+6*64(%r12), %zmm24
+	vbroadcastsd	0+6*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm24
+	vbroadcastsd	8+6*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm24
+	vbroadcastsd	16+6*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm24
+	vbroadcastsd	24+6*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm24
+	vbroadcastsd	32+6*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm24
+	vbroadcastsd	40+6*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm24
+	vaddpd			%zmm24, %zmm6, %zmm24
+	vmovapd			%zmm24, 0+6*64(%r12)
+	//
+	vmovapd			0+7*64(%r12), %zmm24
+	vbroadcastsd	0+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm24
+	vbroadcastsd	8+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm24
+	vbroadcastsd	16+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm24
+	vbroadcastsd	24+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm24
+	vbroadcastsd	32+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm24
+	vbroadcastsd	40+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm24
+	vbroadcastsd	48+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm6, %zmm25, %zmm24
+	vaddpd			%zmm24, %zmm7, %zmm24
+	vmovapd			%zmm24, 0+7*64(%r12)
+
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+	addq	$ 512, %r12
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEBP_NN_8X8_LIB8
+#else
+	CALL(inner_kernel_dgebp_nn_8x8_lib8)
+#endif
+
+	EPILOGUE
+
+	ret
+
+	FUN_END(kernel_dlarfb8_rn_8_lib8)
 
 
 

--- a/kernel/avx512/kernel_dgemm_8x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_8x8_lib8.S
@@ -278,7 +278,7 @@ NAME:
 	.p2align 4,,15
 	FUN_START(inner_kernel_dgemm_nt_8x8_lib8)
 #endif
-	
+
 	cmpl	$ 0, %r10d
 	jle		2f // return
 

--- a/kernel/avx512/kernel_dgemm_8x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_8x8_lib8.S
@@ -6169,10 +6169,10 @@ NAME:
 // zmm7  <- [a07 ... a77]
 
 #if MACRO_LEVEL>=2
-	.macro INNER_KERNEL_DGEBP_NN_VX8_VS_LIB8
+	.macro INNER_KERNEL_DGEBP_NN_VX8_LIB8
 #else
 	.p2align 4,,15
-	FUN_START(inner_kernel_dgebp_nn_vx8_vs_lib8)
+	FUN_START(inner_kernel_dgebp_nn_vx8_lib8)
 #endif
 
 	cmpl	$ 0, %r10d
@@ -6311,7 +6311,7 @@ NAME:
 #else
 	ret
 
-	FUN_END(inner_kernel_dgebp_nn_vx8_vs_lib8)
+	FUN_END(inner_kernel_dgebp_nn_vx8_lib8)
 #endif
 
 
@@ -12701,6 +12701,7 @@ NAME:
 	vsubpd		%zmm25, %zmm24, %zmm25
 	vpmovq2m	%zmm25, %k1
 
+
 	// zero accumulation registers
 
 //	ZERO_ACC
@@ -12973,9 +12974,9 @@ NAME:
 	addq	$ 512, %r12
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEBP_NN_VX8_VS_LIB8
+	INNER_KERNEL_DGEBP_NN_VX8_LIB8
 #else
-	CALL(inner_kernel_dgebp_nn_vx8_vs_lib8)
+	CALL(inner_kernel_dgebp_nn_vx8_lib8)
 #endif
 
 1000:
@@ -13164,6 +13165,200 @@ NAME:
 	ret
 
 	FUN_END(kernel_dlarfb8_rn_la_8_lib8)
+
+
+
+
+
+//                                     1         2            3           4           5           6
+// void kernel_dlarfb8_rn_la_8_vs_lib8(int kmax, double *pVA, double *pT, double *pD, double *pA, int m1);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dlarfb8_rn_la_8_vs_lib8)
+	
+	PROLOGUE
+
+
+	movq	ARG6, %r10 // k
+
+	// compute mask for rows
+	vcvtsi2sd	%r10d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC00(%rip), %zmm24
+#elif defined(OS_MAC)
+	vmovupd		LC00(%rip), %zmm24
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm24, %zmm25
+	vpmovq2m	%zmm25, %k1
+
+
+	// zero accumulation registers
+
+//	ZERO_ACC
+
+	movq	ARG4, %r10 // D
+
+	//
+	vmovapd			0*64(%r10), %zmm0 {%k1}{z}
+	//
+	vmovapd			1*64(%r10), %zmm1 {%k1}{z}
+	//
+	vmovapd			2*64(%r10), %zmm2 {%k1}{z}
+	//
+	vmovapd			3*64(%r10), %zmm3 {%k1}{z}
+	//
+	vmovapd			4*64(%r10), %zmm4 {%k1}{z}
+	//
+	vmovapd			5*64(%r10), %zmm5 {%k1}{z}
+	//
+	vmovapd			6*64(%r10), %zmm6 {%k1}{z}
+	//
+	vmovapd			7*64(%r10), %zmm7 {%k1}{z}
+
+	movq	ARG1, %r10 // k
+	movq	ARG5, %r11 // A
+	movq	ARG2, %r12 // VA
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_VX8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_vx8_lib8)
+#endif
+
+	movq	ARG3, %r10 // T
+
+	//
+	vbroadcastsd	56+7*64(%r10), %zmm24
+	vmulpd			%zmm7, %zmm24, %zmm7
+	//
+	vbroadcastsd	48+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm6, %zmm24, %zmm7
+	vbroadcastsd	48+6*64(%r10), %zmm24
+	vmulpd			%zmm6, %zmm24, %zmm6
+	//
+	vbroadcastsd	40+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm5, %zmm24, %zmm7
+	vbroadcastsd	40+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm5, %zmm24, %zmm6
+	vbroadcastsd	40+5*64(%r10), %zmm24
+	vmulpd			%zmm5, %zmm24, %zmm5
+	//
+	vbroadcastsd	32+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm7
+	vbroadcastsd	32+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm6
+	vbroadcastsd	32+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm5
+	vbroadcastsd	32+4*64(%r10), %zmm24
+	vmulpd			%zmm4, %zmm24, %zmm4
+	//
+	vbroadcastsd	24+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm7
+	vbroadcastsd	24+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm6
+	vbroadcastsd	24+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm5
+	vbroadcastsd	24+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm4
+	vbroadcastsd	24+3*64(%r10), %zmm24
+	vmulpd			%zmm3, %zmm24, %zmm3
+	//
+	vbroadcastsd	16+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm7
+	vbroadcastsd	16+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm6
+	vbroadcastsd	16+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm5
+	vbroadcastsd	16+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm4
+	vbroadcastsd	16+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm3
+	vbroadcastsd	16+2*64(%r10), %zmm24
+	vmulpd			%zmm2, %zmm24, %zmm2
+	//
+	vbroadcastsd	8+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm7
+	vbroadcastsd	8+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm6
+	vbroadcastsd	8+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm5
+	vbroadcastsd	8+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm4
+	vbroadcastsd	8+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm3
+	vbroadcastsd	8+2*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm2
+	vbroadcastsd	8+1*64(%r10), %zmm24
+	vmulpd			%zmm1, %zmm24, %zmm1
+	//
+	vbroadcastsd	0+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm7
+	vbroadcastsd	0+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm6
+	vbroadcastsd	0+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm5
+	vbroadcastsd	0+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm4
+	vbroadcastsd	0+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm3
+	vbroadcastsd	0+2*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm2
+	vbroadcastsd	0+1*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm1
+	vbroadcastsd	0+0*64(%r10), %zmm24
+	vmulpd			%zmm0, %zmm24, %zmm0
+
+	movq	ARG4, %r10 // D
+
+	//
+	vmovapd			0+0*64(%r10), %zmm24 {%k1}{z}
+	vaddpd			%zmm24, %zmm0, %zmm24
+	vmovapd			%zmm24, 0+0*64(%r10) {%k1}
+	//
+	vmovapd			0+1*64(%r10), %zmm24 {%k1}{z}
+	vaddpd			%zmm24, %zmm1, %zmm24
+	vmovapd			%zmm24, 0+1*64(%r10) {%k1}
+	//
+	vmovapd			0+2*64(%r10), %zmm24 {%k1}{z}
+	vaddpd			%zmm24, %zmm2, %zmm24
+	vmovapd			%zmm24, 0+2*64(%r10) {%k1}
+	//
+	vmovapd			0+3*64(%r10), %zmm24 {%k1}{z}
+	vaddpd			%zmm24, %zmm3, %zmm24
+	vmovapd			%zmm24, 0+3*64(%r10) {%k1}
+	//
+	vmovapd			0+4*64(%r10), %zmm24 {%k1}{z}
+	vaddpd			%zmm24, %zmm4, %zmm24
+	vmovapd			%zmm24, 0+4*64(%r10) {%k1}
+	//
+	vmovapd			0+5*64(%r10), %zmm24 {%k1}{z}
+	vaddpd			%zmm24, %zmm5, %zmm24
+	vmovapd			%zmm24, 0+5*64(%r10) {%k1}
+	//
+	vmovapd			0+6*64(%r10), %zmm24 {%k1}{z}
+	vaddpd			%zmm24, %zmm6, %zmm24
+	vmovapd			%zmm24, 0+6*64(%r10) {%k1}
+	//
+	vmovapd			0+7*64(%r10), %zmm24 {%k1}{z}
+	vaddpd			%zmm24, %zmm7, %zmm24
+	vmovapd			%zmm24, 0+7*64(%r10) {%k1}
+
+	movq	ARG1, %r10 // k
+	movq	ARG2, %r11 // VA
+	movq	ARG5, %r12 // A
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEBP_NN_VX8_LIB8
+#else
+	CALL(inner_kernel_dgebp_nn_vx8_lib8)
+#endif
+
+	EPILOGUE
+
+	ret
+
+	FUN_END(kernel_dlarfb8_rn_la_8_vs_lib8)
 
 
 
@@ -13565,6 +13760,429 @@ NAME:
 	INNER_KERNEL_DGEBP_NN_8X8_LIB8
 #else
 	CALL(inner_kernel_dgebp_nn_8x8_lib8)
+#endif
+
+	EPILOGUE
+
+	ret
+
+	FUN_END(kernel_dlarfb8_rn_lla_8_lib8)
+
+
+
+
+
+//                                      1       2       3            4            5           6           7           8          9
+// void kernel_dlarfb8_rn_lla_8_vs_lib8(int n0, int n1, double *pVL, double *pVA, double *pT, double *pD, double *pL, double *pA, int m1);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dlarfb8_rn_lla_8_vs_lib8)
+	
+	PROLOGUE
+
+
+	movq	ARG9, %r10 // k
+
+	// compute mask for rows
+	vcvtsi2sd	%r10d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC00(%rip), %zmm24
+#elif defined(OS_MAC)
+	vmovupd		LC00(%rip), %zmm24
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm24, %zmm25
+	vpmovq2m	%zmm25, %k1
+
+
+	// zero accumulation registers
+
+//	ZERO_ACC
+
+	movq	ARG6, %r10 // D
+
+	// D
+	//
+	vmovapd			0*64(%r10), %zmm0 {%k1}{z}
+	//
+	vmovapd			1*64(%r10), %zmm1 {%k1}{z}
+	//
+	vmovapd			2*64(%r10), %zmm2 {%k1}{z}
+	//
+	vmovapd			3*64(%r10), %zmm3 {%k1}{z}
+	//
+	vmovapd			4*64(%r10), %zmm4 {%k1}{z}
+	//
+	vmovapd			5*64(%r10), %zmm5 {%k1}{z}
+	//
+	vmovapd			6*64(%r10), %zmm6 {%k1}{z}
+	//
+	vmovapd			7*64(%r10), %zmm7 {%k1}{z}
+
+	// L
+	movq	ARG1, %r10 // n0
+	movq	ARG7, %r11 // L
+	movq	ARG3, %r12 // VL
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_VX8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_vx8_lib8)
+#endif
+	
+	// L final 8x8 lower triangle
+	movq	ARG1, %r10 // n0
+	sall	$ 6, %r10d // n0*ps*sizeof(double)
+	movq	ARG7, %r11 // L
+	addq	%r10, %r11
+	movq	ARG3, %r12 // VL
+	addq	%r10, %r12
+
+	// L 7
+	vmovapd			0+0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	0+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	8+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	48+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	56+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	// L 6
+	vmovapd			0+1*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	48+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	56+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	// L 5
+	vmovapd			0+2*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	16+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	48+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	56+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	// L 4
+	vmovapd			0+3*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	24+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	48+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	56+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	// L 3
+	vmovapd			0+4*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	32+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	48+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	56+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	// L 2
+	vmovapd			0+5*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	40+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	48+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	56+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	// L 1
+	vmovapd			0+6*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	48+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	56+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	// L 0
+	vmovapd			0+7*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	56+7*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	// A
+	movq	ARG2, %r10 // n1
+	movq	ARG8, %r11 // A
+	movq	ARG4, %r12 // VA
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_VX8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_vx8_lib8)
+#endif
+
+	// T
+	movq	ARG5, %r10 // T
+
+	//
+	vbroadcastsd	56+7*64(%r10), %zmm24
+	vmulpd			%zmm7, %zmm24, %zmm7
+	//
+	vbroadcastsd	48+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm6, %zmm24, %zmm7
+	vbroadcastsd	48+6*64(%r10), %zmm24
+	vmulpd			%zmm6, %zmm24, %zmm6
+	//
+	vbroadcastsd	40+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm5, %zmm24, %zmm7
+	vbroadcastsd	40+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm5, %zmm24, %zmm6
+	vbroadcastsd	40+5*64(%r10), %zmm24
+	vmulpd			%zmm5, %zmm24, %zmm5
+	//
+	vbroadcastsd	32+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm7
+	vbroadcastsd	32+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm6
+	vbroadcastsd	32+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm5
+	vbroadcastsd	32+4*64(%r10), %zmm24
+	vmulpd			%zmm4, %zmm24, %zmm4
+	//
+	vbroadcastsd	24+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm7
+	vbroadcastsd	24+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm6
+	vbroadcastsd	24+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm5
+	vbroadcastsd	24+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm4
+	vbroadcastsd	24+3*64(%r10), %zmm24
+	vmulpd			%zmm3, %zmm24, %zmm3
+	//
+	vbroadcastsd	16+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm7
+	vbroadcastsd	16+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm6
+	vbroadcastsd	16+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm5
+	vbroadcastsd	16+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm4
+	vbroadcastsd	16+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm3
+	vbroadcastsd	16+2*64(%r10), %zmm24
+	vmulpd			%zmm2, %zmm24, %zmm2
+	//
+	vbroadcastsd	8+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm7
+	vbroadcastsd	8+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm6
+	vbroadcastsd	8+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm5
+	vbroadcastsd	8+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm4
+	vbroadcastsd	8+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm3
+	vbroadcastsd	8+2*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm2
+	vbroadcastsd	8+1*64(%r10), %zmm24
+	vmulpd			%zmm1, %zmm24, %zmm1
+	//
+	vbroadcastsd	0+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm7
+	vbroadcastsd	0+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm6
+	vbroadcastsd	0+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm5
+	vbroadcastsd	0+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm4
+	vbroadcastsd	0+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm3
+	vbroadcastsd	0+2*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm2
+	vbroadcastsd	0+1*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm1
+	vbroadcastsd	0+0*64(%r10), %zmm24
+	vmulpd			%zmm0, %zmm24, %zmm0
+
+	// D
+	movq	ARG6, %r10 // D
+
+	//
+	vmovapd			0+0*64(%r10), %zmm24 {%k1}{z}
+	vaddpd			%zmm24, %zmm0, %zmm24
+	vmovapd			%zmm24, 0+0*64(%r10) {%k1}
+	//
+	vmovapd			0+1*64(%r10), %zmm24 {%k1}{z}
+	vaddpd			%zmm24, %zmm1, %zmm24
+	vmovapd			%zmm24, 0+1*64(%r10) {%k1}
+	//
+	vmovapd			0+2*64(%r10), %zmm24 {%k1}{z}
+	vaddpd			%zmm24, %zmm2, %zmm24
+	vmovapd			%zmm24, 0+2*64(%r10) {%k1}
+	//
+	vmovapd			0+3*64(%r10), %zmm24 {%k1}{z}
+	vaddpd			%zmm24, %zmm3, %zmm24
+	vmovapd			%zmm24, 0+3*64(%r10) {%k1}
+	//
+	vmovapd			0+4*64(%r10), %zmm24 {%k1}{z}
+	vaddpd			%zmm24, %zmm4, %zmm24
+	vmovapd			%zmm24, 0+4*64(%r10) {%k1}
+	//
+	vmovapd			0+5*64(%r10), %zmm24 {%k1}{z}
+	vaddpd			%zmm24, %zmm5, %zmm24
+	vmovapd			%zmm24, 0+5*64(%r10) {%k1}
+	//
+	vmovapd			0+6*64(%r10), %zmm24 {%k1}{z}
+	vaddpd			%zmm24, %zmm6, %zmm24
+	vmovapd			%zmm24, 0+6*64(%r10) {%k1}
+	//
+	vmovapd			0+7*64(%r10), %zmm24 {%k1}{z}
+	vaddpd			%zmm24, %zmm7, %zmm24
+	vmovapd			%zmm24, 0+7*64(%r10) {%k1}
+
+	// L
+	movq	ARG1, %r10 // n0
+	movq	ARG3, %r11 // VL
+	movq	ARG7, %r12 // L
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEBP_NN_VX8_LIB8
+#else
+	CALL(inner_kernel_dgebp_nn_vx8_lib8)
+#endif
+
+	// L final 8x8 lower triangle
+	movq	ARG1, %r10 // n0
+	sall	$ 6, %r10d // n0*ps*sizeof(double)
+	movq	ARG3, %r11 // VL
+	addq	%r10, %r11
+	movq	ARG7, %r12 // L
+	addq	%r10, %r12
+
+	// L 7
+	vmovapd			0*64(%r12), %zmm28 {%k1}{z}
+	vbroadcastsd	0+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm28
+	vbroadcastsd	8+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm28
+	vbroadcastsd	16+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm28
+	vbroadcastsd	24+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm28
+	vbroadcastsd	32+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm28
+	vbroadcastsd	40+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm28
+	vbroadcastsd	48+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm6, %zmm25, %zmm28
+	vbroadcastsd	56+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm7, %zmm25, %zmm28
+	vmovapd			%zmm28, 0*64(%r12) {%k1}
+	// L 6
+	vmovapd			1*64(%r12), %zmm28 {%k1}{z}
+	vbroadcastsd	8+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm28
+	vbroadcastsd	16+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm28
+	vbroadcastsd	24+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm28
+	vbroadcastsd	32+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm28
+	vbroadcastsd	40+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm28
+	vbroadcastsd	48+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm6, %zmm25, %zmm28
+	vbroadcastsd	56+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm7, %zmm25, %zmm28
+	vmovapd			%zmm28, 1*64(%r12) {%k1}
+	// L 5
+	vmovapd			2*64(%r12), %zmm28 {%k1}{z}
+	vbroadcastsd	16+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm28
+	vbroadcastsd	24+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm28
+	vbroadcastsd	32+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm28
+	vbroadcastsd	40+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm28
+	vbroadcastsd	48+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm6, %zmm25, %zmm28
+	vbroadcastsd	56+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm7, %zmm25, %zmm28
+	vmovapd			%zmm28, 2*64(%r12) {%k1}
+	// L 4
+	vmovapd			3*64(%r12), %zmm28 {%k1}{z}
+	vbroadcastsd	24+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm28
+	vbroadcastsd	32+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm28
+	vbroadcastsd	40+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm28
+	vbroadcastsd	48+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm6, %zmm25, %zmm28
+	vbroadcastsd	56+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm7, %zmm25, %zmm28
+	vmovapd			%zmm28, 3*64(%r12) {%k1}
+	// L 3
+	vmovapd			4*64(%r12), %zmm28 {%k1}{z}
+	vbroadcastsd	32+4*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm28
+	vbroadcastsd	40+4*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm28
+	vbroadcastsd	48+4*64(%r11), %zmm25
+	vfmadd231pd		%zmm6, %zmm25, %zmm28
+	vbroadcastsd	56+4*64(%r11), %zmm25
+	vfmadd231pd		%zmm7, %zmm25, %zmm28
+	vmovapd			%zmm28, 4*64(%r12) {%k1}
+	// L 2
+	vmovapd			5*64(%r12), %zmm28 {%k1}{z}
+	vbroadcastsd	40+5*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm28
+	vbroadcastsd	48+5*64(%r11), %zmm25
+	vfmadd231pd		%zmm6, %zmm25, %zmm28
+	vbroadcastsd	56+5*64(%r11), %zmm25
+	vfmadd231pd		%zmm7, %zmm25, %zmm28
+	vmovapd			%zmm28, 5*64(%r12) {%k1}
+	// L 1
+	vmovapd			6*64(%r12), %zmm28 {%k1}{z}
+	vbroadcastsd	48+6*64(%r11), %zmm25
+	vfmadd231pd		%zmm6, %zmm25, %zmm28
+	vbroadcastsd	56+6*64(%r11), %zmm25
+	vfmadd231pd		%zmm7, %zmm25, %zmm28
+	vmovapd			%zmm28, 6*64(%r12) {%k1}
+	// L 0
+	vmovapd			7*64(%r12), %zmm28 {%k1}{z}
+	vbroadcastsd	56+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm7, %zmm25, %zmm28
+	vmovapd			%zmm28, 7*64(%r12) {%k1}
+
+	// A
+	movq	ARG2, %r10 // n1
+	movq	ARG4, %r11 // VA
+	movq	ARG8, %r12 // A
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEBP_NN_VX8_LIB8
+#else
+	CALL(inner_kernel_dgebp_nn_vx8_lib8)
 #endif
 
 	EPILOGUE

--- a/kernel/avx512/kernel_dgemm_8x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_8x8_lib8.S
@@ -7585,6 +7585,414 @@ NAME:
 
 
 
+//                                   1       2       3            4            5           6           7           8
+// void kernel_dlarfb8_rn_lla_8_lib8(int n0, int n1, double *pVL, double *pVA, double *pT, double *pD, double *pL, double *pA);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dlarfb8_rn_lla_8_lib8)
+	
+	PROLOGUE
+
+	// zero accumulation registers
+
+//	ZERO_ACC
+
+	movq	ARG4, %r10 // D
+
+	// D
+	//
+	vmovapd			0*64(%r10), %zmm0
+	//
+	vmovapd			1*64(%r10), %zmm1
+	//
+	vmovapd			2*64(%r10), %zmm2
+	//
+	vmovapd			3*64(%r10), %zmm3
+	//
+	vmovapd			4*64(%r10), %zmm4
+	//
+	vmovapd			5*64(%r10), %zmm5
+	//
+	vmovapd			6*64(%r10), %zmm6
+	//
+	vmovapd			7*64(%r10), %zmm7
+
+	// L
+	movq	ARG1, %r10 // n0
+	movq	ARG7, %r11 // L
+	movq	ARG3, %r12 // VL
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_8X8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_8x8_lib8)
+#endif
+	
+	// L final 8x8 lower triangle
+	movq	ARG1, %r10 // n0
+	sall	$ 6, %r10d // n0*ps*sizeof(double)
+	movq	ARG7, %r11 // L
+	addq	%r10, %r11
+	movq	ARG3, %r12 // VL
+	addq	%r10, %r12
+
+	// L 7
+	vmovapd			0+0*64(%r11), %zmm25 // A
+	vbroadcastsd	0+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	8+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	48+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	56+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	// L 6
+	vmovapd			0+1*64(%r11), %zmm25 // A
+	vbroadcastsd	8+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	48+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	56+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	// L 5
+	vmovapd			0+2*64(%r11), %zmm25 // A
+	vbroadcastsd	16+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	48+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	56+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	// L 4
+	vmovapd			0+3*64(%r11), %zmm25 // A
+	vbroadcastsd	24+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	48+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	56+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	// L 3
+	vmovapd			0+4*64(%r11), %zmm25 // A
+	vbroadcastsd	32+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	48+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	56+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	// L 2
+	vmovapd			0+5*64(%r11), %zmm25 // A
+	vbroadcastsd	40+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	48+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	56+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	// L 1
+	vmovapd			0+6*64(%r11), %zmm25 // A
+	vbroadcastsd	48+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	56+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	// L 0
+	vmovapd			0+7*64(%r11), %zmm25 // A
+	vbroadcastsd	56+7*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	// A
+	movq	ARG2, %r10 // n1
+	movq	ARG8, %r11 // A
+	movq	ARG4, %r12 // VA
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_8X8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_8x8_lib8)
+#endif
+
+	// T
+	movq	ARG5, %r10 // T
+
+	//
+	vbroadcastsd	56+7*64(%r10), %zmm24
+	vmulpd			%zmm7, %zmm24, %zmm7
+	//
+	vbroadcastsd	48+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm6, %zmm24, %zmm7
+	vbroadcastsd	48+6*64(%r10), %zmm24
+	vmulpd			%zmm6, %zmm24, %zmm6
+	//
+	vbroadcastsd	40+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm5, %zmm24, %zmm7
+	vbroadcastsd	40+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm5, %zmm24, %zmm6
+	vbroadcastsd	40+5*64(%r10), %zmm24
+	vmulpd			%zmm5, %zmm24, %zmm5
+	//
+	vbroadcastsd	32+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm7
+	vbroadcastsd	32+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm6
+	vbroadcastsd	32+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm5
+	vbroadcastsd	32+4*64(%r10), %zmm24
+	vmulpd			%zmm4, %zmm24, %zmm4
+	//
+	vbroadcastsd	24+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm7
+	vbroadcastsd	24+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm6
+	vbroadcastsd	24+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm5
+	vbroadcastsd	24+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm4
+	vbroadcastsd	24+3*64(%r10), %zmm24
+	vmulpd			%zmm3, %zmm24, %zmm3
+	//
+	vbroadcastsd	16+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm7
+	vbroadcastsd	16+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm6
+	vbroadcastsd	16+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm5
+	vbroadcastsd	16+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm4
+	vbroadcastsd	16+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm3
+	vbroadcastsd	16+2*64(%r10), %zmm24
+	vmulpd			%zmm2, %zmm24, %zmm2
+	//
+	vbroadcastsd	8+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm7
+	vbroadcastsd	8+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm6
+	vbroadcastsd	8+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm5
+	vbroadcastsd	8+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm4
+	vbroadcastsd	8+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm3
+	vbroadcastsd	8+2*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm2
+	vbroadcastsd	8+1*64(%r10), %zmm24
+	vmulpd			%zmm1, %zmm24, %zmm1
+	//
+	vbroadcastsd	0+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm7
+	vbroadcastsd	0+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm6
+	vbroadcastsd	0+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm5
+	vbroadcastsd	0+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm4
+	vbroadcastsd	0+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm3
+	vbroadcastsd	0+2*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm2
+	vbroadcastsd	0+1*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm1
+	vbroadcastsd	0+0*64(%r10), %zmm24
+	vmulpd			%zmm0, %zmm24, %zmm0
+
+	// D
+	movq	ARG6, %r10 // D
+
+	//
+	vmovapd			0+0*64(%r10), %zmm24
+	vaddpd			%zmm24, %zmm0, %zmm24
+	vmovapd			%zmm24, 0+0*64(%r10)
+	//
+	vmovapd			0+1*64(%r10), %zmm24
+	vaddpd			%zmm24, %zmm1, %zmm24
+	vmovapd			%zmm24, 0+1*64(%r10)
+	//
+	vmovapd			0+2*64(%r10), %zmm24
+	vaddpd			%zmm24, %zmm2, %zmm24
+	vmovapd			%zmm24, 0+2*64(%r10)
+	//
+	vmovapd			0+3*64(%r10), %zmm24
+	vaddpd			%zmm24, %zmm3, %zmm24
+	vmovapd			%zmm24, 0+3*64(%r10)
+	//
+	vmovapd			0+4*64(%r10), %zmm24
+	vaddpd			%zmm24, %zmm4, %zmm24
+	vmovapd			%zmm24, 0+4*64(%r10)
+	//
+	vmovapd			0+5*64(%r10), %zmm24
+	vaddpd			%zmm24, %zmm5, %zmm24
+	vmovapd			%zmm24, 0+5*64(%r10)
+	//
+	vmovapd			0+6*64(%r10), %zmm24
+	vaddpd			%zmm24, %zmm6, %zmm24
+	vmovapd			%zmm24, 0+6*64(%r10)
+	//
+	vmovapd			0+7*64(%r10), %zmm24
+	vaddpd			%zmm24, %zmm7, %zmm24
+	vmovapd			%zmm24, 0+7*64(%r10)
+
+	// L
+	movq	ARG1, %r10 // n0
+	movq	ARG3, %r11 // VL
+	movq	ARG7, %r12 // L
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEBP_NN_8X8_LIB8
+#else
+	CALL(inner_kernel_dgebp_nn_8x8_lib8)
+#endif
+
+	// L final 8x8 lower triangle
+	movq	ARG1, %r10 // n0
+	sall	$ 6, %r10d // n0*ps*sizeof(double)
+	movq	ARG3, %r11 // VL
+	addq	%r10, %r11
+	movq	ARG7, %r12 // L
+	addq	%r10, %r12
+
+	// L 7
+	vmovapd			0*64(%r12), %zmm28
+	vbroadcastsd	0+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm28
+	vbroadcastsd	8+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm28
+	vbroadcastsd	16+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm28
+	vbroadcastsd	24+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm28
+	vbroadcastsd	32+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm28
+	vbroadcastsd	40+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm28
+	vbroadcastsd	48+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm6, %zmm25, %zmm28
+	vbroadcastsd	56+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm7, %zmm25, %zmm28
+	vmovapd			%zmm28, 0*64(%r12)
+	// L 6
+	vmovapd			1*64(%r12), %zmm28
+	vbroadcastsd	8+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm28
+	vbroadcastsd	16+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm28
+	vbroadcastsd	24+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm28
+	vbroadcastsd	32+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm28
+	vbroadcastsd	40+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm28
+	vbroadcastsd	48+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm6, %zmm25, %zmm28
+	vbroadcastsd	56+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm7, %zmm25, %zmm28
+	vmovapd			%zmm28, 1*64(%r12)
+	// L 5
+	vmovapd			2*64(%r12), %zmm28
+	vbroadcastsd	16+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm28
+	vbroadcastsd	24+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm28
+	vbroadcastsd	32+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm28
+	vbroadcastsd	40+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm28
+	vbroadcastsd	48+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm6, %zmm25, %zmm28
+	vbroadcastsd	56+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm7, %zmm25, %zmm28
+	vmovapd			%zmm28, 2*64(%r12)
+	// L 4
+	vmovapd			3*64(%r12), %zmm28
+	vbroadcastsd	24+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm28
+	vbroadcastsd	32+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm28
+	vbroadcastsd	40+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm28
+	vbroadcastsd	48+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm6, %zmm25, %zmm28
+	vbroadcastsd	56+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm7, %zmm25, %zmm28
+	vmovapd			%zmm28, 3*64(%r12)
+	// L 3
+	vmovapd			4*64(%r12), %zmm28
+	vbroadcastsd	32+4*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm28
+	vbroadcastsd	40+4*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm28
+	vbroadcastsd	48+4*64(%r11), %zmm25
+	vfmadd231pd		%zmm6, %zmm25, %zmm28
+	vbroadcastsd	56+4*64(%r11), %zmm25
+	vfmadd231pd		%zmm7, %zmm25, %zmm28
+	vmovapd			%zmm28, 4*64(%r12)
+	// L 2
+	vmovapd			5*64(%r12), %zmm28
+	vbroadcastsd	40+5*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm28
+	vbroadcastsd	48+5*64(%r11), %zmm25
+	vfmadd231pd		%zmm6, %zmm25, %zmm28
+	vbroadcastsd	56+5*64(%r11), %zmm25
+	vfmadd231pd		%zmm7, %zmm25, %zmm28
+	vmovapd			%zmm28, 5*64(%r12)
+	// L 1
+	vmovapd			6*64(%r12), %zmm28
+	vbroadcastsd	48+6*64(%r11), %zmm25
+	vfmadd231pd		%zmm6, %zmm25, %zmm28
+	vbroadcastsd	56+6*64(%r11), %zmm25
+	vfmadd231pd		%zmm7, %zmm25, %zmm28
+	vmovapd			%zmm28, 6*64(%r12)
+	// L 0
+	vmovapd			7*64(%r12), %zmm28
+	vbroadcastsd	56+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm7, %zmm25, %zmm28
+	vmovapd			%zmm28, 7*64(%r12)
+
+	// A
+	movq	ARG2, %r10 // n1
+	movq	ARG4, %r11 // VA
+	movq	ARG8, %r12 // A
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEBP_NN_8X8_LIB8
+#else
+	CALL(inner_kernel_dgebp_nn_8x8_lib8)
+#endif
+
+	EPILOGUE
+
+	ret
+
+	FUN_END(kernel_dlarfb8_rn_lla_8_lib8)
+
+
+
+
+
 //#if defined(BLAS_API)
 #if ( defined(BLAS_API) | ( defined(LA_HIGH_PERFORMANCE) & defined(MF_COLMAJ) ) )
 

--- a/kernel/avx512/kernel_dgemm_8x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_8x8_lib8.S
@@ -3060,50 +3060,8 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+1*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm0, %zmm27, %zmm26
-	vfnmadd231pd	%zmm0, %zmm26, %zmm1
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+2*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+2*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm0, %zmm27, %zmm26
-	vfnmadd231pd	%zmm0, %zmm26, %zmm2
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+3*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+3*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm0, %zmm27, %zmm26
-	vfnmadd231pd	%zmm0, %zmm26, %zmm3
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+4*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+4*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm0, %zmm27, %zmm26
-	vfnmadd231pd	%zmm0, %zmm26, %zmm4
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+5*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+5*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm0, %zmm27, %zmm26
-	vfnmadd231pd	%zmm0, %zmm26, %zmm5
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+6*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+6*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm0, %zmm27, %zmm26
-	vfnmadd231pd	%zmm0, %zmm26, %zmm6
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+7*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+7*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm0, %zmm27, %zmm26
-	vfnmadd231pd	%zmm0, %zmm26, %zmm7
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm1
 
 	// 1
 //	vpermilpd		$ 0x3, %xmm1, %xmm26
@@ -3118,6 +3076,48 @@ NAME:
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 4:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm2
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm3
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm4
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm5
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm6
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm7
 	vmovsd			%xmm26, 8(%r10)
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm1, %zmm26, %zmm1
@@ -3128,43 +3128,8 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+2*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm1, %zmm27, %zmm26
-	vfnmadd231pd	%zmm1, %zmm26, %zmm2
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+3*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+3*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm1, %zmm27, %zmm26
-	vfnmadd231pd	%zmm1, %zmm26, %zmm3
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+4*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+4*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm1, %zmm27, %zmm26
-	vfnmadd231pd	%zmm1, %zmm26, %zmm4
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+5*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+5*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm1, %zmm27, %zmm26
-	vfnmadd231pd	%zmm1, %zmm26, %zmm5
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+6*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+6*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm1, %zmm27, %zmm26
-	vfnmadd231pd	%zmm1, %zmm26, %zmm6
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+7*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+7*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm1, %zmm27, %zmm26
-	vfnmadd231pd	%zmm1, %zmm26, %zmm7
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm2
 
 	// 2
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -3178,6 +3143,41 @@ NAME:
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 6:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm3
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm4
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm5
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm6
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm7
 	vmovsd			%xmm26, 16(%r10)
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm2, %zmm26, %zmm2
@@ -3188,36 +3188,8 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+3*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm2, %zmm27, %zmm26
-	vfnmadd231pd	%zmm2, %zmm26, %zmm3
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+4*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+4*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm2, %zmm27, %zmm26
-	vfnmadd231pd	%zmm2, %zmm26, %zmm4
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+5*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+5*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm2, %zmm27, %zmm26
-	vfnmadd231pd	%zmm2, %zmm26, %zmm5
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+6*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+6*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm2, %zmm27, %zmm26
-	vfnmadd231pd	%zmm2, %zmm26, %zmm6
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+7*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+7*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm2, %zmm27, %zmm26
-	vfnmadd231pd	%zmm2, %zmm26, %zmm7
+	vpermpd			%zmm2, %zmm27, %zmm27
+	vfnmadd231pd	%zmm2, %zmm27, %zmm3
 
 	// 3
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -3231,6 +3203,34 @@ NAME:
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 8:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm27
+	vfnmadd231pd	%zmm2, %zmm27, %zmm4
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm27
+	vfnmadd231pd	%zmm2, %zmm27, %zmm5
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm27
+	vfnmadd231pd	%zmm2, %zmm27, %zmm6
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm27
+	vfnmadd231pd	%zmm2, %zmm27, %zmm7
 	vmovsd			%xmm26, 24(%r10)
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm3, %zmm26, %zmm3
@@ -3241,29 +3241,8 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+4*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm3, %zmm27, %zmm26
-	vfnmadd231pd	%zmm3, %zmm26, %zmm4
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+5*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+5*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm3, %zmm27, %zmm26
-	vfnmadd231pd	%zmm3, %zmm26, %zmm5
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+6*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+6*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm3, %zmm27, %zmm26
-	vfnmadd231pd	%zmm3, %zmm26, %zmm6
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+7*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+7*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm3, %zmm27, %zmm26
-	vfnmadd231pd	%zmm3, %zmm26, %zmm7
+	vpermpd			%zmm3, %zmm27, %zmm27
+	vfnmadd231pd	%zmm3, %zmm27, %zmm4
 
 	// 4
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -3277,6 +3256,27 @@ NAME:
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 10:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm3, %zmm27, %zmm27
+	vfnmadd231pd	%zmm3, %zmm27, %zmm5
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm3, %zmm27, %zmm27
+	vfnmadd231pd	%zmm3, %zmm27, %zmm6
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm3, %zmm27, %zmm27
+	vfnmadd231pd	%zmm3, %zmm27, %zmm7
 	vmovsd			%xmm26, 32(%r10)
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm4, %zmm26, %zmm4
@@ -3287,22 +3287,8 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+5*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm4, %zmm27, %zmm26
-	vfnmadd231pd	%zmm4, %zmm26, %zmm5
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+6*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+6*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm4, %zmm27, %zmm26
-	vfnmadd231pd	%zmm4, %zmm26, %zmm6
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+7*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+7*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm4, %zmm27, %zmm26
-	vfnmadd231pd	%zmm4, %zmm26, %zmm7
+	vpermpd			%zmm4, %zmm27, %zmm27
+	vfnmadd231pd	%zmm4, %zmm27, %zmm5
 
 	// 5
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -3316,6 +3302,20 @@ NAME:
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 12:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm4, %zmm27, %zmm27
+	vfnmadd231pd	%zmm4, %zmm27, %zmm6
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm4, %zmm27, %zmm27
+	vfnmadd231pd	%zmm4, %zmm27, %zmm7
 	vmovsd			%xmm26, 40(%r10)
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm5, %zmm26, %zmm5
@@ -3326,15 +3326,8 @@ NAME:
 #elif defined(OS_MAC)
 	vbroadcastsd	LC05+6*8(%rip), %zmm27
 #endif
-	vpermpd			%zmm5, %zmm27, %zmm26
-	vfnmadd231pd	%zmm5, %zmm26, %zmm6
-#if defined(OS_LINUX) | defined(OS_WINDOWS)
-	vbroadcastsd	.LC05+7*8(%rip), %zmm27
-#elif defined(OS_MAC)
-	vbroadcastsd	LC05+7*8(%rip), %zmm27
-#endif
-	vpermpd			%zmm5, %zmm27, %zmm26
-	vfnmadd231pd	%zmm5, %zmm26, %zmm7
+	vpermpd			%zmm5, %zmm27, %zmm27
+	vfnmadd231pd	%zmm5, %zmm27, %zmm6
 
 	// 6
 #if defined(OS_LINUX) | defined(OS_WINDOWS)
@@ -3348,6 +3341,13 @@ NAME:
 	vsqrtsd			%xmm26, %xmm26, %xmm26
 	vdivsd			%xmm26, %xmm24, %xmm26
 14:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm5, %zmm27, %zmm27
+	vfnmadd231pd	%zmm5, %zmm27, %zmm7
 	vmovsd			%xmm26, 48(%r10)
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm6, %zmm26, %zmm6

--- a/kernel/avx512/kernel_dgemm_8x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_8x8_lib8.S
@@ -529,6 +529,2014 @@ NAME:
 // r10d  <- k
 // r11   <- A
 // r12   <- B
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- B+8*k*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_VX8_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_vx8_lib8)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 {%k1}{z} // A
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	48(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	56(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			128(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	16+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	24+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	32+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	40+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	48+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vbroadcastsd	56+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 0
+	vbroadcastsd	0+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			192(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	8+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	48+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	56+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	16+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	24+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	32+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	40+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	48+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vbroadcastsd	56+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	$ 256, %r12
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean4-up
+	
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	48(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	56(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			128(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	16+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	24+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	32+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	40+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	48+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vbroadcastsd	56+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 0
+	vbroadcastsd	0+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			192(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	8+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	48+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	56+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+//	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	16+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	24+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	32+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	40+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	48+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vbroadcastsd	56+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	$ 256, %r12
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	48(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	56(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	addq	$ 64, %r11
+	addq	$ 64, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_vx8_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- B
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- B+8*k*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_VX7_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_vx7_lib8)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 {%k1}{z} // A
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	48(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	56(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			128(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	16+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	24+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	32+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	40+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	48+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	56+64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 0
+	vbroadcastsd	0+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			192(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	8+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	48+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	56+128(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	16+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	24+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	32+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	40+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	48+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	56+192(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	$ 256, %r12
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean4-up
+	
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	48(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	56(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			128(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	16+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	24+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	32+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	40+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	48+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	56+64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 0
+	vbroadcastsd	0+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			192(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	8+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	48+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	56+128(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+//	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	16+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	24+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	32+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	40+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	48+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	56+192(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	$ 256, %r12
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	48(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	56(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	addq	$ 64, %r11
+	addq	$ 64, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_vx7_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- B
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- B+8*k*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_VX6_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_vx6_lib8)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 {%k1}{z} // A
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	48(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	56(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			128(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	16+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	24+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	32+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	40+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	48+64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	56+64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 0
+	vbroadcastsd	0+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			192(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	8+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	48+128(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	56+128(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	16+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	24+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	32+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	40+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	48+192(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	56+192(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	$ 256, %r12
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean4-up
+	
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	48(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	56(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			128(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	16+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	24+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	32+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	40+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	48+64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	56+64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 0
+	vbroadcastsd	0+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			192(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	8+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	48+128(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	56+128(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+//	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	16+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	24+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	32+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	40+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	48+192(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	56+192(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	$ 256, %r12
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	40(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	48(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	56(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	addq	$ 64, %r11
+	addq	$ 64, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_vx6_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- B
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- B+8*k*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_VX5_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_vx5_lib8)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 {%k1}{z} // A
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+//	vbroadcastsd	40(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	48(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	56(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			128(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	16+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	24+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	32+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+//	vbroadcastsd	40+64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	48+64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	56+64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 0
+	vbroadcastsd	0+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			192(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	8+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+//	vbroadcastsd	40+128(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	48+128(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	56+128(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	16+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	24+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	32+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+//	vbroadcastsd	40+192(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	48+192(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	56+192(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	$ 256, %r12
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean4-up
+	
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+//	vbroadcastsd	40(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	48(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	56(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			128(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	16+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	24+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	32+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+//	vbroadcastsd	40+64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	48+64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	56+64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 0
+	vbroadcastsd	0+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			192(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	8+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+//	vbroadcastsd	40+128(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	48+128(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	56+128(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+//	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	16+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	24+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	32+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+//	vbroadcastsd	40+192(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	48+192(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	56+192(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	$ 256, %r12
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+//	vbroadcastsd	40(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	48(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	56(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	addq	$ 64, %r11
+	addq	$ 64, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_vx5_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- B
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- B+8*k*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_VX4_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_vx4_lib8)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		5f // return
+
+	// prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 {%k1}{z} // A
+
+	vxorpd			%zmm4, %zmm4, %zmm4
+	vmovapd			%zmm4, %zmm5
+	vmovapd			%zmm4, %zmm6
+	vmovapd			%zmm4, %zmm7
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			128(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	16+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vbroadcastsd	24+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 0
+	vbroadcastsd	0+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			192(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	8+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	16+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vbroadcastsd	24+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	$ 256, %r12
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean4-up
+	
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			128(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	16+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vbroadcastsd	24+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 0
+	vbroadcastsd	0+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			192(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	8+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+//	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	16+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vbroadcastsd	24+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	$ 256, %r12
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	24(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+
+	addq	$ 64, %r11
+	addq	$ 64, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+	vaddpd			%zmm4, %zmm0, %zmm0
+	vaddpd			%zmm5, %zmm1, %zmm1
+	vaddpd			%zmm6, %zmm2, %zmm2
+	vaddpd			%zmm7, %zmm3, %zmm3
+
+5: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_vx4_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- B
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- B+8*k*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_VX3_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_vx3_lib8)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		5f // return
+
+	// prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 {%k1}{z} // A
+
+	vxorpd			%zmm4, %zmm4, %zmm4
+	vmovapd			%zmm4, %zmm5
+	vmovapd			%zmm4, %zmm6
+//	vmovapd			%zmm4, %zmm7
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	24(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			128(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	16+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	24+64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 0
+	vbroadcastsd	0+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			192(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	8+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	24+128(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	16+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	24+192(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	$ 256, %r12
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean4-up
+	
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	24(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			128(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	16+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	24+64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 0
+	vbroadcastsd	0+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			192(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	8+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	24+128(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+//	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	16+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	24+192(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	$ 256, %r12
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	24(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+
+	addq	$ 64, %r11
+	addq	$ 64, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+	vaddpd			%zmm4, %zmm0, %zmm0
+	vaddpd			%zmm5, %zmm1, %zmm1
+	vaddpd			%zmm6, %zmm2, %zmm2
+//	vaddpd			%zmm7, %zmm3, %zmm3
+
+5: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_vx3_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- B
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- B+8*k*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_VX2_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_vx2_lib8)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		5f // return
+
+	// prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 {%k1}{z} // A
+
+	vxorpd			%zmm4, %zmm4, %zmm4
+	vmovapd			%zmm4, %zmm5
+//	vmovapd			%zmm4, %zmm6
+//	vmovapd			%zmm4, %zmm7
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vbroadcastsd	16(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	24(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			128(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	16+64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	24+64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 0
+	vbroadcastsd	0+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			192(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	8+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vbroadcastsd	16+128(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	24+128(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	16+192(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	24+192(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	$ 256, %r12
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean4-up
+	
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vbroadcastsd	16(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	24(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			128(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	16+64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	24+64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 0
+	vbroadcastsd	0+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			192(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	8+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vbroadcastsd	16+128(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	24+128(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+//	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	16+192(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	24+192(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	$ 256, %r12
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	8(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vbroadcastsd	16(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	24(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+
+	addq	$ 64, %r11
+	addq	$ 64, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+	vaddpd			%zmm4, %zmm0, %zmm0
+	vaddpd			%zmm5, %zmm1, %zmm1
+//	vaddpd			%zmm6, %zmm2, %zmm2
+//	vaddpd			%zmm7, %zmm3, %zmm3
+
+5: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_vx2_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- B
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- B+8*k*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_VX1_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_vx1_lib8)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		5f // return
+
+	// prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 {%k1}{z} // A
+
+	vxorpd			%zmm4, %zmm4, %zmm4
+//	vmovapd			%zmm4, %zmm5
+//	vmovapd			%zmm4, %zmm6
+//	vmovapd			%zmm4, %zmm7
+
+	cmpl	$ 4, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			64(%r11), %zmm26 {%k1}{z} // A
+//	vbroadcastsd	8(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vbroadcastsd	16(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	24(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			128(%r11), %zmm25 {%k1}{z} // A
+//	vbroadcastsd	8+64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	16+64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	24+64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 0
+	vbroadcastsd	0+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			192(%r11), %zmm26 {%k1}{z} // A
+//	vbroadcastsd	8+128(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vbroadcastsd	16+128(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	24+128(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+//	vbroadcastsd	8+192(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	16+192(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	24+192(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	$ 256, %r12
+
+	cmpl	$ 4, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean4-up
+	
+	cmpl	$ 3, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			64(%r11), %zmm26 {%k1}{z} // A
+//	vbroadcastsd	8(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vbroadcastsd	16(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	24(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	subl	$ 4, %r10d
+
+	// unroll 0
+	vbroadcastsd	0+64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			128(%r11), %zmm25 {%k1}{z} // A
+//	vbroadcastsd	8+64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	16+64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	24+64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 0
+	vbroadcastsd	0+128(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			192(%r11), %zmm26 {%k1}{z} // A
+//	vbroadcastsd	8+128(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vbroadcastsd	16+128(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	24+128(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	addq	$ 256, %r11
+
+	// unroll 0
+	vbroadcastsd	0+192(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+//	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+//	vbroadcastsd	8+192(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	16+192(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	24+192(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	$ 256, %r12
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	0(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+//	vbroadcastsd	8(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vbroadcastsd	16(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	24(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+
+	addq	$ 64, %r11
+	addq	$ 64, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+	vaddpd			%zmm4, %zmm0, %zmm0
+//	vaddpd			%zmm5, %zmm1, %zmm1
+//	vaddpd			%zmm6, %zmm2, %zmm2
+//	vaddpd			%zmm7, %zmm3, %zmm3
+
+5: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_vx1_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- B
+// r13   <- m1
+// r14   <- n1
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- B+8*k*sizeof(double)
+// r13   <- m1
+// r14   <- n1
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NT_8X8_VS_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nt_8x8_vs_lib8)
+#endif
+
+	// compute mask for rows
+	vcvtsi2sd	%r13d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC00(%rip), %zmm24
+#elif defined(OS_MAC)
+	vmovupd		LC00(%rip), %zmm24
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm24, %zmm25
+	vpmovq2m	%zmm25, %k1
+
+	cmpl	$ 1, %r14d
+	jg		100f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_VX1_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_vx1_lib8)
+#endif
+	
+	jmp		107f
+
+100:
+
+	cmpl	$ 2, %r14d
+	jg		101f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_VX2_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_vx2_lib8)
+#endif
+	
+	jmp		107f
+
+101:
+
+	cmpl	$ 3, %r14d
+	jg		102f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_VX3_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_vx3_lib8)
+#endif
+	
+	jmp		107f
+
+102:
+
+	cmpl	$ 4, %r14d
+	jg		103f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_VX4_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_vx4_lib8)
+#endif
+	
+	jmp		107f
+
+103:
+
+	cmpl	$ 5, %r14d
+	jg		104f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_VX5_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_vx5_lib8)
+#endif
+	
+	jmp		107f
+
+104:
+
+	cmpl	$ 6, %r14d
+	jg		105f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_VX6_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_vx6_lib8)
+#endif
+	
+	jmp		107f
+
+105:
+
+	cmpl	$ 7, %r14d
+	jg		106f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_VX7_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_vx7_lib8)
+#endif
+	
+	jmp		107f
+
+106:
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_VX8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_vx8_lib8)
+#endif
+
+107:
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nt_8x8_vs_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- B
 // r13   <- 4*sdb*sizeof(double)
 // zmm0  <- []
 // ...
@@ -5471,11 +7479,13 @@ NAME:
 	movq	ARG1, %r10 // k
 	movq	ARG3, %r11  // A
 	movq	ARG4, %r12  // B
+	movq	ARG8, %r13 // m1 
+	movq	ARG9, %r14 // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_8X8_LIB8
+	INNER_KERNEL_DGEMM_NT_8X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_8x8_lib8)
+	CALL(inner_kernel_dgemm_nt_8x8_vs_lib8)
 #endif
 
 
@@ -5534,11 +7544,13 @@ NAME:
 	movq	ARG1, %r10 // k
 	movq	ARG3, %r11  // A
 	movq	ARG4, %r12  // B
+	movq	ARG13, %r13 // m1
+	movq	ARG15, %r14 // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_8X8_LIB8
+	INNER_KERNEL_DGEMM_NT_8X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_8x8_lib8)
+	CALL(inner_kernel_dgemm_nt_8x8_vs_lib8)
 #endif
 
 
@@ -6129,11 +8141,13 @@ NAME:
 	movq	ARG1, %r10 // k
 	movq	ARG3, %r11  // A
 	movq	ARG4, %r12  // B
+	movq	ARG8, %r13 // m1 
+	movq	ARG9, %r14 // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_8X8_LIB8
+	INNER_KERNEL_DGEMM_NT_8X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_8x8_lib8)
+	CALL(inner_kernel_dgemm_nt_8x8_vs_lib8)
 #endif
 
 
@@ -6193,11 +8207,13 @@ NAME:
 	movq	ARG1, %r10 // k
 	movq	ARG3, %r11  // A
 	movq	ARG4, %r12  // B
+	movq	ARG13, %r13 // m1
+	movq	ARG15, %r14 // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_8X8_LIB8
+	INNER_KERNEL_DGEMM_NT_8X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_8x8_lib8)
+	CALL(inner_kernel_dgemm_nt_8x8_vs_lib8)
 #endif
 
 
@@ -6570,11 +8586,13 @@ NAME:
 	movq	ARG1, %r10 // kmax
 	movq	ARG2, %r11 // A
 	movq	ARG3, %r12 // B
+	movq	ARG9, %r13 // m1
+	movq	ARG10, %r14 // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_8X8_LIB8
+	INNER_KERNEL_DGEMM_NT_8X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_8x8_lib8)
+	CALL(inner_kernel_dgemm_nt_8x8_vs_lib8)
 #endif
 
 
@@ -6732,11 +8750,13 @@ NAME:
 	movq	ARG1, %r10 // kp
 	movq	ARG2, %r11  // Ap
 	movq	ARG3, %r12  // Bp
+	movq	ARG11, %r13   // m1
+	movq	ARG12, %r14   // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_8X8_LIB8
+	INNER_KERNEL_DGEMM_NT_8X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_8x8_lib8)
+	CALL(inner_kernel_dgemm_nt_8x8_vs_lib8)
 #endif
 
 
@@ -6749,11 +8769,13 @@ NAME:
 	movq	ARG4, %r10 // km
 	movq	ARG5, %r11   // Am
 	movq	ARG6, %r12   // Bm
+	movq	ARG11, %r13   // m1
+	movq	ARG12, %r14   // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_8X8_LIB8
+	INNER_KERNEL_DGEMM_NT_8X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_8x8_lib8)
+	CALL(inner_kernel_dgemm_nt_8x8_vs_lib8)
 #endif
 
 
@@ -6893,11 +8915,13 @@ NAME:
 	movq	ARG1, %r10
 	movq	ARG2, %r11
 	movq	ARG3, %r12
+	movq	ARG7, %r13 // m1
+	movq	ARG8, %r14 // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_8X8_LIB8
+	INNER_KERNEL_DGEMM_NT_8X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_8x8_lib8)
+	CALL(inner_kernel_dgemm_nt_8x8_vs_lib8)
 #endif
 
 
@@ -7053,11 +9077,13 @@ NAME:
 	movq	ARG1, %r10 // kp
 	movq	ARG2, %r11  // Ap
 	movq	ARG3, %r12  // Bp
+	movq	ARG10, %r13  // m1
+	movq	ARG11, %r14  // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_8X8_LIB8
+	INNER_KERNEL_DGEMM_NT_8X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_8x8_lib8)
+	CALL(inner_kernel_dgemm_nt_8x8_vs_lib8)
 #endif
 
 
@@ -7070,11 +9096,13 @@ NAME:
 	movq	ARG4, %r10 // km
 	movq	ARG5, %r11   // Am
 	movq	ARG6, %r12   // Bm
+	movq	ARG10, %r13  // m1
+	movq	ARG11, %r14  // n1
 
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NT_8X8_LIB8
+	INNER_KERNEL_DGEMM_NT_8X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nt_8x8_lib8)
+	CALL(inner_kernel_dgemm_nt_8x8_vs_lib8)
 #endif
 
 

--- a/kernel/avx512/kernel_dgemm_8x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_8x8_lib8.S
@@ -7406,6 +7406,187 @@ NAME:
 
 
 
+//                                  1         2            3           4           5
+// void kernel_dlarfb8_rn_la_8_lib8(int kmax, double *pVA, double *pT, double *pD, double *pA);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dlarfb8_rn_la_8_lib8)
+	
+	PROLOGUE
+
+	// zero accumulation registers
+
+//	ZERO_ACC
+
+	movq	ARG4, %r10 // D
+
+	//
+	vmovapd			0*64(%r10), %zmm0
+	//
+	vmovapd			1*64(%r10), %zmm1
+	//
+	vmovapd			2*64(%r10), %zmm2
+	//
+	vmovapd			3*64(%r10), %zmm3
+	//
+	vmovapd			4*64(%r10), %zmm4
+	//
+	vmovapd			5*64(%r10), %zmm5
+	//
+	vmovapd			6*64(%r10), %zmm6
+	//
+	vmovapd			7*64(%r10), %zmm7
+
+
+	movq	ARG1, %r10 // k
+	movq	ARG5, %r11 // A
+	movq	ARG2, %r12 // VA
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_8X8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_8x8_lib8)
+#endif
+
+	movq	ARG3, %r10 // T
+
+	//
+	vbroadcastsd	56+7*64(%r10), %zmm24
+	vmulpd			%zmm7, %zmm24, %zmm7
+	//
+	vbroadcastsd	48+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm6, %zmm24, %zmm7
+	vbroadcastsd	48+6*64(%r10), %zmm24
+	vmulpd			%zmm6, %zmm24, %zmm6
+	//
+	vbroadcastsd	40+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm5, %zmm24, %zmm7
+	vbroadcastsd	40+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm5, %zmm24, %zmm6
+	vbroadcastsd	40+5*64(%r10), %zmm24
+	vmulpd			%zmm5, %zmm24, %zmm5
+	//
+	vbroadcastsd	32+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm7
+	vbroadcastsd	32+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm6
+	vbroadcastsd	32+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm5
+	vbroadcastsd	32+4*64(%r10), %zmm24
+	vmulpd			%zmm4, %zmm24, %zmm4
+	//
+	vbroadcastsd	24+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm7
+	vbroadcastsd	24+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm6
+	vbroadcastsd	24+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm5
+	vbroadcastsd	24+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm4
+	vbroadcastsd	24+3*64(%r10), %zmm24
+	vmulpd			%zmm3, %zmm24, %zmm3
+	//
+	vbroadcastsd	16+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm7
+	vbroadcastsd	16+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm6
+	vbroadcastsd	16+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm5
+	vbroadcastsd	16+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm4
+	vbroadcastsd	16+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm3
+	vbroadcastsd	16+2*64(%r10), %zmm24
+	vmulpd			%zmm2, %zmm24, %zmm2
+	//
+	vbroadcastsd	8+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm7
+	vbroadcastsd	8+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm6
+	vbroadcastsd	8+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm5
+	vbroadcastsd	8+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm4
+	vbroadcastsd	8+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm3
+	vbroadcastsd	8+2*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm2
+	vbroadcastsd	8+1*64(%r10), %zmm24
+	vmulpd			%zmm1, %zmm24, %zmm1
+	//
+	vbroadcastsd	0+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm7
+	vbroadcastsd	0+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm6
+	vbroadcastsd	0+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm5
+	vbroadcastsd	0+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm4
+	vbroadcastsd	0+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm3
+	vbroadcastsd	0+2*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm2
+	vbroadcastsd	0+1*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm1
+	vbroadcastsd	0+0*64(%r10), %zmm24
+	vmulpd			%zmm0, %zmm24, %zmm0
+
+
+	movq	ARG4, %r10 // D
+
+	//
+	vmovapd			0+0*64(%r10), %zmm24
+	vaddpd			%zmm24, %zmm0, %zmm24
+	vmovapd			%zmm24, 0+0*64(%r10)
+	//
+	vmovapd			0+1*64(%r10), %zmm24
+	vaddpd			%zmm24, %zmm1, %zmm24
+	vmovapd			%zmm24, 0+1*64(%r10)
+	//
+	vmovapd			0+2*64(%r10), %zmm24
+	vaddpd			%zmm24, %zmm2, %zmm24
+	vmovapd			%zmm24, 0+2*64(%r10)
+	//
+	vmovapd			0+3*64(%r10), %zmm24
+	vaddpd			%zmm24, %zmm3, %zmm24
+	vmovapd			%zmm24, 0+3*64(%r10)
+	//
+	vmovapd			0+4*64(%r10), %zmm24
+	vaddpd			%zmm24, %zmm4, %zmm24
+	vmovapd			%zmm24, 0+4*64(%r10)
+	//
+	vmovapd			0+5*64(%r10), %zmm24
+	vaddpd			%zmm24, %zmm5, %zmm24
+	vmovapd			%zmm24, 0+5*64(%r10)
+	//
+	vmovapd			0+6*64(%r10), %zmm24
+	vaddpd			%zmm24, %zmm6, %zmm24
+	vmovapd			%zmm24, 0+6*64(%r10)
+	//
+	vmovapd			0+7*64(%r10), %zmm24
+	vaddpd			%zmm24, %zmm7, %zmm24
+	vmovapd			%zmm24, 0+7*64(%r10)
+
+	movq	ARG1, %r10 // k
+	movq	ARG2, %r11 // VA
+	movq	ARG5, %r12 // A
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEBP_NN_8X8_LIB8
+#else
+	CALL(inner_kernel_dgebp_nn_8x8_lib8)
+#endif
+
+	EPILOGUE
+
+	ret
+
+	FUN_END(kernel_dlarfb8_rn_la_8_lib8)
+
+
+
+
+
 //#if defined(BLAS_API)
 #if ( defined(BLAS_API) | ( defined(LA_HIGH_PERFORMANCE) & defined(MF_COLMAJ) ) )
 

--- a/kernel/avx512/kernel_dgemm_8x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_8x8_lib8.S
@@ -7597,7 +7597,7 @@ NAME:
 
 //	ZERO_ACC
 
-	movq	ARG4, %r10 // D
+	movq	ARG6, %r10 // D
 
 	// D
 	//

--- a/kernel/avx512/kernel_dgemm_8x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_8x8_lib8.S
@@ -283,8 +283,10 @@ NAME:
 	jle		2f // return
 
 	// prefetch
-//	prefetcht0	0(%r12) // software prefetch
-//	prefetcht0	0+64(%r12) // software prefetch
+	prefetcht0	0+0*64(%r12) // software prefetch
+	prefetcht0	0+1*64(%r12) // software prefetch
+	prefetcht0	0+2*64(%r12) // software prefetch
+	prefetcht0	0+3*64(%r12) // software prefetch
 
 	// preload
 	vmovapd 		0(%r11), %zmm25 // A
@@ -302,10 +304,10 @@ NAME:
 	vmovapd			64(%r11), %zmm26 // A
 	vbroadcastsd	8(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm1
-//	prefetcht0	128(%r12) // software prefetch
+	prefetcht0	256+0*64(%r12) // software prefetch
 	vbroadcastsd	16(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm2
-//	prefetcht0	128+64(%r12) // software prefetch
+	prefetcht0	256+1*64(%r12) // software prefetch
 	vbroadcastsd	24(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm3
 	vbroadcastsd	32(%r12), %zmm24 // B
@@ -343,10 +345,10 @@ NAME:
 	vmovapd			192(%r11), %zmm26 // A
 	vbroadcastsd	8+128(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm1
-//	prefetcht0	128(%r12) // software prefetch
+	prefetcht0	256+2*64(%r12) // software prefetch
 	vbroadcastsd	16+128(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm2
-//	prefetcht0	128+64(%r12) // software prefetch
+	prefetcht0	256+3*64(%r12) // software prefetch
 	vbroadcastsd	24+128(%r12), %zmm24 // B
 	vfmadd231pd		%zmm25, %zmm24, %zmm3
 	vbroadcastsd	32+128(%r12), %zmm24 // B

--- a/kernel/avx512/kernel_dgemm_8x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_8x8_lib8.S
@@ -2954,6 +2954,3032 @@ NAME:
 //
 // input arguments:
 // r10d  <- k
+// r11   <- A
+// r12   <- B
+// r13   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- B+8*k*sizeof(double)
+// r13   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_VX8_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_vx8_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+//	prefetcht0	0(%r12) // software prefetch
+//	prefetcht0	0+64(%r12) // software prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 {%k1}{z} // A
+
+	cmpl	$ 8, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+//	prefetcht0	128(%r12) // software prefetch
+//	prefetcht0	128+64(%r12) // software prefetch
+
+	// unroll 0
+	vbroadcastsd	0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	7*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	8+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	8+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	8+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	8+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	8+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vbroadcastsd	8+7*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			3*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	16+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	16+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	16+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	16+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	16+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	16+7*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			4*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	24+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	24+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	24+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	24+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	24+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	24+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vbroadcastsd	24+7*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			5*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	32+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	32+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	32+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	32+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	32+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	32+7*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			6*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	40+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	40+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	40+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	40+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	40+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	40+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vbroadcastsd	40+7*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			7*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	48+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	48+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	48+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	48+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	48+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	48+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	48+7*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	56+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	56+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	56+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	56+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	56+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	56+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vbroadcastsd	56+7*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	%r13, %r12
+
+	cmpl	$ 8, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean8-up
+	
+	cmpl	$ 7, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	7*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	8+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	8+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	8+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	8+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	8+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vbroadcastsd	8+7*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			3*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	16+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	16+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	16+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	16+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	16+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	16+7*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			4*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	24+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	24+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	24+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	24+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	24+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	24+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vbroadcastsd	24+7*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			5*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	32+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	32+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	32+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	32+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	32+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	32+7*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			6*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	40+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	40+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	40+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	40+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	40+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	40+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vbroadcastsd	40+7*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			7*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	48+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	48+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	48+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	48+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	48+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	48+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	48+7*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+//	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	56+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	56+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	56+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	56+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	56+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	56+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vbroadcastsd	56+7*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	%r13, %r12
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+	vbroadcastsd	7*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	addq	$ 64, %r11
+	addq	$ 8, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_vx8_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- B
+// r13   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- B+8*k*sizeof(double)
+// r13   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_VX7_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_vx7_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+//	prefetcht0	0(%r12) // software prefetch
+//	prefetcht0	0+64(%r12) // software prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 {%k1}{z} // A
+
+	cmpl	$ 8, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+//	prefetcht0	128(%r12) // software prefetch
+//	prefetcht0	128+64(%r12) // software prefetch
+
+	// unroll 0
+	vbroadcastsd	0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	8+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	8+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	8+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	8+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	8+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	8+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			3*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	16+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	16+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	16+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	16+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	16+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	16+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			4*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	24+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	24+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	24+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	24+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	24+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	24+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	24+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			5*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	32+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	32+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	32+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	32+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	32+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	32+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			6*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	40+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	40+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	40+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	40+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	40+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	40+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	40+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			7*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	48+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	48+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	48+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	48+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	48+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	48+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	48+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	56+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	56+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	56+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	56+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	56+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	56+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	56+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	%r13, %r12
+
+	cmpl	$ 8, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean8-up
+	
+	cmpl	$ 7, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	8+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	8+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	8+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	8+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	8+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	8+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			3*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	16+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	16+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	16+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	16+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	16+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	16+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			4*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	24+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	24+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	24+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	24+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	24+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	24+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	24+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			5*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	32+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	32+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	32+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	32+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	32+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	32+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			6*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	40+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	40+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	40+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	40+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	40+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	40+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	40+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			7*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	48+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	48+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	48+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	48+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	48+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	48+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	48+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+//	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	56+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	56+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	56+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	56+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	56+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	56+6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	56+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	%r13, %r12
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+	vbroadcastsd	6*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	addq	$ 64, %r11
+	addq	$ 8, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_vx7_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- B
+// r13   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- B+8*k*sizeof(double)
+// r13   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_VX6_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_vx6_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+//	prefetcht0	0(%r12) // software prefetch
+//	prefetcht0	0+64(%r12) // software prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 {%k1}{z} // A
+
+	cmpl	$ 8, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+//	prefetcht0	128(%r12) // software prefetch
+//	prefetcht0	128+64(%r12) // software prefetch
+
+	// unroll 0
+	vbroadcastsd	0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	8+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	8+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	8+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	8+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	8+6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	8+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			3*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	16+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	16+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	16+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	16+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	16+6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	16+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			4*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	24+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	24+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	24+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	24+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	24+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	24+6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	24+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			5*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	32+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	32+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	32+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	32+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	32+6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	32+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			6*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	40+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	40+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	40+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	40+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	40+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	40+6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	40+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			7*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	48+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	48+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	48+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	48+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	48+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	48+6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	48+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	56+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	56+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	56+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	56+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	56+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	56+6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	56+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	%r13, %r12
+
+	cmpl	$ 8, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean8-up
+	
+	cmpl	$ 7, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	8+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	8+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	8+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	8+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	8+6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	8+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			3*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	16+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	16+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	16+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	16+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	16+6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	16+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			4*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	24+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	24+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	24+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	24+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	24+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	24+6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	24+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			5*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	32+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	32+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	32+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	32+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	32+6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	32+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			6*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	40+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	40+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	40+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	40+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	40+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	40+6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	40+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			7*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	48+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	48+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	48+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	48+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	48+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	48+6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	48+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+//	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	56+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	56+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	56+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	56+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vbroadcastsd	56+5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	56+6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	56+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	%r13, %r12
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+	vbroadcastsd	5*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	addq	$ 64, %r11
+	addq	$ 8, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_vx6_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- B
+// r13   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- B+8*k*sizeof(double)
+// r13   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_VX5_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_vx5_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+//	prefetcht0	0(%r12) // software prefetch
+//	prefetcht0	0+64(%r12) // software prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 {%k1}{z} // A
+
+	cmpl	$ 8, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+//	prefetcht0	128(%r12) // software prefetch
+//	prefetcht0	128+64(%r12) // software prefetch
+
+	// unroll 0
+	vbroadcastsd	0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+//	vbroadcastsd	5*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	8+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	8+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	8+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+//	vbroadcastsd	8+5*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	8+6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	8+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			3*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	16+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	16+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	16+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+//	vbroadcastsd	16+5*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	16+6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	16+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			4*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	24+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	24+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	24+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	24+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+//	vbroadcastsd	24+5*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	24+6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	24+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			5*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	32+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	32+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	32+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+//	vbroadcastsd	32+5*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	32+6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	32+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			6*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	40+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	40+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	40+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	40+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+//	vbroadcastsd	40+5*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	40+6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	40+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			7*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	48+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	48+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	48+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	48+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+//	vbroadcastsd	48+5*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	48+6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	48+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	56+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	56+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	56+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	56+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+//	vbroadcastsd	56+5*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	56+6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	56+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	%r13, %r12
+
+	cmpl	$ 8, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean8-up
+	
+	cmpl	$ 7, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+//	vbroadcastsd	5*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	8+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	8+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	8+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+//	vbroadcastsd	8+5*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	8+6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	8+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			3*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	16+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	16+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	16+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+//	vbroadcastsd	16+5*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	16+6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	16+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			4*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	24+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	24+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	24+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	24+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+//	vbroadcastsd	24+5*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	24+6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	24+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			5*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	32+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	32+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	32+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	32+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+//	vbroadcastsd	32+5*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	32+6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	32+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+	vmovapd			6*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	40+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	40+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	40+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	40+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+//	vbroadcastsd	40+5*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	40+6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	40+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			7*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	48+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	48+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	48+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	48+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+//	vbroadcastsd	48+5*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	48+6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	48+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm0
+//	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	56+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm1
+	vbroadcastsd	56+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm2
+	vbroadcastsd	56+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm3
+	vbroadcastsd	56+4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+//	vbroadcastsd	56+5*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	56+6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	56+7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	%r13, %r12
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	vbroadcastsd	4*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm4
+//	vbroadcastsd	5*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm5
+//	vbroadcastsd	6*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm6
+//	vbroadcastsd	7*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm7
+
+	addq	$ 64, %r11
+	addq	$ 8, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_vx5_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- B
+// r13   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- B+8*k*sizeof(double)
+// r13   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_VX4_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_vx4_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		5f // return
+
+	// prefetch
+//	prefetcht0	0(%r12) // software prefetch
+//	prefetcht0	0+64(%r12) // software prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 {%k1}{z} // A
+
+	vxorpd			%zmm4, %zmm4, %zmm4
+	vmovapd			%zmm4, %zmm5
+	vmovapd			%zmm4, %zmm6
+	vmovapd			%zmm4, %zmm7
+
+	cmpl	$ 8, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+//	prefetcht0	128(%r12) // software prefetch
+//	prefetcht0	128+64(%r12) // software prefetch
+
+	// unroll 0
+	vbroadcastsd	0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	8+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vbroadcastsd	8+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			3*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	16+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	16+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			4*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	24+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	24+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vbroadcastsd	24+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			5*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	32+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	32+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	32+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			6*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	40+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	40+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vbroadcastsd	40+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			7*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	48+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	48+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	48+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	56+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	56+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vbroadcastsd	56+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	%r13, %r12
+
+	cmpl	$ 8, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean8-up
+	
+	cmpl	$ 7, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	8+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vbroadcastsd	8+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			3*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	16+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	16+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			4*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	24+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	24+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vbroadcastsd	24+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			5*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	32+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	32+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	32+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			6*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	40+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	40+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vbroadcastsd	40+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			7*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	48+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	48+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	48+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+//	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	56+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	56+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+	vbroadcastsd	56+3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	%r13, %r12
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+	vbroadcastsd	3*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm3
+
+	addq	$ 64, %r11
+	addq	$ 8, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+	vaddpd			%zmm4, %zmm0, %zmm0
+	vaddpd			%zmm5, %zmm1, %zmm1
+	vaddpd			%zmm6, %zmm2, %zmm2
+	vaddpd			%zmm7, %zmm3, %zmm3
+
+5: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_vx4_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- B
+// r13   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- B+8*k*sizeof(double)
+// r13   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_VX3_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_vx3_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		5f // return
+
+	// prefetch
+//	prefetcht0	0(%r12) // software prefetch
+//	prefetcht0	0+64(%r12) // software prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 {%k1}{z} // A
+
+	vxorpd			%zmm4, %zmm4, %zmm4
+	vmovapd			%zmm4, %zmm5
+	vmovapd			%zmm4, %zmm6
+//	vmovapd			%zmm4, %zmm7
+
+	cmpl	$ 8, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+//	prefetcht0	128(%r12) // software prefetch
+//	prefetcht0	128+64(%r12) // software prefetch
+
+	// unroll 0
+	vbroadcastsd	0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	8+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	8+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			3*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	16+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	16+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			4*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	24+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	24+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	24+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			5*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	32+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	32+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	32+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			6*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	40+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	40+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	40+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			7*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	48+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	48+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	48+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	56+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	56+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	56+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	%r13, %r12
+
+	cmpl	$ 8, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean8-up
+	
+	cmpl	$ 7, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	8+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	8+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			3*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	16+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	16+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	16+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			4*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	24+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	24+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	24+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			5*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	32+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	32+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	32+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			6*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	40+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	40+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	40+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			7*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	48+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	48+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	48+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+//	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	56+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+	vbroadcastsd	56+2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	56+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	%r13, %r12
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+	vbroadcastsd	2*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+
+	addq	$ 64, %r11
+	addq	$ 8, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+	vaddpd			%zmm4, %zmm0, %zmm0
+	vaddpd			%zmm5, %zmm1, %zmm1
+	vaddpd			%zmm6, %zmm2, %zmm2
+//	vaddpd			%zmm7, %zmm3, %zmm3
+
+5: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_vx3_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- B
+// r13   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- B+8*k*sizeof(double)
+// r13   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_VX2_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_vx2_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		5f // return
+
+	// prefetch
+//	prefetcht0	0(%r12) // software prefetch
+//	prefetcht0	0+64(%r12) // software prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 {%k1}{z} // A
+
+	vxorpd			%zmm4, %zmm4, %zmm4
+	vmovapd			%zmm4, %zmm5
+//	vmovapd			%zmm4, %zmm6
+//	vmovapd			%zmm4, %zmm7
+
+	cmpl	$ 8, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+//	prefetcht0	128(%r12) // software prefetch
+//	prefetcht0	128+64(%r12) // software prefetch
+
+	// unroll 0
+	vbroadcastsd	0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vbroadcastsd	2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	8+2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	8+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			3*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	16+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vbroadcastsd	16+2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	16+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			4*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	24+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	24+2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	24+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			5*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	32+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vbroadcastsd	32+2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	32+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			6*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	40+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	40+2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	40+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			7*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	48+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vbroadcastsd	48+2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	48+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	56+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	56+2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	56+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	%r13, %r12
+
+	cmpl	$ 8, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean8-up
+	
+	cmpl	$ 7, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vbroadcastsd	2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	8+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	8+2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	8+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			3*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	16+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vbroadcastsd	16+2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	16+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			4*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	24+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	24+2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	24+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			5*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	32+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vbroadcastsd	32+2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	32+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			6*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	40+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	40+2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	40+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			7*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastsd	48+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vbroadcastsd	48+2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	48+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+//	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	56+1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	56+2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	56+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	%r13, %r12
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vbroadcastsd	1*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vbroadcastsd	2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+
+	addq	$ 64, %r11
+	addq	$ 8, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+	vaddpd			%zmm4, %zmm0, %zmm0
+	vaddpd			%zmm5, %zmm1, %zmm1
+//	vaddpd			%zmm6, %zmm2, %zmm2
+//	vaddpd			%zmm7, %zmm3, %zmm3
+
+5: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_vx2_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- B
+// r13   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- B+8*k*sizeof(double)
+// r13   <- 4*sdb*sizeof(double)
+// k1    <- m-maks
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_VX1_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_vx1_lib8)
+#endif
+	
+	cmpl	$ 0, %r10d
+	jle		5f // return
+
+	// prefetch
+//	prefetcht0	0(%r12) // software prefetch
+//	prefetcht0	0+64(%r12) // software prefetch
+
+	// preload
+	vmovapd 		0(%r11), %zmm25 {%k1}{z} // A
+
+	vxorpd			%zmm4, %zmm4, %zmm4
+//	vmovapd			%zmm4, %zmm5
+//	vmovapd			%zmm4, %zmm6
+//	vmovapd			%zmm4, %zmm7
+
+	cmpl	$ 8, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+//	prefetcht0	128(%r12) // software prefetch
+//	prefetcht0	128+64(%r12) // software prefetch
+
+	// unroll 0
+	vbroadcastsd	0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			1*64(%r11), %zmm26 {%k1}{z} // A
+//	vbroadcastsd	1*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vbroadcastsd	2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
+//	vbroadcastsd	8+1*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	8+2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	8+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			3*64(%r11), %zmm26 {%k1}{z} // A
+//	vbroadcastsd	16+1*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vbroadcastsd	16+2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	16+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			4*64(%r11), %zmm25 {%k1}{z} // A
+//	vbroadcastsd	24+1*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	24+2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	24+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			5*64(%r11), %zmm26 {%k1}{z} // A
+//	vbroadcastsd	32+1*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vbroadcastsd	32+2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	32+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			6*64(%r11), %zmm25 {%k1}{z} // A
+//	vbroadcastsd	40+1*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	40+2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	40+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			7*64(%r11), %zmm26 {%k1}{z} // A
+//	vbroadcastsd	48+1*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vbroadcastsd	48+2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	48+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
+//	vbroadcastsd	56+1*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	56+2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	56+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	%r13, %r12
+
+	cmpl	$ 8, %r10d
+	jg		1b // main loop 
+
+
+0: // consider clean8-up
+	
+	cmpl	$ 7, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastsd	0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			1*64(%r11), %zmm26 {%k1}{z} // A
+//	vbroadcastsd	1*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vbroadcastsd	2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	subl	$ 8, %r10d
+
+	// unroll 1
+	vbroadcastsd	8+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			2*64(%r11), %zmm25 {%k1}{z} // A
+//	vbroadcastsd	8+1*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	8+2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	8+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 2
+	vbroadcastsd	16+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			3*64(%r11), %zmm26 {%k1}{z} // A
+//	vbroadcastsd	16+1*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vbroadcastsd	16+2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	16+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+
+	// unroll 3
+	vbroadcastsd	24+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			4*64(%r11), %zmm25 {%k1}{z} // A
+//	vbroadcastsd	24+1*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	24+2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	24+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 4
+	vbroadcastsd	32+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			5*64(%r11), %zmm26 {%k1}{z} // A
+//	vbroadcastsd	32+1*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vbroadcastsd	32+2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	32+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+
+	// unroll 5
+	vbroadcastsd	40+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+	vmovapd			6*64(%r11), %zmm25 {%k1}{z} // A
+//	vbroadcastsd	40+1*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	40+2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	40+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+
+	// unroll 6
+	vbroadcastsd	48+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+	vmovapd			7*64(%r11), %zmm26 {%k1}{z} // A
+//	vbroadcastsd	48+1*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vbroadcastsd	48+2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	48+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+	addq	$ 512, %r11
+
+	// unroll 7
+	vbroadcastsd	56+0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm26, %zmm24, %zmm4
+//	vmovapd			0*64(%r11), %zmm25 {%k1}{z} // A
+//	vbroadcastsd	56+1*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm5
+//	vbroadcastsd	56+2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm6
+//	vbroadcastsd	56+3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	addq	%r13, %r12
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+	
+	// unroll 0
+	vmovapd			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastsd	0*64(%r12), %zmm24 // B
+	vfmadd231pd		%zmm25, %zmm24, %zmm0
+//	vbroadcastsd	1*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm1
+//	vbroadcastsd	2*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm2
+//	vbroadcastsd	3*64(%r12), %zmm24 // B
+//	vfmadd231pd		%zmm25, %zmm24, %zmm3
+
+	addq	$ 64, %r11
+	addq	$ 8, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop 
+
+
+2: // return
+
+	vaddpd			%zmm4, %zmm0, %zmm0
+//	vaddpd			%zmm5, %zmm1, %zmm1
+//	vaddpd			%zmm6, %zmm2, %zmm2
+//	vaddpd			%zmm7, %zmm3, %zmm3
+
+5: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_vx1_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
+// r11   <- A
+// r12   <- B
+// r13   <- 4*sdb*sizeof(double)
+// r14   <- m1
+// r15   <- n1
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- A+8*k*sizeof(double)
+// r12   <- B+8*k*sizeof(double)
+// r13   <- 4*sdb*sizeof(double)
+// r14   <- m1
+// r15   <- n1
+// zmm0  <- []
+// ...
+// zmm7  <- []
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEMM_NN_8X8_VS_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgemm_nn_8x8_vs_lib8)
+#endif
+
+	// compute mask for rows
+	vcvtsi2sd	%r14d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC00(%rip), %zmm24
+#elif defined(OS_MAC)
+	vmovupd		LC00(%rip), %zmm24
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm24, %zmm25
+	vpmovq2m	%zmm25, %k1
+
+	cmpl	$ 1, %r15d
+	jg		100f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_VX1_LIB8
+#else
+	CALL(inner_kernel_dgemm_nn_vx1_lib8)
+#endif
+	
+	jmp		107f
+
+100:
+
+	cmpl	$ 2, %r15d
+	jg		101f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_VX2_LIB8
+#else
+	CALL(inner_kernel_dgemm_nn_vx2_lib8)
+#endif
+	
+	jmp		107f
+
+101:
+
+	cmpl	$ 3, %r15d
+	jg		102f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_VX3_LIB8
+#else
+	CALL(inner_kernel_dgemm_nn_vx3_lib8)
+#endif
+	
+	jmp		107f
+
+102:
+
+	cmpl	$ 4, %r15d
+	jg		103f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_VX4_LIB8
+#else
+	CALL(inner_kernel_dgemm_nn_vx4_lib8)
+#endif
+	
+	jmp		107f
+
+103:
+
+	cmpl	$ 5, %r15d
+	jg		104f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_VX5_LIB8
+#else
+	CALL(inner_kernel_dgemm_nn_vx5_lib8)
+#endif
+	
+	jmp		107f
+
+104:
+
+	cmpl	$ 6, %r15d
+	jg		105f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_VX6_LIB8
+#else
+	CALL(inner_kernel_dgemm_nn_vx6_lib8)
+#endif
+	
+	jmp		107f
+
+105:
+
+	cmpl	$ 7, %r15d
+	jg		106f
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_VX7_LIB8
+#else
+	CALL(inner_kernel_dgemm_nn_vx7_lib8)
+#endif
+	
+	jmp		107f
+
+106:
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NN_VX8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nn_vx8_lib8)
+#endif
+
+107:
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgemm_nn_8x8_vs_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// input arguments:
+// r10d  <- k
 // r11   <- B
 // r12   <- C
 // zmm0  <- [a00 ... a70]
@@ -7689,18 +10715,23 @@ NAME:
 	movq	ARG5, %r12  // B
 	movq	ARG6, %r13 // sdb
 	sall	$ 6, %r13d // 4*sdb*sizeof(double)
+
 	movq	ARG4, %r14 // offsetB
 
+	// TODO vs
 #if MACRO_LEVEL>=1
 	INNER_EDGE_DGEMM_NN_8X8_LIB8
 #else
 	CALL(inner_edge_dgemm_nn_8x8_lib8)
 #endif
 
+	movq	ARG10, %r14 // km 
+	movq	ARG11, %r15 // kn 
+
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_8X8_LIB8
+	INNER_KERNEL_DGEMM_NN_8X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nn_8x8_lib8)
+	CALL(inner_kernel_dgemm_nn_8x8_vs_lib8)
 #endif
 
 
@@ -7761,18 +10792,23 @@ NAME:
 	movq	ARG5, %r12  // B
 	movq	ARG6, %r13 // sdb
 	sall	$ 6, %r13d // 4*sdb*sizeof(double)
+
 	movq	ARG4, %r14 // offsetB
 
+	// TODO vs
 #if MACRO_LEVEL>=1
 	INNER_EDGE_DGEMM_NN_8X8_LIB8
 #else
 	CALL(inner_edge_dgemm_nn_8x8_lib8)
 #endif
 
+	movq	ARG15, %r14 // km 
+	movq	ARG17, %r15 // kn 
+
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_8X8_LIB8
+	INNER_KERNEL_DGEMM_NN_8X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nn_8x8_lib8)
+	CALL(inner_kernel_dgemm_nn_8x8_vs_lib8)
 #endif
 
 
@@ -7917,18 +10953,23 @@ NAME:
 	movq	ARG4, %r12  // A
 	movq	ARG5, %r13 // sda
 	sall	$ 6, %r13d // 8*sda*sizeof(double)
+
 	movq	ARG3, %r14 // offsetA
 
+	// TODO vs
 #if MACRO_LEVEL>=1
 	INNER_EDGE_DGEMM_NN_8X8_LIB8
 #else
 	CALL(inner_edge_dgemm_nn_8x8_lib8)
 #endif
 
+	movq	ARG11, %r14 // n1
+	movq	ARG10, %r15 // m1
+
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_8X8_LIB8
+	INNER_KERNEL_DGEMM_NN_8X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nn_8x8_lib8)
+	CALL(inner_kernel_dgemm_nn_8x8_vs_lib8)
 #endif
 
 #if MACRO_LEVEL>=1
@@ -7995,18 +11036,23 @@ NAME:
 	movq	ARG4, %r12  // A
 	movq	ARG5, %r13 // sda
 	sall	$ 6, %r13d // 8*sda*sizeof(double)
+
 	movq	ARG3, %r14 // offsetA
 
+	// TODO vs
 #if MACRO_LEVEL>=1
 	INNER_EDGE_DGEMM_NN_8X8_LIB8
 #else
 	CALL(inner_edge_dgemm_nn_8x8_lib8)
 #endif
 
+	movq	ARG17, %r14 // n1
+	movq	ARG15, %r15 // m1
+
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_8X8_LIB8
+	INNER_KERNEL_DGEMM_NN_8X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nn_8x8_lib8)
+	CALL(inner_kernel_dgemm_nn_8x8_vs_lib8)
 #endif
 
 #if MACRO_LEVEL>=1
@@ -8358,14 +11404,17 @@ NAME:
 	movq	ARG5, %r12 // B
 	movq	ARG6, %r13 // sdb
 	sall	$ 6, %r13d // 4*sdb*sizeof(double)
+
 	movq	ARG4, %r14 // offsetB
 
+	// TODO vs
 #if MACRO_LEVEL>=1
 	INNER_EDGE_DTRMM_NN_RL_8X8_LIB8
 #else
 	CALL(inner_edge_dtrmm_nn_rl_8x8_lib8)
 #endif
 
+	// TODO vs
 #if MACRO_LEVEL>=1
 	INNER_EDGE_DGEMM_NN_8X8_LIB8
 #else
@@ -8374,10 +11423,13 @@ NAME:
 
 	// call inner dgemm kernel nn after initial triangle
 
+	movq	ARG8, %r13 // m1
+	movq	ARG9, %r14 // n1
+
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_8X8_LIB8
+	INNER_KERNEL_DGEMM_NN_8X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nn_8x8_lib8)
+	CALL(inner_kernel_dgemm_nn_8x8_vs_lib8)
 #endif
 
 
@@ -8435,14 +11487,17 @@ NAME:
 	movq	ARG5, %r12 // B
 	movq	ARG6, %r13 // sdb
 	sall	$ 6, %r13d // 4*sdb*sizeof(double)
+
 	movq	ARG4, %r14 // offsetB
 
+	// TODO vs
 #if MACRO_LEVEL>=1
 	INNER_EDGE_DTRMM_NN_RL_8X8_LIB8
 #else
 	CALL(inner_edge_dtrmm_nn_rl_8x8_lib8)
 #endif
 
+	// TODO vs
 #if MACRO_LEVEL>=1
 	INNER_EDGE_DGEMM_NN_8X8_LIB8
 #else
@@ -8451,10 +11506,13 @@ NAME:
 
 	// call inner dgemm kernel nn after initial triangle
 
+	movq	ARG11, %r14 // m1
+	movq	ARG13, %r15 // n1
+
 #if MACRO_LEVEL>=2
-	INNER_KERNEL_DGEMM_NN_8X8_LIB8
+	INNER_KERNEL_DGEMM_NN_8X8_VS_LIB8
 #else
-	CALL(inner_kernel_dgemm_nn_8x8_lib8)
+	CALL(inner_kernel_dgemm_nn_8x8_vs_lib8)
 #endif
 
 

--- a/kernel/avx512/kernel_dgemm_8x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_8x8_lib8.S
@@ -8235,23 +8235,21 @@ NAME:
 //
 // input arguments:
 // r10  <- inv_diag_E
-// r11d <- kn
 // zmm0 <- []
 // ...
 // ymm7 <- []
 //
 // output arguments:
 // r10  <- inv_diag_E
-// r11d <- kn
 // zmm0 <- []
 // ...
 // ymm7 <- []
 
 #if MACRO_LEVEL>=1
-	.macro INNER_EDGE_DPOTRF_8X8_VS_LIB8
+	.macro INNER_EDGE_DPOTRF_8X8_LIB8
 #else
 	.p2align 4,,15
-	FUN_START(inner_edge_dpotrf_8x8_vs_lib8)
+	FUN_START(inner_edge_dpotrf_8x8_lib8)
 #endif
 
 	vxorpd	%ymm25, %ymm25, %ymm25 // 0.0
@@ -8271,7 +8269,442 @@ NAME:
 	vmovsd			%xmm26, 0(%r10)
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm0, %zmm26, %zmm0
-	cmpl			$ 2, %r11d
+	vmovapd			%zmm1, %zmm26
+	vfnmadd231pd	%zmm0, %zmm0, %zmm26
+
+	// 1
+//	vpermilpd		$ 0x3, %xmm1, %xmm26
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm26, %zmm27, %zmm26
+	vucomisd		%xmm25, %xmm26 // d_11 > 0.0 ?
+	jbe				3f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+4:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+1*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+1*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm1
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm2
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm3
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm4
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm5
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm6
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm0, %zmm27, %zmm27
+	vfnmadd231pd	%zmm0, %zmm27, %zmm7
+	vmovsd			%xmm26, 8(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm1, %zmm26, %zmm1
+	vmovapd			%zmm2, %zmm26
+	vfnmadd231pd	%zmm1, %zmm1, %zmm26
+
+	// 2
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm26, %zmm27, %zmm26
+	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
+	jbe				5f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+6:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+2*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+2*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm2
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm3
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm4
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm5
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm6
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm1, %zmm27, %zmm27
+	vfnmadd231pd	%zmm1, %zmm27, %zmm7
+	vmovsd			%xmm26, 16(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm2, %zmm26, %zmm2
+	vmovapd			%zmm3, %zmm26
+	vfnmadd231pd	%zmm2, %zmm2, %zmm26
+
+	// 3
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm26, %zmm27, %zmm26
+	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
+	jbe				7f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+8:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+3*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+3*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm27
+	vfnmadd231pd	%zmm2, %zmm27, %zmm3
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm27
+	vfnmadd231pd	%zmm2, %zmm27, %zmm4
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm27
+	vfnmadd231pd	%zmm2, %zmm27, %zmm5
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm27
+	vfnmadd231pd	%zmm2, %zmm27, %zmm6
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm2, %zmm27, %zmm27
+	vfnmadd231pd	%zmm2, %zmm27, %zmm7
+	vmovsd			%xmm26, 24(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm3, %zmm26, %zmm3
+	vmovapd			%zmm4, %zmm26
+	vfnmadd231pd	%zmm3, %zmm3, %zmm26
+
+	// 4
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm26, %zmm27, %zmm26
+	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
+	jbe				9f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+10:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+4*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+4*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm3, %zmm27, %zmm27
+	vfnmadd231pd	%zmm3, %zmm27, %zmm4
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm3, %zmm27, %zmm27
+	vfnmadd231pd	%zmm3, %zmm27, %zmm5
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm3, %zmm27, %zmm27
+	vfnmadd231pd	%zmm3, %zmm27, %zmm6
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm3, %zmm27, %zmm27
+	vfnmadd231pd	%zmm3, %zmm27, %zmm7
+	vmovsd			%xmm26, 32(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm4, %zmm26, %zmm4
+	vmovapd			%zmm5, %zmm26
+	vfnmadd231pd	%zmm4, %zmm4, %zmm26
+
+	// 5
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm26, %zmm27, %zmm26
+	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
+	jbe				11f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+12:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+5*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+5*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm4, %zmm27, %zmm27
+	vfnmadd231pd	%zmm4, %zmm27, %zmm5
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm4, %zmm27, %zmm27
+	vfnmadd231pd	%zmm4, %zmm27, %zmm6
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm4, %zmm27, %zmm27
+	vfnmadd231pd	%zmm4, %zmm27, %zmm7
+	vmovsd			%xmm26, 40(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm5, %zmm26, %zmm5
+	vmovapd			%zmm6, %zmm26
+	vfnmadd231pd	%zmm5, %zmm5, %zmm26
+
+	// 6
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm26, %zmm27, %zmm26
+	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
+	jbe				13f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+14:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+6*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+6*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm5, %zmm27, %zmm27
+	vfnmadd231pd	%zmm5, %zmm27, %zmm6
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm5, %zmm27, %zmm27
+	vfnmadd231pd	%zmm5, %zmm27, %zmm7
+	vmovsd			%xmm26, 48(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm6, %zmm26, %zmm6
+	vmovapd			%zmm7, %zmm26
+	vfnmadd231pd	%zmm6, %zmm6, %zmm26
+
+	// 7
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm26, %zmm27, %zmm26
+	vucomisd		%xmm25, %xmm26 // d_22 > 0.0 ?
+	jbe				15f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+16:
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+//	vbroadcastsd	.LC05+7*8(%rip), %zmm27
+#elif defined(OS_MAC)
+//	vbroadcastsd	LC05+7*8(%rip), %zmm27
+#endif
+	vpermpd			%zmm6, %zmm27, %zmm27
+	vfnmadd231pd	%zmm6, %zmm27, %zmm7
+	vmovsd			%xmm26, 56(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm7, %zmm26, %zmm7
+
+	jmp				0f
+
+1:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				2b
+
+3:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				4b
+
+5:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				6b
+
+7:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				8b
+
+9:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				10b
+
+11:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				12b
+
+13:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				14b
+
+15:
+	vxorpd			%zmm26, %zmm26, %zmm26
+	jmp				16b
+
+0:
+	#if MACRO_LEVEL>=1
+	.endm
+#else
+	ret
+
+	FUN_END(inner_edge_dpotrf_8x8_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
+// cholesky factorization 
+//
+// input arguments:
+// r10  <- inv_diag_E
+// r11d <- m1
+// r12d <- n1
+// zmm0 <- []
+// ...
+// ymm7 <- []
+//
+// output arguments:
+// r10  <- inv_diag_E
+// r11d <- m1
+// r12d <- n1
+// zmm0 <- []
+// ...
+// ymm7 <- []
+
+#if MACRO_LEVEL>=1
+	.macro INNER_EDGE_DPOTRF_8X8_VS_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_edge_dpotrf_8x8_vs_lib8)
+#endif
+
+	// compute mask for rows
+	vcvtsi2sd	%r11d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC00(%rip), %zmm24
+#elif defined(OS_MAC)
+	vmovupd		LC00(%rip), %zmm24
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm24, %zmm25
+	vpmovq2m	%zmm25, %k1
+
+	vmovapd		%zmm0, %zmm0 {%k1}{z}
+	vmovapd		%zmm1, %zmm1 {%k1}{z}
+	vmovapd		%zmm2, %zmm2 {%k1}{z}
+	vmovapd		%zmm3, %zmm3 {%k1}{z}
+	vmovapd		%zmm4, %zmm4 {%k1}{z}
+	vmovapd		%zmm5, %zmm5 {%k1}{z}
+	vmovapd		%zmm6, %zmm6 {%k1}{z}
+	vmovapd		%zmm7, %zmm7 {%k1}{z}
+
+	vxorpd	%ymm25, %ymm25, %ymm25 // 0.0
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovsd	.LC04(%rip), %xmm24 // 1.0
+#elif defined(OS_MAC)
+	vmovsd	LC04(%rip), %xmm24 // 1.0
+#endif
+
+	// 0
+	vmovsd			%xmm0, %xmm0, %xmm26
+	vucomisd		%xmm25, %xmm26 // d_00 > 0.0 ?
+	jbe				1f
+	vsqrtsd			%xmm26, %xmm26, %xmm26
+	vdivsd			%xmm26, %xmm24, %xmm26
+2:
+	vmovsd			%xmm26, 0(%r10)
+	vbroadcastsd	%xmm26, %zmm26
+	vmulpd			%zmm0, %zmm26, %zmm0
+	cmpl			$ 2, %r12d
 	jl				0f // ret
 	vmovapd			%zmm1, %zmm26
 	vfnmadd231pd	%zmm0, %zmm0, %zmm26
@@ -8341,7 +8774,7 @@ NAME:
 	vmovsd			%xmm26, 8(%r10)
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm1, %zmm26, %zmm1
-	cmpl			$ 3, %r11d
+	cmpl			$ 3, %r12d
 	jl				0f // ret
 	vmovapd			%zmm2, %zmm26
 	vfnmadd231pd	%zmm1, %zmm1, %zmm26
@@ -8403,7 +8836,7 @@ NAME:
 	vmovsd			%xmm26, 16(%r10)
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm2, %zmm26, %zmm2
-	cmpl			$ 4, %r11d
+	cmpl			$ 4, %r12d
 	jl				0f // ret
 	vmovapd			%zmm3, %zmm26
 	vfnmadd231pd	%zmm2, %zmm2, %zmm26
@@ -8458,7 +8891,7 @@ NAME:
 	vmovsd			%xmm26, 24(%r10)
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm3, %zmm26, %zmm3
-	cmpl			$ 5, %r11d
+	cmpl			$ 5, %r12d
 	jl				0f // ret
 	vmovapd			%zmm4, %zmm26
 	vfnmadd231pd	%zmm3, %zmm3, %zmm26
@@ -8506,7 +8939,7 @@ NAME:
 	vmovsd			%xmm26, 32(%r10)
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm4, %zmm26, %zmm4
-	cmpl			$ 6, %r11d
+	cmpl			$ 6, %r12d
 	jl				0f // ret
 	vmovapd			%zmm5, %zmm26
 	vfnmadd231pd	%zmm4, %zmm4, %zmm26
@@ -8547,7 +8980,7 @@ NAME:
 	vmovsd			%xmm26, 40(%r10)
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm5, %zmm26, %zmm5
-	cmpl			$ 7, %r11d
+	cmpl			$ 7, %r12d
 	jl				0f // ret
 	vmovapd			%zmm6, %zmm26
 	vfnmadd231pd	%zmm5, %zmm5, %zmm26
@@ -8581,7 +9014,7 @@ NAME:
 	vmovsd			%xmm26, 48(%r10)
 	vbroadcastsd	%xmm26, %zmm26
 	vmulpd			%zmm6, %zmm26, %zmm6
-	cmpl			$ 8, %r11d
+	cmpl			$ 8, %r12d
 	jl				0f // ret
 	vmovapd			%zmm7, %zmm26
 	vfnmadd231pd	%zmm6, %zmm6, %zmm26
@@ -8742,7 +9175,8 @@ NAME:
 // r10   <- alpha
 // r11   <- beta
 // r12   <- C
-// r13d  <- n1
+// r13d  <- m1
+// r14d  <- n1
 // zmm0 <- []
 // ...
 // zmm7 <- []
@@ -8751,7 +9185,8 @@ NAME:
 // r10   <- alpha
 // r11   <- beta
 // r12   <- C
-// r13d  <- n1
+// r13d  <- m1
+// r14d  <- n1
 // zmm0 <- []
 // ...
 // zmm7 <- []
@@ -8783,35 +9218,46 @@ NAME:
 	vucomisd	%xmm25, %xmm24 // beta==0.0 ?
 	je			0f // end
 
-	vmovapd		0(%r12), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm0
-	cmpl	$ 2, %r13d
+	// compute mask for rows
+	vcvtsi2sd	%r13d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC00(%rip), %zmm26
+#elif defined(OS_MAC)
+	vmovupd		LC00(%rip), %zmm26
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm26, %zmm25
+	vpmovq2m	%zmm25, %k1
+
+	vmovapd		0(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm0 {%k1}
+	cmpl	$ 2, %r14d
 	jl		0f // end
-	vmovapd		64(%r12), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm1
-	cmpl	$ 3, %r13d
+	vmovapd		64(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm1 {%k1}
+	cmpl	$ 3, %r14d
 	jl		0f // end
-	vmovapd		128(%r12), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm2
-	cmpl	$ 4, %r13d
+	vmovapd		128(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm2 {%k1}
+	cmpl	$ 4, %r14d
 	jl		0f // end
-	vmovapd		192(%r12), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm3
-	cmpl	$ 5, %r13d
+	vmovapd		192(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm3 {%k1}
+	cmpl	$ 5, %r14d
 	jl		0f // end
-	vmovapd		0+256(%r12), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm4
-	cmpl	$ 6, %r13d
+	vmovapd		0+256(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm4 {%k1}
+	cmpl	$ 6, %r14d
 	jl		0f // end
-	vmovapd		64+256(%r12), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm5
-	cmpl	$ 7, %r13d
+	vmovapd		64+256(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm5 {%k1}
+	cmpl	$ 7, %r14d
 	jl		0f // end
-	vmovapd		128+256(%r12), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm6
-	je		0f // end
-	vmovapd		192+256(%r12), %zmm25
-	vfmadd231pd	%zmm24, %zmm25, %zmm7
+	vmovapd		128+256(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm6 {%k1}
+	je		0f // end {%k1}
+	vmovapd		192+256(%r12), %zmm25 {%k1}{z}
+	vfmadd231pd	%zmm24, %zmm25, %zmm7 {%k1}
 
 0:
 
@@ -8854,6 +9300,8 @@ NAME:
 // zmm0 <- []
 // ...
 // zmm7 <- []
+
+// TODO m-mask !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 #if MACRO_LEVEL>=1
 	.macro INNER_SCALE_AB_8X8_GEN_LIB8
@@ -9294,7 +9742,8 @@ NAME:
 // input arguments:
 // r10   <- beta
 // r11   <- C
-// r12d  <- n1
+// r12d  <- m1
+// r13d  <- n1
 // zmm0 <- []
 // ...
 // zmm7 <- []
@@ -9302,7 +9751,8 @@ NAME:
 // output arguments:
 // r10   <- beta
 // r11   <- C
-// r12d  <- n1
+// r12d  <- m1
+// r13d  <- n1
 // zmm0 <- []
 // ...
 // zmm7 <- []
@@ -9322,35 +9772,46 @@ NAME:
 	vucomisd	%xmm25, %xmm24 // beta==0.0 ?
 	je			0f // end
 
-	vmovapd		0(%r11), %zmm25
-	vfmsub231pd	%zmm24, %zmm25, %zmm0
-	cmpl	$ 2, %r12d
+	// compute mask for rows
+	vcvtsi2sd	%r12d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC00(%rip), %zmm26
+#elif defined(OS_MAC)
+	vmovupd		LC00(%rip), %zmm26
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm26, %zmm25
+	vpmovq2m	%zmm25, %k1
+
+	vmovapd		0(%r11), %zmm25 {%k1}{z}
+	vfmsub231pd	%zmm24, %zmm25, %zmm0 {%k1}
+	cmpl	$ 2, %r13d
 	jl		0f // end
-	vmovapd		1*64(%r11), %zmm25
-	vfmsub231pd	%zmm24, %zmm25, %zmm1
-	cmpl	$ 3, %r12d
+	vmovapd		1*64(%r11), %zmm25 {%k1}{z}
+	vfmsub231pd	%zmm24, %zmm25, %zmm1 {%k1}
+	cmpl	$ 3, %r13d
 	jl		0f // end
-	vmovapd		2*64(%r11), %zmm25
-	vfmsub231pd	%zmm24, %zmm25, %zmm2
-	cmpl	$ 4, %r12d
+	vmovapd		2*64(%r11), %zmm25 {%k1}{z}
+	vfmsub231pd	%zmm24, %zmm25, %zmm2 {%k1}
+	cmpl	$ 4, %r13d
 	jl		0f // end
-	vmovapd		3*64(%r11), %zmm25
-	vfmsub231pd	%zmm24, %zmm25, %zmm3
-	cmpl	$ 5, %r12d
+	vmovapd		3*64(%r11), %zmm25 {%k1}{z}
+	vfmsub231pd	%zmm24, %zmm25, %zmm3 {%k1}
+	cmpl	$ 5, %r13d
 	jl		0f // end
-	vmovapd		4*64(%r11), %zmm25
-	vfmsub231pd	%zmm24, %zmm25, %zmm4
-	cmpl	$ 6, %r12d
+	vmovapd		4*64(%r11), %zmm25 {%k1}{z}
+	vfmsub231pd	%zmm24, %zmm25, %zmm4 {%k1}
+	cmpl	$ 6, %r13d
 	jl		0f // end
-	vmovapd		5*64(%r11), %zmm25
-	vfmsub231pd	%zmm24, %zmm25, %zmm5
-	cmpl	$ 7, %r12d
+	vmovapd		5*64(%r11), %zmm25 {%k1}{z}
+	vfmsub231pd	%zmm24, %zmm25, %zmm5 {%k1}
+	cmpl	$ 7, %r13d
 	jl		0f // end
-	vmovapd		6*64(%r11), %zmm25
-	vfmsub231pd	%zmm24, %zmm25, %zmm6
+	vmovapd		6*64(%r11), %zmm25 {%k1}{z}
+	vfmsub231pd	%zmm24, %zmm25, %zmm6 {%k1}
 	je		0f // end
-	vmovapd		7*64(%r11), %zmm25
-	vfmsub231pd	%zmm24, %zmm25, %zmm7
+	vmovapd		7*64(%r11), %zmm25 {%k1}{z}
+	vfmsub231pd	%zmm24, %zmm25, %zmm7 {%k1}
 
 0:
 
@@ -9424,14 +9885,16 @@ NAME:
 //
 // input arguments:
 // r10   <- C
-// r11d  <- n1
+// r11d  <- m1
+// r12d  <- n1
 // zmm0 <- []
 // ...
 // zmm7 <- []
 //
 // output arguments:
 // r10   <- C
-// r11d  <- n1
+// r11d  <- m1
+// r12d  <- n1
 // zmm0 <- []
 // ...
 // zmm7 <- []
@@ -9443,35 +9906,46 @@ NAME:
 	FUN_START(inner_scale_m11_8x8_vs_lib8)
 #endif	
 	
-	vmovapd		0(%r10), %zmm24
-	vsubpd		%zmm0, %zmm24, %zmm0
-	cmpl	$ 2, %r11d
+	// compute mask for rows
+	vcvtsi2sd	%r11d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC00(%rip), %zmm26
+#elif defined(OS_MAC)
+	vmovupd		LC00(%rip), %zmm26
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm26, %zmm25
+	vpmovq2m	%zmm25, %k1
+
+	vmovapd		0(%r10), %zmm24 {%k1}{z}
+	vsubpd		%zmm0, %zmm24, %zmm0 {%k1}
+	cmpl	$ 2, %r12d
 	jl		0f // end
-	vmovapd		1*64(%r10), %zmm24
-	vsubpd		%zmm1, %zmm24, %zmm1
-	cmpl	$ 3, %r11d
+	vmovapd		1*64(%r10), %zmm24 {%k1}{z}
+	vsubpd		%zmm1, %zmm24, %zmm1 {%k1}
+	cmpl	$ 3, %r12d
 	jl		0f // end
-	vmovapd		2*64(%r10), %zmm24
-	vsubpd		%zmm2, %zmm24, %zmm2
-	cmpl	$ 4, %r11d
+	vmovapd		2*64(%r10), %zmm24 {%k1}{z}
+	vsubpd		%zmm2, %zmm24, %zmm2 {%k1}
+	cmpl	$ 4, %r12d
 	jl		0f // end
-	vmovapd		3*64(%r10), %zmm24
-	vsubpd		%zmm3, %zmm24, %zmm3
-	cmpl	$ 5, %r11d
+	vmovapd		3*64(%r10), %zmm24 {%k1}{z}
+	vsubpd		%zmm3, %zmm24, %zmm3 {%k1}
+	cmpl	$ 5, %r12d
 	jl		0f // end
-	vmovapd		4*64(%r10), %zmm24
-	vsubpd		%zmm4, %zmm24, %zmm4
-	cmpl	$ 6, %r11d
+	vmovapd		4*64(%r10), %zmm24 {%k1}{z}
+	vsubpd		%zmm4, %zmm24, %zmm4 {%k1}
+	cmpl	$ 6, %r12d
 	jl		0f // end
-	vmovapd		5*64(%r10), %zmm24
-	vsubpd		%zmm5, %zmm24, %zmm5
-	cmpl	$ 7, %r11d
+	vmovapd		5*64(%r10), %zmm24 {%k1}{z}
+	vsubpd		%zmm5, %zmm24, %zmm5 {%k1}
+	cmpl	$ 7, %r12d
 	jl		0f // end
-	vmovapd		6*64(%r10), %zmm24
-	vsubpd		%zmm6, %zmm24, %zmm6
+	vmovapd		6*64(%r10), %zmm24 {%k1}{z}
+	vsubpd		%zmm6, %zmm24, %zmm6 {%k1}
 	je		0f // end
-	vmovapd		7*64(%r10), %zmm24
-	vsubpd		%zmm7, %zmm24, %zmm7
+	vmovapd		7*64(%r10), %zmm24 {%k1}{z}
+	vsubpd		%zmm7, %zmm24, %zmm7 {%k1}
 
 0:
 
@@ -10704,7 +11178,8 @@ NAME:
 	movq	ARG2, %r10 // alpha
 	movq	ARG5, %r11 // beta
 	movq	ARG6, %r12   // C
-	movq	ARG9, %r13 // n1
+	movq	ARG8, %r13 // m1 
+	movq	ARG9, %r14 // n1
 
 #if MACRO_LEVEL>=1
 	INNER_SCALE_AB_8X8_VS_LIB8
@@ -10924,7 +11399,8 @@ NAME:
 	movq	ARG2, %r10 // alpha
 	movq	ARG7, %r11 // beta
 	movq	ARG8, %r12   // C
-	movq	ARG11, %r13 // kn 
+	movq	ARG10, %r13 // km 
+	movq	ARG11, %r14 // kn 
 
 #if MACRO_LEVEL>=1
 	INNER_SCALE_AB_8X8_VS_LIB8
@@ -11168,7 +11644,8 @@ NAME:
 	movq	ARG2, %r10 // alpha
 	movq	ARG7, %r11 // beta
 	movq	ARG8, %r12 // C
-	movq	ARG11, %r13 // kn 
+	movq	ARG10, %r13 // km 
+	movq	ARG11, %r14 // kn 
 
 #if MACRO_LEVEL>=1
 	INNER_SCALE_AB_8X8_VS_LIB8
@@ -11386,7 +11863,8 @@ NAME:
 	movq	ARG2, %r10 // alpha
 	movq	ARG5, %r11 // beta
 	movq	ARG6, %r12   // C
-	movq	ARG9, %r13 // n1
+	movq	ARG8, %r13 // m1 
+	movq	ARG9, %r14 // n1
 
 #if MACRO_LEVEL>=1
 	INNER_SCALE_AB_8X8_VS_LIB8
@@ -11842,7 +12320,8 @@ NAME:
 
 	movq	ARG4, %r10 // C
 	movq	ARG5, %r11 // beta
-	movq	ARG10, %r12 // n1
+	movq	ARG9, %r12 // m1
+	movq	ARG10, %r13 // n1
 
 #if MACRO_LEVEL>=1
 	INNER_SCALE_M1B_8X8_VS_LIB8
@@ -12024,7 +12503,8 @@ NAME:
 	// call inner blender_loader nn
 
 	movq	ARG7, %r10   // C
-	movq	ARG12, %r11   // n1
+	movq	ARG11, %r11   // m1
+	movq	ARG12, %r12   // n1
 
 #if MACRO_LEVEL>=1
 	INNER_SCALE_M11_8X8_VS_LIB8
@@ -12109,12 +12589,11 @@ NAME:
 	// factorization
 
 	movq	ARG6, %r10  // inv_diag_D 
-	movl	$ 8, %r11d
 
 #if MACRO_LEVEL>=1
-	INNER_EDGE_DPOTRF_8X8_VS_LIB8
+	INNER_EDGE_DPOTRF_8X8_LIB8
 #else
-	CALL(inner_edge_dpotrf_8x8_vs_lib8)
+	CALL(inner_edge_dpotrf_8x8_lib8)
 #endif
 
 
@@ -12170,7 +12649,8 @@ NAME:
 	// call inner blender_loader nn
 
 	movq	ARG4, %r10 // C
-	movq	ARG8, %r11 // kn 
+	movq	ARG7, %r11 // m1
+	movq	ARG8, %r12 // n1
 
 #if MACRO_LEVEL>=1
 	INNER_SCALE_M11_8X8_VS_LIB8
@@ -12182,7 +12662,8 @@ NAME:
 	// factorization
 
 	movq	ARG6, %r10  // inv_diag_D 
-	movq	ARG8, %r11 // kn 
+	movq	ARG7, %r11 // m1
+	movq	ARG8, %r12 // n1
 
 #if MACRO_LEVEL>=1
 	INNER_EDGE_DPOTRF_8X8_VS_LIB8
@@ -12271,12 +12752,11 @@ NAME:
 	// factorization
 
 	movq	ARG9, %r10  // inv_diag_D 
-	movl	$ 8, %r11d
 
 #if MACRO_LEVEL>=1
-	INNER_EDGE_DPOTRF_8X8_VS_LIB8
+	INNER_EDGE_DPOTRF_8X8_LIB8
 #else
-	CALL(inner_edge_dpotrf_8x8_vs_lib8)
+	CALL(inner_edge_dpotrf_8x8_lib8)
 #endif
 
 
@@ -12351,7 +12831,8 @@ NAME:
 	// call inner blender_loader nn
 
 	movq	ARG7, %r10   // C
-	movq	ARG11, %r11  // n1
+	movq	ARG10, %r11  // m1
+	movq	ARG11, %r12  // n1
 
 #if MACRO_LEVEL>=1
 	INNER_SCALE_M11_8X8_VS_LIB8
@@ -12363,7 +12844,8 @@ NAME:
 	// factorization
 
 	movq	ARG9, %r10  // inv_diag_D 
-	movq	ARG11, %r11  // n1
+	movq	ARG10, %r11  // m1
+	movq	ARG11, %r12  // n1
 
 #if MACRO_LEVEL>=1
 	INNER_EDGE_DPOTRF_8X8_VS_LIB8

--- a/kernel/avx512/kernel_dgemm_8x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_8x8_lib8.S
@@ -7437,7 +7437,6 @@ NAME:
 	//
 	vmovapd			7*64(%r10), %zmm7
 
-
 	movq	ARG1, %r10 // k
 	movq	ARG5, %r11 // A
 	movq	ARG2, %r12 // VA
@@ -7530,7 +7529,6 @@ NAME:
 	vfmadd231pd		%zmm0, %zmm24, %zmm1
 	vbroadcastsd	0+0*64(%r10), %zmm24
 	vmulpd			%zmm0, %zmm24, %zmm0
-
 
 	movq	ARG4, %r10 // D
 

--- a/kernel/avx512/kernel_dgemm_8x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_8x8_lib8.S
@@ -2565,8 +2565,14 @@ NAME:
 	jle		2f // return
 
 	// prefetch
-//	prefetcht0	0(%r12) // software prefetch
-//	prefetcht0	0+64(%r12) // software prefetch
+	prefetcht0	0*64(%r12) // software prefetch
+	prefetcht0	1*64(%r12) // software prefetch
+	prefetcht0	2*64(%r12) // software prefetch
+	prefetcht0	3*64(%r12) // software prefetch
+	prefetcht0	4*64(%r12) // software prefetch
+	prefetcht0	5*64(%r12) // software prefetch
+	prefetcht0	6*64(%r12) // software prefetch
+	prefetcht0	7*64(%r12) // software prefetch
 
 	// preload
 	vmovapd 		0(%r11), %zmm25 // A
@@ -2578,28 +2584,32 @@ NAME:
 	.p2align 3
 1: // main loop
 
-//	prefetcht0	128(%r12) // software prefetch
-//	prefetcht0	128+64(%r12) // software prefetch
-
 	// unroll 0
 	vbroadcastsd	0*64(%r12), %zmm24 // B
+	prefetcht0	0*64(%r12, %r13) // software prefetch
 	vfmadd231pd		%zmm25, %zmm24, %zmm0
 	vmovapd			1*64(%r11), %zmm26 // A
 	vbroadcastsd	1*64(%r12), %zmm24 // B
+	prefetcht0	1*64(%r12, %r13) // software prefetch
 	vfmadd231pd		%zmm25, %zmm24, %zmm1
 	vbroadcastsd	2*64(%r12), %zmm24 // B
+	prefetcht0	2*64(%r12, %r13) // software prefetch
 	vfmadd231pd		%zmm25, %zmm24, %zmm2
 	vbroadcastsd	3*64(%r12), %zmm24 // B
+	prefetcht0	3*64(%r12, %r13) // software prefetch
 	vfmadd231pd		%zmm25, %zmm24, %zmm3
 	vbroadcastsd	4*64(%r12), %zmm24 // B
+	prefetcht0	4*64(%r12, %r13) // software prefetch
 	vfmadd231pd		%zmm25, %zmm24, %zmm4
 	vbroadcastsd	5*64(%r12), %zmm24 // B
+	prefetcht0	5*64(%r12, %r13) // software prefetch
 	vfmadd231pd		%zmm25, %zmm24, %zmm5
 	vbroadcastsd	6*64(%r12), %zmm24 // B
+	prefetcht0	6*64(%r12, %r13) // software prefetch
 	vfmadd231pd		%zmm25, %zmm24, %zmm6
 	vbroadcastsd	7*64(%r12), %zmm24 // B
+	prefetcht0	7*64(%r12, %r13) // software prefetch
 	vfmadd231pd		%zmm25, %zmm24, %zmm7
-	subl	$ 8, %r10d
 
 	// unroll 1
 	vbroadcastsd	8+0*64(%r12), %zmm24 // B
@@ -2619,6 +2629,7 @@ NAME:
 	vfmadd231pd		%zmm26, %zmm24, %zmm6
 	vbroadcastsd	8+7*64(%r12), %zmm24 // B
 	vfmadd231pd		%zmm26, %zmm24, %zmm7
+	subl	$ 8, %r10d
 
 	// unroll 2
 	vbroadcastsd	16+0*64(%r12), %zmm24 // B

--- a/kernel/avx512/kernel_dgemm_8x8_lib8.S
+++ b/kernel/avx512/kernel_dgemm_8x8_lib8.S
@@ -6149,6 +6149,177 @@ NAME:
 
 // common inner routine with file scope
 //
+// input arguments:
+// r10d  <- k
+// r11   <- B
+// r12   <- C
+// k1    <- m-mask
+// zmm0  <- [a00 ... a70]
+// ...
+// zmm7  <- [a07 ... a77]
+
+//
+// output arguments:
+// r10d  <- 0
+// r11   <- ?
+// r12   <- ?
+// k1    <- m-mask
+// zmm0  <- [a00 ... a70]
+// ...
+// zmm7  <- [a07 ... a77]
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_DGEBP_NN_VX8_VS_LIB8
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_dgebp_nn_vx8_vs_lib8)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		0f // return
+
+	cmpl	$ 3, %r10d
+	jle		2f // cleanup loop
+
+	// main loop
+	.p2align 
+1:
+	// merged k-iter 0-3 to have more independent acc
+	vmovapd			0*64(%r12), %zmm28 {%k1}{z}
+	vbroadcastsd	0+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm28
+	vmovapd			1*64(%r12), %zmm29 {%k1}{z}
+	vbroadcastsd	0+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm29
+	vmovapd			2*64(%r12), %zmm30 {%k1}{z}
+	vbroadcastsd	0+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm30
+	vmovapd			3*64(%r12), %zmm31 {%k1}{z}
+	vbroadcastsd	0+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm31
+
+	vbroadcastsd	8+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm28
+	vbroadcastsd	8+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm29
+	vbroadcastsd	8+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm30
+	vbroadcastsd	8+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm31
+
+	vbroadcastsd	16+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm28
+	vbroadcastsd	16+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm29
+	vbroadcastsd	16+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm30
+	vbroadcastsd	16+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm31
+
+	vbroadcastsd	24+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm28
+	vbroadcastsd	24+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm29
+	vbroadcastsd	24+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm30
+	vbroadcastsd	24+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm31
+
+	vbroadcastsd	32+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm28
+	vbroadcastsd	32+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm29
+	vbroadcastsd	32+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm30
+	vbroadcastsd	32+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm31
+
+	vbroadcastsd	40+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm28
+	vbroadcastsd	40+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm29
+	vbroadcastsd	40+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm30
+	vbroadcastsd	40+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm31
+
+	vbroadcastsd	48+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm6, %zmm25, %zmm28
+	vbroadcastsd	48+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm6, %zmm25, %zmm29
+	vbroadcastsd	48+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm6, %zmm25, %zmm30
+	vbroadcastsd	48+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm6, %zmm25, %zmm31
+
+	vbroadcastsd	56+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm7, %zmm25, %zmm28
+	vmovapd			%zmm28, 0*64(%r12) {%k1}
+	vbroadcastsd	56+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm7, %zmm25, %zmm29
+	vmovapd			%zmm29, 1*64(%r12) {%k1}
+	vbroadcastsd	56+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm7, %zmm25, %zmm30
+	vmovapd			%zmm30, 2*64(%r12) {%k1}
+	vbroadcastsd	56+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm7, %zmm25, %zmm31
+	vmovapd			%zmm31, 3*64(%r12) {%k1}
+
+	addq	$ 256, %r11
+	addq	$ 256, %r12
+	subl	$ 4, %r10d
+
+	cmpl	$ 3, %r10d
+	jg		1b // main loop
+
+	cmpl	$ 0, %r10d
+	jle		0f // return
+
+	// cleanup loop
+2:
+	vmovapd			0*64(%r12), %zmm28 {%k1}{z}
+	vbroadcastsd	0+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm28
+	vbroadcastsd	8+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm28
+	vbroadcastsd	16+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm28
+	vbroadcastsd	24+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm28
+	vbroadcastsd	32+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm28
+	vbroadcastsd	40+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm28
+	vbroadcastsd	48+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm6, %zmm25, %zmm28
+	vbroadcastsd	56+0*64(%r11), %zmm25
+	vfmadd231pd		%zmm7, %zmm25, %zmm28
+	vmovapd			%zmm28, 0*64(%r12) {%k1}
+
+	subl	$ 1, %r10d
+	addq	$ 64, %r11
+	addq	$ 64, %r12
+
+	cmpl	$ 0, %r10d
+	jg		2b // main loop
+
+	// return
+0:
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_dgebp_nn_vx8_vs_lib8)
+#endif
+
+
+
+
+
+// common inner routine with file scope
+//
 // edge for B unaligned
 //
 // input arguments:
@@ -12503,6 +12674,317 @@ NAME:
 	ret
 
 	FUN_END(kernel_dlarfb8_rn_8_lib8)
+
+
+
+
+
+//                                  1         2           3           4           5
+// void kernel_dlarfb8_rn_8_vs_lib8(int kmax, double *pV, double *pT, double *pD, int m1);
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dlarfb8_rn_8_vs_lib8)
+	
+	PROLOGUE
+
+
+	movq	ARG5, %r10 // k
+
+	// compute mask for rows
+	vcvtsi2sd	%r10d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC00(%rip), %zmm24
+#elif defined(OS_MAC)
+	vmovupd		LC00(%rip), %zmm24
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm24, %zmm25
+	vpmovq2m	%zmm25, %k1
+
+	// zero accumulation registers
+
+//	ZERO_ACC
+
+	movq	ARG1, %r10 // k
+	movq	ARG4, %r11 // D
+	movq	ARG2, %r12 // V
+
+	//
+	vmovapd			0*64(%r11), %zmm0 {%k1}{z}
+	//
+	vmovapd			1*64(%r11), %zmm1 {%k1}{z}
+	vbroadcastsd	1*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm1, %zmm0
+	//
+	vmovapd			2*64(%r11), %zmm2 {%k1}{z}
+	vbroadcastsd	0+2*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm2, %zmm0
+	vbroadcastsd	8+2*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm2, %zmm1
+	//
+	vmovapd			3*64(%r11), %zmm3 {%k1}{z}
+	vbroadcastsd	0+3*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm3, %zmm0
+	vbroadcastsd	8+3*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm3, %zmm1
+	vbroadcastsd	16+3*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm3, %zmm2
+	//
+	vmovapd			4*64(%r11), %zmm4 {%k1}{z}
+	vbroadcastsd	0+4*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm4, %zmm0
+	vbroadcastsd	8+4*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm4, %zmm1
+	vbroadcastsd	16+4*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm4, %zmm2
+	vbroadcastsd	24+4*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm4, %zmm3
+	//
+	vmovapd			5*64(%r11), %zmm5 {%k1}{z}
+	vbroadcastsd	0+5*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm5, %zmm0
+	vbroadcastsd	8+5*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm5, %zmm1
+	vbroadcastsd	16+5*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm5, %zmm2
+	vbroadcastsd	24+5*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm5, %zmm3
+	vbroadcastsd	32+5*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm5, %zmm4
+	//
+	vmovapd			6*64(%r11), %zmm6 {%k1}{z}
+	vbroadcastsd	0+6*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm6, %zmm0
+	vbroadcastsd	8+6*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm6, %zmm1
+	vbroadcastsd	16+6*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm6, %zmm2
+	vbroadcastsd	24+6*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm6, %zmm3
+	vbroadcastsd	32+6*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm6, %zmm4
+	vbroadcastsd	40+6*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm6, %zmm5
+	//
+	vmovapd			7*64(%r11), %zmm7 {%k1}{z}
+	vbroadcastsd	0+7*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm7, %zmm0
+	vbroadcastsd	8+7*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm7, %zmm1
+	vbroadcastsd	16+7*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm7, %zmm2
+	vbroadcastsd	24+7*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm7, %zmm3
+	vbroadcastsd	32+7*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm7, %zmm4
+	vbroadcastsd	40+7*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm7, %zmm5
+	vbroadcastsd	48+7*64(%r12), %zmm24
+	vfmadd231pd		%zmm24, %zmm7, %zmm6
+
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+	addq	$ 512, %r12
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEMM_NT_VX8_LIB8
+#else
+	CALL(inner_kernel_dgemm_nt_vx8_lib8)
+#endif
+
+	movq	ARG3, %r10 // T
+
+	//
+	vbroadcastsd	56+7*64(%r10), %zmm24
+	vmulpd			%zmm7, %zmm24, %zmm7
+	//
+	vbroadcastsd	48+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm6, %zmm24, %zmm7
+	vbroadcastsd	48+6*64(%r10), %zmm24
+	vmulpd			%zmm6, %zmm24, %zmm6
+	//
+	vbroadcastsd	40+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm5, %zmm24, %zmm7
+	vbroadcastsd	40+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm5, %zmm24, %zmm6
+	vbroadcastsd	40+5*64(%r10), %zmm24
+	vmulpd			%zmm5, %zmm24, %zmm5
+	//
+	vbroadcastsd	32+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm7
+	vbroadcastsd	32+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm6
+	vbroadcastsd	32+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm4, %zmm24, %zmm5
+	vbroadcastsd	32+4*64(%r10), %zmm24
+	vmulpd			%zmm4, %zmm24, %zmm4
+	//
+	vbroadcastsd	24+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm7
+	vbroadcastsd	24+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm6
+	vbroadcastsd	24+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm5
+	vbroadcastsd	24+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm3, %zmm24, %zmm4
+	vbroadcastsd	24+3*64(%r10), %zmm24
+	vmulpd			%zmm3, %zmm24, %zmm3
+	//
+	vbroadcastsd	16+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm7
+	vbroadcastsd	16+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm6
+	vbroadcastsd	16+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm5
+	vbroadcastsd	16+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm4
+	vbroadcastsd	16+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm2, %zmm24, %zmm3
+	vbroadcastsd	16+2*64(%r10), %zmm24
+	vmulpd			%zmm2, %zmm24, %zmm2
+	//
+	vbroadcastsd	8+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm7
+	vbroadcastsd	8+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm6
+	vbroadcastsd	8+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm5
+	vbroadcastsd	8+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm4
+	vbroadcastsd	8+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm3
+	vbroadcastsd	8+2*64(%r10), %zmm24
+	vfmadd231pd		%zmm1, %zmm24, %zmm2
+	vbroadcastsd	8+1*64(%r10), %zmm24
+	vmulpd			%zmm1, %zmm24, %zmm1
+	//
+	vbroadcastsd	0+7*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm7
+	vbroadcastsd	0+6*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm6
+	vbroadcastsd	0+5*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm5
+	vbroadcastsd	0+4*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm4
+	vbroadcastsd	0+3*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm3
+	vbroadcastsd	0+2*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm2
+	vbroadcastsd	0+1*64(%r10), %zmm24
+	vfmadd231pd		%zmm0, %zmm24, %zmm1
+	vbroadcastsd	0+0*64(%r10), %zmm24
+	vmulpd			%zmm0, %zmm24, %zmm0
+
+	movq	ARG1, %r10 // k
+	movq	ARG2, %r11 // V
+	movq	ARG4, %r12 // D
+
+	//
+	vmovapd			0+0*64(%r12), %zmm24 {%k1}{z}
+	vaddpd			%zmm24, %zmm0, %zmm24
+	vmovapd			%zmm24, 0+0*64(%r12) {%k1}
+	//
+	vmovapd			0+1*64(%r12), %zmm24 {%k1}{z}
+	vbroadcastsd	0+1*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm24
+	vaddpd			%zmm24, %zmm1, %zmm24
+	vmovapd			%zmm24, 0+1*64(%r12) {%k1}
+	//
+	vmovapd			0+2*64(%r12), %zmm24 {%k1}{z}
+	vbroadcastsd	0+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm24
+	vbroadcastsd	8+2*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm24
+	vaddpd			%zmm24, %zmm2, %zmm24
+	vmovapd			%zmm24, 0+2*64(%r12) {%k1}
+	//
+	vmovapd			0+3*64(%r12), %zmm24 {%k1}{z}
+	vbroadcastsd	0+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm24
+	vbroadcastsd	8+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm24
+	vbroadcastsd	16+3*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm24
+	vaddpd			%zmm24, %zmm3, %zmm24
+	vmovapd			%zmm24, 0+3*64(%r12) {%k1}
+	//
+	vmovapd			0+4*64(%r12), %zmm24 {%k1}{z}
+	vbroadcastsd	0+4*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm24
+	vbroadcastsd	8+4*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm24
+	vbroadcastsd	16+4*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm24
+	vbroadcastsd	24+4*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm24
+	vaddpd			%zmm24, %zmm4, %zmm24
+	vmovapd			%zmm24, 0+4*64(%r12) {%k1}
+	//
+	vmovapd			0+5*64(%r12), %zmm24 {%k1}{z}
+	vbroadcastsd	0+5*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm24
+	vbroadcastsd	8+5*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm24
+	vbroadcastsd	16+5*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm24
+	vbroadcastsd	24+5*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm24
+	vbroadcastsd	32+5*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm24
+	vaddpd			%zmm24, %zmm5, %zmm24
+	vmovapd			%zmm24, 0+5*64(%r12) {%k1}
+	//
+	vmovapd			0+6*64(%r12), %zmm24 {%k1}{z}
+	vbroadcastsd	0+6*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm24
+	vbroadcastsd	8+6*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm24
+	vbroadcastsd	16+6*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm24
+	vbroadcastsd	24+6*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm24
+	vbroadcastsd	32+6*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm24
+	vbroadcastsd	40+6*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm24
+	vaddpd			%zmm24, %zmm6, %zmm24
+	vmovapd			%zmm24, 0+6*64(%r12) {%k1}
+	//
+	vmovapd			0+7*64(%r12), %zmm24 {%k1}{z}
+	vbroadcastsd	0+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm0, %zmm25, %zmm24
+	vbroadcastsd	8+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm1, %zmm25, %zmm24
+	vbroadcastsd	16+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm2, %zmm25, %zmm24
+	vbroadcastsd	24+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm3, %zmm25, %zmm24
+	vbroadcastsd	32+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm4, %zmm25, %zmm24
+	vbroadcastsd	40+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm5, %zmm25, %zmm24
+	vbroadcastsd	48+7*64(%r11), %zmm25
+	vfmadd231pd		%zmm6, %zmm25, %zmm24
+	vaddpd			%zmm24, %zmm7, %zmm24
+	vmovapd			%zmm24, 0+7*64(%r12) {%k1}
+
+	subl	$ 8, %r10d
+	addq	$ 512, %r11
+	addq	$ 512, %r12
+
+#if MACRO_LEVEL>=2
+	INNER_KERNEL_DGEBP_NN_VX8_VS_LIB8
+#else
+	CALL(inner_kernel_dgebp_nn_vx8_vs_lib8)
+#endif
+
+1000:
+
+	EPILOGUE
+
+	ret
+
+	FUN_END(kernel_dlarfb8_rn_8_vs_lib8)
 
 
 

--- a/kernel/avx512/kernel_dgeqrf_8_lib8.c
+++ b/kernel/avx512/kernel_dgeqrf_8_lib8.c
@@ -858,4 +858,107 @@ void kernel_dlarft_8_lib8(int kmax, double *pD, double *dD, double *pT)
 
 
 
+void kernel_dlarfb8_rn_1_lib8(int kmax, double *pV, double *pT, double *pD)
+	{
+	const int ps = 8;
+	double pW[8];
+	int kk;
+	// 0
+	pW[0+ps*0] = pD[0+ps*0];
+	// 1
+	pW[0+ps*0] += pD[0+ps*1]*pV[0+ps*1];
+	pW[0+ps*1] = pD[0+ps*1];
+	// 2
+	pW[0+ps*0] += pD[0+ps*2]*pV[0+ps*2];
+	pW[0+ps*1] += pD[0+ps*2]*pV[1+ps*2];
+	pW[0+ps*2] = pD[0+ps*2];
+	// 3
+	pW[0+ps*0] += pD[0+ps*3]*pV[0+ps*3];
+	pW[0+ps*1] += pD[0+ps*3]*pV[1+ps*3];
+	pW[0+ps*2] += pD[0+ps*3]*pV[2+ps*3];
+	pW[0+ps*3] = pD[0+ps*3];
+	// 4
+	pW[0+ps*0] += pD[0+ps*4]*pV[0+ps*4];
+	pW[0+ps*1] += pD[0+ps*4]*pV[1+ps*4];
+	pW[0+ps*2] += pD[0+ps*4]*pV[2+ps*4];
+	pW[0+ps*3] += pD[0+ps*4]*pV[3+ps*4];
+	pW[0+ps*4] = pD[0+ps*4];
+	// 5
+	pW[0+ps*0] += pD[0+ps*5]*pV[0+ps*5];
+	pW[0+ps*1] += pD[0+ps*5]*pV[1+ps*5];
+	pW[0+ps*2] += pD[0+ps*5]*pV[2+ps*5];
+	pW[0+ps*3] += pD[0+ps*5]*pV[3+ps*5];
+	pW[0+ps*4] += pD[0+ps*5]*pV[4+ps*5];
+	pW[0+ps*5] = pD[0+ps*5];
+	// 6
+	pW[0+ps*0] += pD[0+ps*6]*pV[0+ps*6];
+	pW[0+ps*1] += pD[0+ps*6]*pV[1+ps*6];
+	pW[0+ps*2] += pD[0+ps*6]*pV[2+ps*6];
+	pW[0+ps*3] += pD[0+ps*6]*pV[3+ps*6];
+	pW[0+ps*4] += pD[0+ps*6]*pV[4+ps*6];
+	pW[0+ps*5] += pD[0+ps*6]*pV[5+ps*6];
+	pW[0+ps*6] = pD[0+ps*6];
+	// 7
+	pW[0+ps*0] += pD[0+ps*7]*pV[0+ps*7];
+	pW[0+ps*1] += pD[0+ps*7]*pV[1+ps*7];
+	pW[0+ps*2] += pD[0+ps*7]*pV[2+ps*7];
+	pW[0+ps*3] += pD[0+ps*7]*pV[3+ps*7];
+	pW[0+ps*4] += pD[0+ps*7]*pV[4+ps*7];
+	pW[0+ps*5] += pD[0+ps*7]*pV[5+ps*7];
+	pW[0+ps*6] += pD[0+ps*7]*pV[6+ps*7];
+	pW[0+ps*7] = pD[0+ps*7];
+	//
+	for(kk=8; kk<kmax; kk++)
+		{
+		pW[0+ps*0] += pD[0+ps*kk]*pV[0+ps*kk];
+		pW[0+ps*1] += pD[0+ps*kk]*pV[1+ps*kk];
+		pW[0+ps*2] += pD[0+ps*kk]*pV[2+ps*kk];
+		pW[0+ps*3] += pD[0+ps*kk]*pV[3+ps*kk];
+		pW[0+ps*4] += pD[0+ps*kk]*pV[4+ps*kk];
+		pW[0+ps*5] += pD[0+ps*kk]*pV[5+ps*kk];
+		pW[0+ps*6] += pD[0+ps*kk]*pV[6+ps*kk];
+		pW[0+ps*7] += pD[0+ps*kk]*pV[7+ps*kk];
+		}
+	//
+	pW[0+ps*7] = pW[0+ps*0]*pT[0+ps*7] + pW[0+ps*1]*pT[1+ps*7] + pW[0+ps*2]*pT[2+ps*7] + pW[0+ps*3]*pT[3+ps*7] + pW[0+ps*4]*pT[4+ps*7] + pW[0+ps*5]*pT[5+ps*7] + pW[0+ps*6]*pT[6+ps*7] + pW[0+ps*7]*pT[7+ps*7];
+	//
+	pW[0+ps*6] = pW[0+ps*0]*pT[0+ps*6] + pW[0+ps*1]*pT[1+ps*6] + pW[0+ps*2]*pT[2+ps*6] + pW[0+ps*3]*pT[3+ps*6] + pW[0+ps*4]*pT[4+ps*6] + pW[0+ps*5]*pT[5+ps*6] + pW[0+ps*6]*pT[6+ps*6];
+	//
+	pW[0+ps*5] = pW[0+ps*0]*pT[0+ps*5] + pW[0+ps*1]*pT[1+ps*5] + pW[0+ps*2]*pT[2+ps*5] + pW[0+ps*3]*pT[3+ps*5] + pW[0+ps*4]*pT[4+ps*5] + pW[0+ps*5]*pT[5+ps*5];
+	//
+	pW[0+ps*4] = pW[0+ps*0]*pT[0+ps*4] + pW[0+ps*1]*pT[1+ps*4] + pW[0+ps*2]*pT[2+ps*4] + pW[0+ps*3]*pT[3+ps*4] + pW[0+ps*4]*pT[4+ps*4];
+	//
+	pW[0+ps*3] = pW[0+ps*0]*pT[0+ps*3] + pW[0+ps*1]*pT[1+ps*3] + pW[0+ps*2]*pT[2+ps*3] + pW[0+ps*3]*pT[3+ps*3];
+	//
+	pW[0+ps*2] = pW[0+ps*0]*pT[0+ps*2] + pW[0+ps*1]*pT[1+ps*2] + pW[0+ps*2]*pT[2+ps*2];
+	//
+	pW[0+ps*1] = pW[0+ps*0]*pT[0+ps*1] + pW[0+ps*1]*pT[1+ps*1];
+	//
+	pW[0+ps*0] = pW[0+ps*0]*pT[0+ps*0];
+	//
+	pD[0+ps*0] += pW[0+ps*0];
+	//
+	pD[0+ps*1] += pW[0+ps*0]*pV[0+ps*1] + pW[0+ps*1];
+	//
+	pD[0+ps*2] += pW[0+ps*0]*pV[0+ps*2] + pW[0+ps*1]*pV[1+ps*2] + pW[0+ps*2];
+	//
+	pD[0+ps*3] += pW[0+ps*0]*pV[0+ps*3] + pW[0+ps*1]*pV[1+ps*3] + pW[0+ps*2]*pV[2+ps*3] + pW[0+ps*3];
+	//
+	pD[0+ps*4] += pW[0+ps*0]*pV[0+ps*4] + pW[0+ps*1]*pV[1+ps*4] + pW[0+ps*2]*pV[2+ps*4] + pW[0+ps*3]*pV[3+ps*4] + pW[0+ps*4];
+	//
+	pD[0+ps*5] += pW[0+ps*0]*pV[0+ps*5] + pW[0+ps*1]*pV[1+ps*5] + pW[0+ps*2]*pV[2+ps*5] + pW[0+ps*3]*pV[3+ps*5] + pW[0+ps*4]*pV[4+ps*5] + pW[0+ps*5];
+	//
+	pD[0+ps*6] += pW[0+ps*0]*pV[0+ps*6] + pW[0+ps*1]*pV[1+ps*6] + pW[0+ps*2]*pV[2+ps*6] + pW[0+ps*3]*pV[3+ps*6] + pW[0+ps*4]*pV[4+ps*6] + pW[0+ps*5]*pV[5+ps*6] + pW[0+ps*6];
+	//
+	pD[0+ps*7] += pW[0+ps*0]*pV[0+ps*7] + pW[0+ps*1]*pV[1+ps*7] + pW[0+ps*2]*pV[2+ps*7] + pW[0+ps*3]*pV[3+ps*7] + pW[0+ps*4]*pV[4+ps*7] + pW[0+ps*5]*pV[5+ps*7] + pW[0+ps*6]*pV[6+ps*7] + pW[0+ps*7];
+	//
+	for(kk=8; kk<kmax; kk++)
+		{
+		pD[0+ps*kk] += pW[0+ps*0]*pV[0+ps*kk] + pW[0+ps*1]*pV[1+ps*kk] + pW[0+ps*2]*pV[2+ps*kk] + pW[0+ps*3]*pV[3+ps*kk] + pW[0+ps*4]*pV[4+ps*kk] + pW[0+ps*5]*pV[5+ps*kk] + pW[0+ps*6]*pV[6+ps*kk] + pW[0+ps*7]*pV[7+ps*kk];
+		}
+	return;
+	}
+
+
+
 

--- a/kernel/avx512/kernel_dgeqrf_8_lib8.c
+++ b/kernel/avx512/kernel_dgeqrf_8_lib8.c
@@ -853,6 +853,9 @@ void kernel_dlarft_8_lib8(int kmax, double *pD, double *dD, double *pT)
 	//
 	pT[0+ps*7] = - dD[7] * (v70*pT[0+ps*0] + v71*pT[0+ps*1] + v72*pT[0+ps*2] + v73*pT[0+ps*3] + v74*pT[0+ps*4] + v75*pT[0+ps*5] + v76*pT[0+ps*6]);
 
+//printf("\n%f\n", v10);
+//printf("\n%f %f\n", v20, v21);
+//printf("\n%f %f %f\n", v30, v31, v32);
 	return;
 	}
 

--- a/kernel/avx512/kernel_dgeqrf_8_lib8.c
+++ b/kernel/avx512/kernel_dgeqrf_8_lib8.c
@@ -662,4 +662,200 @@ void kernel_dgelqf_pd_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd
 
 
 
+// assume kmax>=4
+// 1 d d d d
+// 0 1 d d d
+// 0 0 1 d d
+// 0 0 0 1 d
+void kernel_dlarft_8_lib8(int kmax, double *pD, double *dD, double *pT)
+	{
+	const int ps = 8;
+	int kk;
+	double v10,
+	       v20, v21,
+		   v30, v31, v32,
+		   v40, v41, v42, v43,
+		   v50, v51, v52, v53, v54,
+		   v60, v61, v62, v63, v64, v65,
+		   v70, v71, v72, v73, v74, v75, v76;
+	// 0
+	// 1
+	v10 =  pD[0+ps*1];
+	// 2
+	v10 += pD[1+ps*2]*pD[0+ps*2];
+	v20 =  pD[0+ps*2];
+	v21 =  pD[1+ps*2];
+	// 3
+	v10 += pD[1+ps*3]*pD[0+ps*3];
+	v20 += pD[2+ps*3]*pD[0+ps*3];
+	v21 += pD[2+ps*3]*pD[1+ps*3];
+	v30 =  pD[0+ps*3];
+	v31 =  pD[1+ps*3];
+	v32 =  pD[2+ps*3];
+	// 4
+	v10 += pD[1+ps*4]*pD[0+ps*4];
+	v20 += pD[2+ps*4]*pD[0+ps*4];
+	v21 += pD[2+ps*4]*pD[1+ps*4];
+	v30 += pD[3+ps*4]*pD[0+ps*4];
+	v31 += pD[3+ps*4]*pD[1+ps*4];
+	v32 += pD[3+ps*4]*pD[2+ps*4];
+	v40 =  pD[0+ps*4];
+	v41 =  pD[1+ps*4];
+	v42 =  pD[2+ps*4];
+	v43 =  pD[3+ps*4];
+	// 5
+	v10 += pD[1+ps*5]*pD[0+ps*5];
+	v20 += pD[2+ps*5]*pD[0+ps*5];
+	v21 += pD[2+ps*5]*pD[1+ps*5];
+	v30 += pD[3+ps*5]*pD[0+ps*5];
+	v31 += pD[3+ps*5]*pD[1+ps*5];
+	v32 += pD[3+ps*5]*pD[2+ps*5];
+	v40 += pD[4+ps*5]*pD[0+ps*5];
+	v41 += pD[4+ps*5]*pD[1+ps*5];
+	v42 += pD[4+ps*5]*pD[2+ps*5];
+	v43 += pD[4+ps*5]*pD[3+ps*5];
+	v50 =  pD[0+ps*5];
+	v51 =  pD[1+ps*5];
+	v52 =  pD[2+ps*5];
+	v53 =  pD[3+ps*5];
+	v54 =  pD[4+ps*5];
+	// 6
+	v10 += pD[1+ps*6]*pD[0+ps*6];
+	v20 += pD[2+ps*6]*pD[0+ps*6];
+	v21 += pD[2+ps*6]*pD[1+ps*6];
+	v30 += pD[3+ps*6]*pD[0+ps*6];
+	v31 += pD[3+ps*6]*pD[1+ps*6];
+	v32 += pD[3+ps*6]*pD[2+ps*6];
+	v40 += pD[4+ps*6]*pD[0+ps*6];
+	v41 += pD[4+ps*6]*pD[1+ps*6];
+	v42 += pD[4+ps*6]*pD[2+ps*6];
+	v43 += pD[4+ps*6]*pD[3+ps*6];
+	v50 += pD[5+ps*6]*pD[0+ps*6];
+	v51 += pD[5+ps*6]*pD[1+ps*6];
+	v52 += pD[5+ps*6]*pD[2+ps*6];
+	v53 += pD[5+ps*6]*pD[3+ps*6];
+	v54 += pD[5+ps*6]*pD[4+ps*6];
+	v60 =  pD[0+ps*6];
+	v61 =  pD[1+ps*6];
+	v62 =  pD[2+ps*6];
+	v63 =  pD[3+ps*6];
+	v64 =  pD[4+ps*6];
+	v65 =  pD[5+ps*6];
+	// 7
+	v10 += pD[1+ps*7]*pD[0+ps*7];
+	v20 += pD[2+ps*7]*pD[0+ps*7];
+	v21 += pD[2+ps*7]*pD[1+ps*7];
+	v30 += pD[3+ps*7]*pD[0+ps*7];
+	v31 += pD[3+ps*7]*pD[1+ps*7];
+	v32 += pD[3+ps*7]*pD[2+ps*7];
+	v40 += pD[4+ps*7]*pD[0+ps*7];
+	v41 += pD[4+ps*7]*pD[1+ps*7];
+	v42 += pD[4+ps*7]*pD[2+ps*7];
+	v43 += pD[4+ps*7]*pD[3+ps*7];
+	v50 += pD[5+ps*7]*pD[0+ps*7];
+	v51 += pD[5+ps*7]*pD[1+ps*7];
+	v52 += pD[5+ps*7]*pD[2+ps*7];
+	v53 += pD[5+ps*7]*pD[3+ps*7];
+	v54 += pD[5+ps*7]*pD[4+ps*7];
+	v60 += pD[6+ps*7]*pD[0+ps*7];
+	v61 += pD[6+ps*7]*pD[1+ps*7];
+	v62 += pD[6+ps*7]*pD[2+ps*7];
+	v63 += pD[6+ps*7]*pD[3+ps*7];
+	v64 += pD[6+ps*7]*pD[4+ps*7];
+	v65 += pD[6+ps*7]*pD[5+ps*7];
+	v70 =  pD[0+ps*7];
+	v71 =  pD[1+ps*7];
+	v72 =  pD[2+ps*7];
+	v73 =  pD[3+ps*7];
+	v74 =  pD[4+ps*7];
+	v75 =  pD[5+ps*7];
+	v76 =  pD[6+ps*7];
+	//
+	for(kk=8; kk<kmax; kk++)
+		{
+		v10 += pD[1+ps*kk]*pD[0+ps*kk];
+		v20 += pD[2+ps*kk]*pD[0+ps*kk];
+		v30 += pD[3+ps*kk]*pD[0+ps*kk];
+		v40 += pD[4+ps*kk]*pD[0+ps*kk];
+		v50 += pD[5+ps*kk]*pD[0+ps*kk];
+		v60 += pD[6+ps*kk]*pD[0+ps*kk];
+		v70 += pD[7+ps*kk]*pD[0+ps*kk];
+		//
+		v21 += pD[2+ps*kk]*pD[1+ps*kk];
+		v31 += pD[3+ps*kk]*pD[1+ps*kk];
+		v41 += pD[4+ps*kk]*pD[1+ps*kk];
+		v51 += pD[5+ps*kk]*pD[1+ps*kk];
+		v61 += pD[6+ps*kk]*pD[1+ps*kk];
+		v71 += pD[7+ps*kk]*pD[1+ps*kk];
+		//
+		v32 += pD[3+ps*kk]*pD[2+ps*kk];
+		v42 += pD[4+ps*kk]*pD[2+ps*kk];
+		v52 += pD[5+ps*kk]*pD[2+ps*kk];
+		v62 += pD[6+ps*kk]*pD[2+ps*kk];
+		v72 += pD[7+ps*kk]*pD[2+ps*kk];
+		//
+		v43 += pD[4+ps*kk]*pD[3+ps*kk];
+		v53 += pD[5+ps*kk]*pD[3+ps*kk];
+		v63 += pD[6+ps*kk]*pD[3+ps*kk];
+		v73 += pD[7+ps*kk]*pD[3+ps*kk];
+		//
+		v54 += pD[5+ps*kk]*pD[4+ps*kk];
+		v64 += pD[6+ps*kk]*pD[4+ps*kk];
+		v74 += pD[7+ps*kk]*pD[4+ps*kk];
+		//
+		v65 += pD[6+ps*kk]*pD[4+ps*kk];
+		v75 += pD[7+ps*kk]*pD[5+ps*kk];
+		//
+		v76 += pD[7+ps*kk]*pD[6+ps*kk];
+		}
+	//
+	pT[0+ps*0] = - dD[0];
+	pT[1+ps*1] = - dD[1];
+	pT[2+ps*2] = - dD[2];
+	pT[3+ps*3] = - dD[3];
+	pT[4+ps*4] = - dD[4];
+	pT[5+ps*5] = - dD[5];
+	pT[6+ps*6] = - dD[6];
+	pT[7+ps*7] = - dD[7];
+	//
+	pT[0+ps*1] = - dD[1] * (v10*pT[0+ps*0]);
+	pT[1+ps*2] = - dD[2] * (v21*pT[1+ps*1]);
+	pT[2+ps*3] = - dD[3] * (v32*pT[2+ps*2]);
+	pT[3+ps*4] = - dD[4] * (v43*pT[3+ps*3]);
+	pT[4+ps*5] = - dD[5] * (v54*pT[4+ps*4]);
+	pT[5+ps*6] = - dD[6] * (v65*pT[5+ps*5]);
+	pT[6+ps*7] = - dD[7] * (v76*pT[6+ps*6]);
+	//
+	pT[0+ps*2] = - dD[2] * (v20*pT[0+ps*0] + v21*pT[0+ps*1]);
+	pT[1+ps*3] = - dD[3] * (v31*pT[1+ps*1] + v32*pT[1+ps*2]);
+	pT[2+ps*4] = - dD[4] * (v42*pT[2+ps*2] + v43*pT[2+ps*3]);
+	pT[3+ps*5] = - dD[5] * (v53*pT[3+ps*3] + v54*pT[3+ps*4]);
+	pT[4+ps*6] = - dD[6] * (v64*pT[4+ps*4] + v65*pT[4+ps*5]);
+	pT[5+ps*7] = - dD[7] * (v75*pT[5+ps*5] + v76*pT[5+ps*6]);
+	//
+	pT[0+ps*3] = - dD[3] * (v30*pT[0+ps*0] + v31*pT[0+ps*1] + v32*pT[0+ps*2]);
+	pT[1+ps*4] = - dD[4] * (v41*pT[1+ps*1] + v42*pT[1+ps*2] + v43*pT[1+ps*3]);
+	pT[2+ps*5] = - dD[5] * (v52*pT[2+ps*2] + v53*pT[2+ps*3] + v54*pT[2+ps*4]);
+	pT[3+ps*6] = - dD[6] * (v63*pT[3+ps*3] + v64*pT[3+ps*4] + v65*pT[3+ps*5]);
+	pT[4+ps*7] = - dD[7] * (v74*pT[4+ps*4] + v75*pT[4+ps*5] + v76*pT[4+ps*6]);
+	//
+	pT[0+ps*4] = - dD[4] * (v40*pT[0+ps*0] + v41*pT[0+ps*1] + v42*pT[0+ps*2] + v43*pT[0+ps*3]);
+	pT[1+ps*5] = - dD[5] * (v51*pT[1+ps*1] + v52*pT[1+ps*2] + v53*pT[1+ps*3] + v54*pT[1+ps*4]);
+	pT[2+ps*6] = - dD[6] * (v62*pT[2+ps*2] + v63*pT[2+ps*3] + v64*pT[2+ps*4] + v65*pT[2+ps*5]);
+	pT[3+ps*7] = - dD[7] * (v73*pT[3+ps*3] + v74*pT[3+ps*4] + v75*pT[3+ps*5] + v76*pT[3+ps*6]);
+	//
+	pT[0+ps*5] = - dD[5] * (v50*pT[0+ps*0] + v51*pT[0+ps*1] + v52*pT[0+ps*2] + v53*pT[0+ps*3] + v54*pT[0+ps*4]);
+	pT[1+ps*6] = - dD[6] * (v61*pT[1+ps*1] + v62*pT[1+ps*2] + v63*pT[1+ps*3] + v64*pT[1+ps*4] + v65*pT[1+ps*5]);
+	pT[2+ps*7] = - dD[7] * (v72*pT[2+ps*2] + v73*pT[2+ps*3] + v74*pT[2+ps*4] + v75*pT[2+ps*5] + v76*pT[2+ps*6]);
+	//
+	pT[0+ps*6] = - dD[6] * (v60*pT[0+ps*0] + v61*pT[0+ps*1] + v62*pT[0+ps*2] + v63*pT[0+ps*3] + v64*pT[0+ps*4] + v65*pT[0+ps*5]);
+	pT[1+ps*7] = - dD[7] * (v71*pT[1+ps*1] + v72*pT[1+ps*2] + v73*pT[1+ps*3] + v74*pT[1+ps*4] + v75*pT[1+ps*5] + v76*pT[1+ps*6]);
+	//
+	pT[0+ps*7] = - dD[7] * (v70*pT[0+ps*0] + v71*pT[0+ps*1] + v72*pT[0+ps*2] + v73*pT[0+ps*3] + v74*pT[0+ps*4] + v75*pT[0+ps*5] + v76*pT[0+ps*6]);
+
+	return;
+	}
+
+
+
 

--- a/kernel/avx512/kernel_dgeqrf_8_lib8.c
+++ b/kernel/avx512/kernel_dgeqrf_8_lib8.c
@@ -179,25 +179,21 @@ void kernel_dgelqf_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd, d
 			_w0 = _mm512_load_pd( &pC20[0+ps*0] );
 			_a0 = _mm512_load_pd( &pC20[0+ps*1] );
 			_b0 = _mm512_set1_pd( pC00[0+ps*1] );
-			_t0 = _mm512_mul_pd( _a0, _b0 );
-			_w0 = _mm512_add_pd( _w0, _t0 );
+			_w0 = _mm512_fmadd_pd( _a0, _b0, _w0 );
 			_w1 = _mm512_load_pd( &pC20[0+ps*1] );
 			for(kk=2; kk<kmax; kk++)
 				{
 				_a0 = _mm512_load_pd( &pC20[0+ps*kk] );
 				_b0 = _mm512_set1_pd( pC00[0+ps*kk] );
-				_t0 = _mm512_mul_pd( _a0, _b0 );
-				_w0 = _mm512_add_pd( _w0, _t0 );
+				_w0 = _mm512_fmadd_pd( _a0, _b0, _w0 );
 				_b0 = _mm512_set1_pd( pC10[0+ps*kk] );
-				_t0 = _mm512_mul_pd( _a0, _b0 );
-				_w1 = _mm512_add_pd( _w1, _t0 );
+				_w1 = _mm512_fmadd_pd( _a0, _b0, _w1 );
 				}
 			//
 			_b0 = _mm512_set1_pd( pT[1+ldt*1] );
 			_w1 = _mm512_mul_pd( _w1, _b0 );
 			_b0 = _mm512_set1_pd( pT[0+ldt*1] );
-			_t0 = _mm512_mul_pd( _w0, _b0 );
-			_w1 = _mm512_add_pd( _w1, _t0 );
+			_w1 = _mm512_fmadd_pd( _w0, _b0, _w1 );
 			_b0 = _mm512_set1_pd( pT[0+ldt*0] );
 			_w0 = _mm512_mul_pd( _w0, _b0 );
 			//
@@ -206,19 +202,16 @@ void kernel_dgelqf_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd, d
 			_mm512_store_pd( &pC20[0+ps*0], _a0 );
 			_a0 = _mm512_load_pd( &pC20[0+ps*1] );
 			_b0 = _mm512_set1_pd( pC00[0+ps*1] );
-			_t0 = _mm512_mul_pd( _w0, _b0 );
-			_a0 = _mm512_add_pd( _a0, _t0 );
+			_a0 = _mm512_fmadd_pd( _w0, _b0, _a0 );
 			_a0 = _mm512_add_pd( _a0, _w1 );
 			_mm512_store_pd( &pC20[0+ps*1], _a0 );
 			for(kk=2; kk<kmax; kk++)
 				{
 				_a0 = _mm512_load_pd( &pC20[0+ps*kk] );
 				_b0 = _mm512_set1_pd( pC00[0+ps*kk] );
-				_t0 = _mm512_mul_pd( _w0, _b0 );
-				_a0 = _mm512_add_pd( _a0, _t0 );
+				_a0 = _mm512_fmadd_pd( _w0, _b0, _a0 );
 				_b0 = _mm512_set1_pd( pC10[0+ps*kk] );
-				_t0 = _mm512_mul_pd( _w1, _b0 );
-				_a0 = _mm512_add_pd( _a0, _t0 );
+				_a0 = _mm512_fmadd_pd( _w1, _b0, _a0 );
 				_mm512_store_pd( &pC20[0+ps*kk], _a0 );
 				}
 			pC20 += ps*sdd;
@@ -309,8 +302,7 @@ void kernel_dgelqf_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd, d
 					{
 					_a0 = _mm512_load_pd( &pC10[0+ps*kk] );
 					_b0 = _mm512_set1_pd( pC00[0+ps*kk] );
-					_t0 = _mm512_mul_pd( _a0, _b0 );
-					_w0 = _mm512_add_pd( _w0, _t0 );
+					_w0 = _mm512_fmadd_pd( _a0, _b0, _w0 );
 					}
 				//
 				_b0 = _mm512_set1_pd( pT[0+ldt*0] );
@@ -323,8 +315,7 @@ void kernel_dgelqf_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd, d
 					{
 					_a0 = _mm512_load_pd( &pC10[0+ps*kk] );
 					_b0 = _mm512_set1_pd( pC00[0+ps*kk] );
-					_t0 = _mm512_mul_pd( _w0, _b0 );
-					_a0 = _mm512_add_pd( _a0, _t0 );
+					_a0 = _mm512_fmadd_pd( _w0, _b0, _a0 );
 					_mm512_store_pd( &pC10[0+ps*kk], _a0 );
 					}
 				pC10 += ps*sdd;
@@ -486,25 +477,21 @@ void kernel_dgelqf_pd_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd
 			_w0 = _mm512_load_pd( &pC20[0+ps*0] );
 			_a0 = _mm512_load_pd( &pC20[0+ps*1] );
 			_b0 = _mm512_set1_pd( pC00[0+ps*1] );
-			_t0 = _mm512_mul_pd( _a0, _b0 );
-			_w0 = _mm512_add_pd( _w0, _t0 );
+			_w0 = _mm512_fmadd_pd( _a0, _b0, _w0 );
 			_w1 = _mm512_load_pd( &pC20[0+ps*1] );
 			for(kk=2; kk<kmax; kk++)
 				{
 				_a0 = _mm512_load_pd( &pC20[0+ps*kk] );
 				_b0 = _mm512_set1_pd( pC00[0+ps*kk] );
-				_t0 = _mm512_mul_pd( _a0, _b0 );
-				_w0 = _mm512_add_pd( _w0, _t0 );
+				_w0 = _mm512_fmadd_pd( _a0, _b0, _w0 );
 				_b0 = _mm512_set1_pd( pC10[0+ps*kk] );
-				_t0 = _mm512_mul_pd( _a0, _b0 );
-				_w1 = _mm512_add_pd( _w1, _t0 );
+				_w1 = _mm512_fmadd_pd( _a0, _b0, _w1 );
 				}
 			//
 			_b0 = _mm512_set1_pd( pT[1+ldt*1] );
 			_w1 = _mm512_mul_pd( _w1, _b0 );
 			_b0 = _mm512_set1_pd( pT[0+ldt*1] );
-			_t0 = _mm512_mul_pd( _w0, _b0 );
-			_w1 = _mm512_add_pd( _w1, _t0 );
+			_w1 = _mm512_fmadd_pd( _w0, _b0, _w1 );
 			_b0 = _mm512_set1_pd( pT[0+ldt*0] );
 			_w0 = _mm512_mul_pd( _w0, _b0 );
 			//
@@ -513,19 +500,16 @@ void kernel_dgelqf_pd_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd
 			_mm512_store_pd( &pC20[0+ps*0], _a0 );
 			_a0 = _mm512_load_pd( &pC20[0+ps*1] );
 			_b0 = _mm512_set1_pd( pC00[0+ps*1] );
-			_t0 = _mm512_mul_pd( _w0, _b0 );
-			_a0 = _mm512_add_pd( _a0, _t0 );
+			_a0 = _mm512_fmadd_pd( _w0, _b0, _a0 );
 			_a0 = _mm512_add_pd( _a0, _w1 );
 			_mm512_store_pd( &pC20[0+ps*1], _a0 );
 			for(kk=2; kk<kmax; kk++)
 				{
 				_a0 = _mm512_load_pd( &pC20[0+ps*kk] );
 				_b0 = _mm512_set1_pd( pC00[0+ps*kk] );
-				_t0 = _mm512_mul_pd( _w0, _b0 );
-				_a0 = _mm512_add_pd( _a0, _t0 );
+				_a0 = _mm512_fmadd_pd( _w0, _b0, _a0 );
 				_b0 = _mm512_set1_pd( pC10[0+ps*kk] );
-				_t0 = _mm512_mul_pd( _w1, _b0 );
-				_a0 = _mm512_add_pd( _a0, _t0 );
+				_a0 = _mm512_fmadd_pd( _w1, _b0, _a0 );
 				_mm512_store_pd( &pC20[0+ps*kk], _a0 );
 				}
 			pC20 += ps*sdd;
@@ -618,8 +602,7 @@ void kernel_dgelqf_pd_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd
 					{
 					_a0 = _mm512_load_pd( &pC10[0+ps*kk] );
 					_b0 = _mm512_set1_pd( pC00[0+ps*kk] );
-					_t0 = _mm512_mul_pd( _a0, _b0 );
-					_w0 = _mm512_add_pd( _w0, _t0 );
+					_w0 = _mm512_fmadd_pd( _a0, _b0, _w0 );
 					}
 				//
 				_b0 = _mm512_set1_pd( pT[0+ldt*0] );
@@ -632,8 +615,7 @@ void kernel_dgelqf_pd_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd
 					{
 					_a0 = _mm512_load_pd( &pC10[0+ps*kk] );
 					_b0 = _mm512_set1_pd( pC00[0+ps*kk] );
-					_t0 = _mm512_mul_pd( _w0, _b0 );
-					_a0 = _mm512_add_pd( _a0, _t0 );
+					_a0 = _mm512_fmadd_pd( _w0, _b0, _a0 );
 					_mm512_store_pd( &pC10[0+ps*kk], _a0 );
 					}
 				pC10 += ps*sdd;
@@ -1098,25 +1080,21 @@ void kernel_dgelqf_pd_la_vs_lib8(int m, int n1, int k, int offD, double *pD, int
 			_w0 = _mm512_load_pd( &pD20[0+ps*0] );
 			_a0 = _mm512_load_pd( &pD20[0+ps*1] );
 			_b0 = _mm512_set1_pd( pD00[0+ps*1] );
-			_t0 = _mm512_mul_pd( _a0, _b0 );
-			_w0 = _mm512_add_pd( _w0, _t0 );
+			_w0 = _mm512_fmadd_pd( _a0, _b0, _w0 );
 			_w1 = _mm512_load_pd( &pD20[0+ps*1] );
 			for(kk=0; kk<n1; kk++)
 				{
 				_a0 = _mm512_load_pd( &pA20[0+ps*kk] );
 				_b0 = _mm512_set1_pd( pA00[0+ps*kk] );
-				_t0 = _mm512_mul_pd( _a0, _b0 );
-				_w0 = _mm512_add_pd( _w0, _t0 );
+				_w0 = _mm512_fmadd_pd( _a0, _b0, _w0 );
 				_b0 = _mm512_set1_pd( pA10[0+ps*kk] );
-				_t0 = _mm512_mul_pd( _a0, _b0 );
-				_w1 = _mm512_add_pd( _w1, _t0 );
+				_w1 = _mm512_fmadd_pd( _a0, _b0, _w1 );
 				}
 			//
 			_b0 = _mm512_set1_pd( pT[1+ldt*1] );
 			_w1 = _mm512_mul_pd( _w1, _b0 );
 			_b0 = _mm512_set1_pd( pT[0+ldt*1] );
-			_t0 = _mm512_mul_pd( _w0, _b0 );
-			_w1 = _mm512_add_pd( _w1, _t0 );
+			_w1 = _mm512_fmadd_pd( _w0, _b0, _w1 );
 			_b0 = _mm512_set1_pd( pT[0+ldt*0] );
 			_w0 = _mm512_mul_pd( _w0, _b0 );
 			//
@@ -1125,19 +1103,16 @@ void kernel_dgelqf_pd_la_vs_lib8(int m, int n1, int k, int offD, double *pD, int
 			_mm512_store_pd( &pD20[0+ps*0], _a0 );
 			_a0 = _mm512_load_pd( &pD20[0+ps*1] );
 			_b0 = _mm512_set1_pd( pD00[0+ps*1] );
-			_t0 = _mm512_mul_pd( _w0, _b0 );
-			_a0 = _mm512_add_pd( _a0, _t0 );
+			_a0 = _mm512_fmadd_pd( _w0, _b0, _a0 );
 			_a0 = _mm512_add_pd( _a0, _w1 );
 			_mm512_store_pd( &pD20[0+ps*1], _a0 );
 			for(kk=0; kk<n1; kk++)
 				{
 				_a0 = _mm512_load_pd( &pA20[0+ps*kk] );
 				_b0 = _mm512_set1_pd( pA00[0+ps*kk] );
-				_t0 = _mm512_mul_pd( _w0, _b0 );
-				_a0 = _mm512_add_pd( _a0, _t0 );
+				_a0 = _mm512_fmadd_pd( _w0, _b0, _a0 );
 				_b0 = _mm512_set1_pd( pA10[0+ps*kk] );
-				_t0 = _mm512_mul_pd( _w1, _b0 );
-				_a0 = _mm512_add_pd( _a0, _t0 );
+				_a0 = _mm512_fmadd_pd( _w1, _b0, _a0 );
 				_mm512_store_pd( &pA20[0+ps*kk], _a0 );
 				}
 			pA20 += ps*sdd;
@@ -1230,8 +1205,7 @@ void kernel_dgelqf_pd_la_vs_lib8(int m, int n1, int k, int offD, double *pD, int
 				{
 				_a0 = _mm512_load_pd( &pA10[0+ps*kk] );
 				_b0 = _mm512_set1_pd( pA00[0+ps*kk] );
-				_t0 = _mm512_mul_pd( _a0, _b0 );
-				_w0 = _mm512_add_pd( _w0, _t0 );
+				_w0 = _mm512_fmadd_pd( _a0, _b0, _w0 );
 				}
 			//
 			_b0 = _mm512_set1_pd( pT[0+ldt*0] );
@@ -1244,8 +1218,7 @@ void kernel_dgelqf_pd_la_vs_lib8(int m, int n1, int k, int offD, double *pD, int
 				{
 				_a0 = _mm512_load_pd( &pA10[0+ps*kk] );
 				_b0 = _mm512_set1_pd( pA00[0+ps*kk] );
-				_t0 = _mm512_mul_pd( _w0, _b0 );
-				_a0 = _mm512_add_pd( _a0, _t0 );
+				_a0 = _mm512_fmadd_pd( _w0, _b0, _a0 );
 				_mm512_store_pd( &pA10[0+ps*kk], _a0 );
 				}
 			pA10 += ps*sda;

--- a/kernel/avx512/kernel_dgeqrf_8_lib8.c
+++ b/kernel/avx512/kernel_dgeqrf_8_lib8.c
@@ -1976,7 +1976,7 @@ void kernel_dlarft_lla_8_lib8(int n0, int n1, double *dD, double *pL, double *pA
 		//
 		v76 += pL[7+ps*kk]*pL[6+ps*kk];
 		}
-	// L 7
+	// L 6
 	v21 += pL[2+ps*kk]*pL[1+ps*kk];
 	v31 += pL[3+ps*kk]*pL[1+ps*kk];
 	v41 += pL[4+ps*kk]*pL[1+ps*kk];
@@ -2004,7 +2004,7 @@ void kernel_dlarft_lla_8_lib8(int n0, int n1, double *dD, double *pL, double *pA
 	//
 	v76 += pL[7+ps*kk]*pL[6+ps*kk];
 	kk++;
-	// L 6
+	// L 5
 	v32 += pL[3+ps*kk]*pL[2+ps*kk];
 	v42 += pL[4+ps*kk]*pL[2+ps*kk];
 	v52 += pL[5+ps*kk]*pL[2+ps*kk];
@@ -2025,7 +2025,7 @@ void kernel_dlarft_lla_8_lib8(int n0, int n1, double *dD, double *pL, double *pA
 	//
 	v76 += pL[7+ps*kk]*pL[6+ps*kk];
 	kk++;
-	// L 5
+	// L 4
 	v43 += pL[4+ps*kk]*pL[3+ps*kk];
 	v53 += pL[5+ps*kk]*pL[3+ps*kk];
 	v63 += pL[6+ps*kk]*pL[3+ps*kk];
@@ -2040,7 +2040,7 @@ void kernel_dlarft_lla_8_lib8(int n0, int n1, double *dD, double *pL, double *pA
 	//
 	v76 += pL[7+ps*kk]*pL[6+ps*kk];
 	kk++;
-	// L 4
+	// L 3
 	v54 += pL[5+ps*kk]*pL[4+ps*kk];
 	v64 += pL[6+ps*kk]*pL[4+ps*kk];
 	v74 += pL[7+ps*kk]*pL[4+ps*kk];
@@ -2050,16 +2050,16 @@ void kernel_dlarft_lla_8_lib8(int n0, int n1, double *dD, double *pL, double *pA
 	//
 	v76 += pL[7+ps*kk]*pL[6+ps*kk];
 	kk++;
-	// L 3
+	// L 2
 	v65 += pL[6+ps*kk]*pL[5+ps*kk];
 	v75 += pL[7+ps*kk]*pL[5+ps*kk];
 	//
 	v76 += pL[7+ps*kk]*pL[6+ps*kk];
 	kk++;
-	// L 2
+	// L 1
 	v76 += pL[7+ps*kk]*pL[6+ps*kk];
 	kk++;
-	// L 1
+	// L 0
 	kk++;
 	// A
 	for(kk=0; kk<n1; kk++)
@@ -2147,6 +2147,161 @@ void kernel_dlarft_lla_8_lib8(int n0, int n1, double *dD, double *pL, double *pA
 //printf("\n%f\n", v10);
 //printf("\n%f %f\n", v20, v21);
 //printf("\n%f %f %f\n", v30, v31, v32);
+	return;
+	}
+
+
+
+void kernel_dlarfb8_rn_lla_1_lib8(int n0, int n1, double *pVL, double *pVA, double *pT, double *pD, double *pL, double *pA)
+	{
+	const int ps = 8;
+	double pW[8];
+	int kk;
+	// D 0
+	pW[0+ps*0] = pD[0+ps*0];
+	// D 1
+	pW[0+ps*1] = pD[0+ps*1];
+	// D 2
+	pW[0+ps*2] = pD[0+ps*2];
+	// D 3
+	pW[0+ps*3] = pD[0+ps*3];
+	// D 4
+	pW[0+ps*4] = pD[0+ps*4];
+	// D 5
+	pW[0+ps*5] = pD[0+ps*5];
+	// D 6
+	pW[0+ps*6] = pD[0+ps*6];
+	// D 7
+	pW[0+ps*7] = pD[0+ps*7];
+	// L
+	for(kk=0; kk<=n0; kk++)
+		{
+		pW[0+ps*0] += pL[0+ps*kk]*pVL[0+ps*kk];
+		pW[0+ps*1] += pL[0+ps*kk]*pVL[1+ps*kk];
+		pW[0+ps*2] += pL[0+ps*kk]*pVL[2+ps*kk];
+		pW[0+ps*3] += pL[0+ps*kk]*pVL[3+ps*kk];
+		pW[0+ps*4] += pL[0+ps*kk]*pVL[4+ps*kk];
+		pW[0+ps*5] += pL[0+ps*kk]*pVL[5+ps*kk];
+		pW[0+ps*6] += pL[0+ps*kk]*pVL[6+ps*kk];
+		pW[0+ps*7] += pL[0+ps*kk]*pVL[7+ps*kk];
+		}
+	// L 6
+	pW[0+ps*1] += pL[0+ps*kk]*pVL[1+ps*kk];
+	pW[0+ps*2] += pL[0+ps*kk]*pVL[2+ps*kk];
+	pW[0+ps*3] += pL[0+ps*kk]*pVL[3+ps*kk];
+	pW[0+ps*4] += pL[0+ps*kk]*pVL[4+ps*kk];
+	pW[0+ps*5] += pL[0+ps*kk]*pVL[5+ps*kk];
+	pW[0+ps*6] += pL[0+ps*kk]*pVL[6+ps*kk];
+	pW[0+ps*7] += pL[0+ps*kk]*pVL[7+ps*kk];
+	kk++;
+	// L 5
+	pW[0+ps*2] += pL[0+ps*kk]*pVL[2+ps*kk];
+	pW[0+ps*3] += pL[0+ps*kk]*pVL[3+ps*kk];
+	pW[0+ps*4] += pL[0+ps*kk]*pVL[4+ps*kk];
+	pW[0+ps*5] += pL[0+ps*kk]*pVL[5+ps*kk];
+	pW[0+ps*6] += pL[0+ps*kk]*pVL[6+ps*kk];
+	pW[0+ps*7] += pL[0+ps*kk]*pVL[7+ps*kk];
+	kk++;
+	// L 4
+	pW[0+ps*3] += pL[0+ps*kk]*pVL[3+ps*kk];
+	pW[0+ps*4] += pL[0+ps*kk]*pVL[4+ps*kk];
+	pW[0+ps*5] += pL[0+ps*kk]*pVL[5+ps*kk];
+	pW[0+ps*6] += pL[0+ps*kk]*pVL[6+ps*kk];
+	pW[0+ps*7] += pL[0+ps*kk]*pVL[7+ps*kk];
+	kk++;
+	// L 3
+	pW[0+ps*4] += pL[0+ps*kk]*pVL[4+ps*kk];
+	pW[0+ps*5] += pL[0+ps*kk]*pVL[5+ps*kk];
+	pW[0+ps*6] += pL[0+ps*kk]*pVL[6+ps*kk];
+	pW[0+ps*7] += pL[0+ps*kk]*pVL[7+ps*kk];
+	kk++;
+	// L 2
+	pW[0+ps*5] += pL[0+ps*kk]*pVL[5+ps*kk];
+	pW[0+ps*6] += pL[0+ps*kk]*pVL[6+ps*kk];
+	pW[0+ps*7] += pL[0+ps*kk]*pVL[7+ps*kk];
+	kk++;
+	// L 1
+	pW[0+ps*6] += pL[0+ps*kk]*pVL[6+ps*kk];
+	pW[0+ps*7] += pL[0+ps*kk]*pVL[7+ps*kk];
+	kk++;
+	// L 0
+	pW[0+ps*7] += pL[0+ps*kk]*pVL[7+ps*kk];
+	kk++;
+	// A
+	for(kk=0; kk<n1; kk++)
+		{
+		pW[0+ps*0] += pA[0+ps*kk]*pVA[0+ps*kk];
+		pW[0+ps*1] += pA[0+ps*kk]*pVA[1+ps*kk];
+		pW[0+ps*2] += pA[0+ps*kk]*pVA[2+ps*kk];
+		pW[0+ps*3] += pA[0+ps*kk]*pVA[3+ps*kk];
+		pW[0+ps*4] += pA[0+ps*kk]*pVA[4+ps*kk];
+		pW[0+ps*5] += pA[0+ps*kk]*pVA[5+ps*kk];
+		pW[0+ps*6] += pA[0+ps*kk]*pVA[6+ps*kk];
+		pW[0+ps*7] += pA[0+ps*kk]*pVA[7+ps*kk];
+		}
+	//
+	pW[0+ps*7] = pW[0+ps*0]*pT[0+ps*7] + pW[0+ps*1]*pT[1+ps*7] + pW[0+ps*2]*pT[2+ps*7] + pW[0+ps*3]*pT[3+ps*7] + pW[0+ps*4]*pT[4+ps*7] + pW[0+ps*5]*pT[5+ps*7] + pW[0+ps*6]*pT[6+ps*7] + pW[0+ps*7]*pT[7+ps*7];
+	//
+	pW[0+ps*6] = pW[0+ps*0]*pT[0+ps*6] + pW[0+ps*1]*pT[1+ps*6] + pW[0+ps*2]*pT[2+ps*6] + pW[0+ps*3]*pT[3+ps*6] + pW[0+ps*4]*pT[4+ps*6] + pW[0+ps*5]*pT[5+ps*6] + pW[0+ps*6]*pT[6+ps*6];
+	//
+	pW[0+ps*5] = pW[0+ps*0]*pT[0+ps*5] + pW[0+ps*1]*pT[1+ps*5] + pW[0+ps*2]*pT[2+ps*5] + pW[0+ps*3]*pT[3+ps*5] + pW[0+ps*4]*pT[4+ps*5] + pW[0+ps*5]*pT[5+ps*5];
+	//
+	pW[0+ps*4] = pW[0+ps*0]*pT[0+ps*4] + pW[0+ps*1]*pT[1+ps*4] + pW[0+ps*2]*pT[2+ps*4] + pW[0+ps*3]*pT[3+ps*4] + pW[0+ps*4]*pT[4+ps*4];
+	//
+	pW[0+ps*3] = pW[0+ps*0]*pT[0+ps*3] + pW[0+ps*1]*pT[1+ps*3] + pW[0+ps*2]*pT[2+ps*3] + pW[0+ps*3]*pT[3+ps*3];
+	//
+	pW[0+ps*2] = pW[0+ps*0]*pT[0+ps*2] + pW[0+ps*1]*pT[1+ps*2] + pW[0+ps*2]*pT[2+ps*2];
+	//
+	pW[0+ps*1] = pW[0+ps*0]*pT[0+ps*1] + pW[0+ps*1]*pT[1+ps*1];
+	//
+	pW[0+ps*0] = pW[0+ps*0]*pT[0+ps*0];
+	// D 0
+	pD[0+ps*0] += pW[0+ps*0];
+	// D 1
+	pD[0+ps*1] += pW[0+ps*1];
+	// D 2
+	pD[0+ps*2] += pW[0+ps*2];
+	// D 3
+	pD[0+ps*3] += pW[0+ps*3];
+	// D 4
+	pD[0+ps*4] += pW[0+ps*4];
+	// D 5
+	pD[0+ps*5] += pW[0+ps*5];
+	// D 6
+	pD[0+ps*6] += pW[0+ps*6];
+	// D 7
+	pD[0+ps*7] += pW[0+ps*7];
+	// L
+	for(kk=0; kk<=n0; kk++)
+		{
+		pL[0+ps*kk] += pW[0+ps*0]*pVL[0+ps*kk] + pW[0+ps*1]*pVL[1+ps*kk] + pW[0+ps*2]*pVL[2+ps*kk] + pW[0+ps*3]*pVL[3+ps*kk] + pW[0+ps*4]*pVL[4+ps*kk] + pW[0+ps*5]*pVL[5+ps*kk] + pW[0+ps*6]*pVL[6+ps*kk] + pW[0+ps*7]*pVL[7+ps*kk];
+		}
+	// L 6
+	pL[0+ps*kk] += pW[0+ps*1]*pVL[1+ps*kk] + pW[0+ps*2]*pVL[2+ps*kk] + pW[0+ps*3]*pVL[3+ps*kk] + pW[0+ps*4]*pVL[4+ps*kk] + pW[0+ps*5]*pVL[5+ps*kk] + pW[0+ps*6]*pVL[6+ps*kk] + pW[0+ps*7]*pVL[7+ps*kk];
+	kk++;
+	// L 5
+	pL[0+ps*kk] += pW[0+ps*2]*pVL[2+ps*kk] + pW[0+ps*3]*pVL[3+ps*kk] + pW[0+ps*4]*pVL[4+ps*kk] + pW[0+ps*5]*pVL[5+ps*kk] + pW[0+ps*6]*pVL[6+ps*kk] + pW[0+ps*7]*pVL[7+ps*kk];
+	kk++;
+	// L 4
+	pL[0+ps*kk] += pW[0+ps*3]*pVL[3+ps*kk] + pW[0+ps*4]*pVL[4+ps*kk] + pW[0+ps*5]*pVL[5+ps*kk] + pW[0+ps*6]*pVL[6+ps*kk] + pW[0+ps*7]*pVL[7+ps*kk];
+	kk++;
+	// L 3
+	pL[0+ps*kk] += pW[0+ps*4]*pVL[4+ps*kk] + pW[0+ps*5]*pVL[5+ps*kk] + pW[0+ps*6]*pVL[6+ps*kk] + pW[0+ps*7]*pVL[7+ps*kk];
+	kk++;
+	// L 2
+	pL[0+ps*kk] += pW[0+ps*5]*pVL[5+ps*kk] + pW[0+ps*6]*pVL[6+ps*kk] + pW[0+ps*7]*pVL[7+ps*kk];
+	kk++;
+	// L 1
+	pL[0+ps*kk] += pW[0+ps*6]*pVL[6+ps*kk] + pW[0+ps*7]*pVL[7+ps*kk];
+	kk++;
+	// L 0
+	pL[0+ps*kk] += pW[0+ps*7]*pVL[7+ps*kk];
+	kk++;
+	// A
+	for(kk=0; kk<n1; kk++)
+		{
+		pA[0+ps*kk] += pW[0+ps*0]*pVA[0+ps*kk] + pW[0+ps*1]*pVA[1+ps*kk] + pW[0+ps*2]*pVA[2+ps*kk] + pW[0+ps*3]*pVA[3+ps*kk] + pW[0+ps*4]*pVA[4+ps*kk] + pW[0+ps*5]*pVA[5+ps*kk] + pW[0+ps*6]*pVA[6+ps*kk] + pW[0+ps*7]*pVA[7+ps*kk];
+		}
 	return;
 	}
 

--- a/kernel/avx512/kernel_dgeqrf_8_lib8.c
+++ b/kernel/avx512/kernel_dgeqrf_8_lib8.c
@@ -1,0 +1,355 @@
+/**************************************************************************************************
+*                                                                                                 *
+* This file is part of BLASFEO.                                                                   *
+*                                                                                                 *
+* BLASFEO -- BLAS For Embedded Optimization.                                                      *
+* Copyright (C) 2019 by Gianluca Frison.                                                          *
+* Developed at IMTEK (University of Freiburg) under the supervision of Moritz Diehl.              *
+* All rights reserved.                                                                            *
+*                                                                                                 *
+* The 2-Clause BSD License                                                                        *
+*                                                                                                 *
+* Redistribution and use in source and binary forms, with or without                              *
+* modification, are permitted provided that the following conditions are met:                     *
+*                                                                                                 *
+* 1. Redistributions of source code must retain the above copyright notice, this                  *
+*    list of conditions and the following disclaimer.                                             *
+* 2. Redistributions in binary form must reproduce the above copyright notice,                    *
+*    this list of conditions and the following disclaimer in the documentation                    *
+*    and/or other materials provided with the distribution.                                       *
+*                                                                                                 *
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND                 *
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED                   *
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE                          *
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR                 *
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES                  *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;                    *
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND                     *
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT                      *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS                   *
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                                    *
+*                                                                                                 *
+* Author: Gianluca Frison, gianluca.frison (at) imtek.uni-freiburg.de                             *
+*                                                                                                 *
+**************************************************************************************************/
+
+#include <math.h>
+#include <stdio.h>
+
+#include <mmintrin.h>
+#include <xmmintrin.h>  // SSE
+#include <emmintrin.h>  // SSE2
+#include <pmmintrin.h>  // SSE3
+#include <smmintrin.h>  // SSE4
+#include <immintrin.h>  // AVX
+
+#include <blasfeo_common.h>
+#include <blasfeo_d_aux.h>
+#include <blasfeo_d_kernel.h>
+
+
+
+// unblocked algorithm
+void kernel_dgelqf_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd, double *dD)
+	{
+	if(m<=0 | n<=0)
+		return;
+	int ii, jj, kk, ll, imax, jmax, jmax0, kmax, kmax0;
+	const int ps = 8;
+	imax = k;//m<n ? m : n;
+	double alpha, beta, tmp;
+	double w00, w01,
+		   w10, w11,
+		   w20, w21,
+		   w30, w31;
+	__m512d
+		_a0, _b0, _t0, _w0, _w1;
+	double *pC00, *pC10, *pC10a, *pC20, *pC20a, *pC01, *pC11;
+	double pT[4];
+	int ldt = 2;
+	double *pD0 = pD-offD;
+	ii = 0;
+#if 1 // rank 2
+	for(; ii<imax-1; ii+=2)
+		{
+		// first row
+		pC00 = &pD0[((offD+ii)&(ps-1))+((offD+ii)-((offD+ii)&(ps-1)))*sdd+ii*ps];
+		beta = 0.0;
+		for(jj=1; jj<n-ii; jj++)
+			{
+			tmp = pC00[0+ps*jj];
+			beta += tmp*tmp;
+			}
+		if(beta==0.0)
+			{
+			dD[ii] = 0.0;
+			}
+		else
+			{
+			alpha = pC00[0];
+			beta += alpha*alpha;
+			beta = sqrt(beta);
+			if(alpha>0)
+				beta = -beta;
+			dD[ii] = (beta-alpha) / beta;
+			tmp = 1.0 / (alpha-beta);
+			pC00[0] = beta;
+			for(jj=1; jj<n-ii; jj++)
+				pC00[0+ps*jj] *= tmp;
+			}
+		pC10 = &pD0[((offD+ii+1)&(ps-1))+((offD+ii+1)-((offD+ii+1)&(ps-1)))*sdd+ii*ps];
+		kmax = n-ii;
+		w00 = pC10[0+ps*0]; // pC00[0+ps*0] = 1.0
+		for(kk=1; kk<kmax; kk++)
+			{
+			w00 += pC10[0+ps*kk] * pC00[0+ps*kk];
+			}
+		w00 = - w00*dD[ii];
+		pC10[0+ps*0] += w00; // pC00[0+ps*0] = 1.0
+		for(kk=1; kk<kmax; kk++)
+			{
+			pC10[0+ps*kk] += w00 * pC00[0+ps*kk];
+			}
+		// second row
+		pC11 = pC10+ps*1;
+		beta = 0.0;
+		for(jj=1; jj<n-(ii+1); jj++)
+			{
+			tmp = pC11[0+ps*jj];
+			beta += tmp*tmp;
+			}
+		if(beta==0.0)
+			{
+			dD[(ii+1)] = 0.0;
+			}
+		else
+			{
+			alpha = pC11[0+ps*0];
+			beta += alpha*alpha;
+			beta = sqrt(beta);
+			if(alpha>0)
+				beta = -beta;
+			dD[(ii+1)] = (beta-alpha) / beta;
+			tmp = 1.0 / (alpha-beta);
+			pC11[0+ps*0] = beta;
+			for(jj=1; jj<n-(ii+1); jj++)
+				pC11[0+ps*jj] *= tmp;
+			}
+		// compute T
+		kmax = n-ii;
+		tmp = 1.0*0.0 + pC00[0+ps*1]*1.0;
+		for(kk=2; kk<kmax; kk++)
+			tmp += pC00[0+ps*kk]*pC10[0+ps*kk];
+		pT[0+ldt*0] = - dD[ii+0];
+		pT[0+ldt*1] = + dD[ii+1] * tmp * dD[ii+0];
+		pT[1+ldt*1] = - dD[ii+1];
+		// downgrade
+		kmax = n-ii;
+		jmax = m-ii-2;
+		jmax0 = (ps-((ii+2+offD)&(ps-1)))&(ps-1);
+		jmax0 = jmax<jmax0 ? jmax : jmax0;
+		jj = 0;
+		pC20a = &pD0[((offD+ii+2)&(ps-1))+((offD+ii+2)-((offD+ii+2)&(ps-1)))*sdd+ii*ps];
+		pC20 = pC20a;
+		if(jmax0>0)
+			{
+			for( ; jj<jmax0; jj++)
+				{
+				w00 = pC20[0+ps*0]*1.0 + pC20[0+ps*1]*pC00[0+ps*1];
+				w01 = pC20[0+ps*0]*0.0 + pC20[0+ps*1]*1.0;
+				for(kk=2; kk<kmax; kk++)
+					{
+					w00 += pC20[0+ps*kk]*pC00[0+ps*kk];
+					w01 += pC20[0+ps*kk]*pC10[0+ps*kk];
+					}
+				w01 = w00*pT[0+ldt*1] + w01*pT[1+ldt*1];
+				w00 = w00*pT[0+ldt*0];
+				pC20[0+ps*0] += w00*1.0          + w01*0.0;
+				pC20[0+ps*1] += w00*pC00[0+ps*1] + w01*1.0;
+				for(kk=2; kk<kmax; kk++)
+					{
+					pC20[0+ps*kk] += w00*pC00[0+ps*kk] + w01*pC10[0+ps*kk];
+					}
+				pC20 += 1;
+				}
+			pC20 += -ps+ps*sdd;
+			}
+		for( ; jj<jmax-7; jj+=8)
+			{
+			//
+			_w0 = _mm512_load_pd( &pC20[0+ps*0] );
+			_a0 = _mm512_load_pd( &pC20[0+ps*1] );
+			_b0 = _mm512_set1_pd( pC00[0+ps*1] );
+			_t0 = _mm512_mul_pd( _a0, _b0 );
+			_w0 = _mm512_add_pd( _w0, _t0 );
+			_w1 = _mm512_load_pd( &pC20[0+ps*1] );
+			for(kk=2; kk<kmax; kk++)
+				{
+				_a0 = _mm512_load_pd( &pC20[0+ps*kk] );
+				_b0 = _mm512_set1_pd( pC00[0+ps*kk] );
+				_t0 = _mm512_mul_pd( _a0, _b0 );
+				_w0 = _mm512_add_pd( _w0, _t0 );
+				_b0 = _mm512_set1_pd( pC10[0+ps*kk] );
+				_t0 = _mm512_mul_pd( _a0, _b0 );
+				_w1 = _mm512_add_pd( _w1, _t0 );
+				}
+			//
+			_b0 = _mm512_set1_pd( pT[1+ldt*1] );
+			_w1 = _mm512_mul_pd( _w1, _b0 );
+			_b0 = _mm512_set1_pd( pT[0+ldt*1] );
+			_t0 = _mm512_mul_pd( _w0, _b0 );
+			_w1 = _mm512_add_pd( _w1, _t0 );
+			_b0 = _mm512_set1_pd( pT[0+ldt*0] );
+			_w0 = _mm512_mul_pd( _w0, _b0 );
+			//
+			_a0 = _mm512_load_pd( &pC20[0+ps*0] );
+			_a0 = _mm512_add_pd( _a0, _w0 );
+			_mm512_store_pd( &pC20[0+ps*0], _a0 );
+			_a0 = _mm512_load_pd( &pC20[0+ps*1] );
+			_b0 = _mm512_set1_pd( pC00[0+ps*1] );
+			_t0 = _mm512_mul_pd( _w0, _b0 );
+			_a0 = _mm512_add_pd( _a0, _t0 );
+			_a0 = _mm512_add_pd( _a0, _w1 );
+			_mm512_store_pd( &pC20[0+ps*1], _a0 );
+			for(kk=2; kk<kmax; kk++)
+				{
+				_a0 = _mm512_load_pd( &pC20[0+ps*kk] );
+				_b0 = _mm512_set1_pd( pC00[0+ps*kk] );
+				_t0 = _mm512_mul_pd( _w0, _b0 );
+				_a0 = _mm512_add_pd( _a0, _t0 );
+				_b0 = _mm512_set1_pd( pC10[0+ps*kk] );
+				_t0 = _mm512_mul_pd( _w1, _b0 );
+				_a0 = _mm512_add_pd( _a0, _t0 );
+				_mm512_store_pd( &pC20[0+ps*kk], _a0 );
+				}
+			pC20 += ps*sdd;
+			}
+		for(ll=0; ll<jmax-jj; ll++)
+			{
+			w00 = pC20[0+ps*0]*1.0 + pC20[0+ps*1]*pC00[0+ps*1];
+			w01 = pC20[0+ps*0]*0.0 + pC20[0+ps*1]*1.0;
+			for(kk=2; kk<kmax; kk++)
+				{
+				w00 += pC20[0+ps*kk]*pC00[0+ps*kk];
+				w01 += pC20[0+ps*kk]*pC10[0+ps*kk];
+				}
+			w01 = w00*pT[0+ldt*1] + w01*pT[1+ldt*1];
+			w00 = w00*pT[0+ldt*0];
+			pC20[0+ps*0] += w00*1.0          + w01*0.0;
+			pC20[0+ps*1] += w00*pC00[0+ps*1] + w01*1.0;
+			for(kk=2; kk<kmax; kk++)
+				{
+				pC20[0+ps*kk] += w00*pC00[0+ps*kk] + w01*pC10[0+ps*kk];
+				}
+			pC20 += 1;
+			}
+		}
+#endif
+	for(; ii<imax; ii++)
+		{
+		pC00 = &pD0[((offD+ii)&(ps-1))+((offD+ii)-((offD+ii)&(ps-1)))*sdd+ii*ps];
+		beta = 0.0;
+		for(jj=1; jj<n-ii; jj++)
+			{
+			tmp = pC00[0+ps*jj];
+			beta += tmp*tmp;
+			}
+		if(beta==0.0)
+			{
+			dD[ii] = 0.0;
+			}
+		else
+			{
+			alpha = pC00[0];
+			beta += alpha*alpha;
+			beta = sqrt(beta);
+			if(alpha>0)
+				beta = -beta;
+			dD[ii] = (beta-alpha) / beta;
+			tmp = 1.0 / (alpha-beta);
+			pC00[0] = beta;
+			for(jj=1; jj<n-ii; jj++)
+				pC00[0+ps*jj] *= tmp;
+			}
+		if(ii<n)
+			{
+			// compute T
+			pT[0+ldt*0] = - dD[ii+0];
+			// downgrade
+			kmax = n-ii;
+			jmax = m-ii-1;
+			jmax0 = (ps-((ii+1+offD)&(ps-1)))&(ps-1);
+			jmax0 = jmax<jmax0 ? jmax : jmax0;
+			jj = 0;
+			pC10a = &pD0[((offD+ii+1)&(ps-1))+((offD+ii+1)-((offD+ii+1)&(ps-1)))*sdd+ii*ps];
+			pC10 = pC10a;
+			if(jmax0>0)
+				{
+				for( ; jj<jmax0; jj++)
+					{
+					w00 = pC10[0+ps*0];
+					for(kk=1; kk<kmax; kk++)
+						{
+						w00 += pC10[0+ps*kk] * pC00[0+ps*kk];
+						}
+					w00 = w00*pT[0+ldt*0];
+					pC10[0+ps*0] += w00;
+					for(kk=1; kk<kmax; kk++)
+						{
+						pC10[0+ps*kk] += w00 * pC00[0+ps*kk];
+						}
+					pC10 += 1;
+					}
+				pC10 += -ps+ps*sdd;
+				}
+			for( ; jj<jmax-7; jj+=8)
+				{
+				//
+				_w0 = _mm512_load_pd( &pC10[0+ps*0] );
+				for(kk=1; kk<kmax; kk++)
+					{
+					_a0 = _mm512_load_pd( &pC10[0+ps*kk] );
+					_b0 = _mm512_set1_pd( pC00[0+ps*kk] );
+					_t0 = _mm512_mul_pd( _a0, _b0 );
+					_w0 = _mm512_add_pd( _w0, _t0 );
+					}
+				//
+				_b0 = _mm512_set1_pd( pT[0+ldt*0] );
+				_w0 = _mm512_mul_pd( _w0, _b0 );
+				//
+				_a0 = _mm512_load_pd( &pC10[0+ps*0] );
+				_a0 = _mm512_add_pd( _a0, _w0 );
+				_mm512_store_pd( &pC10[0+ps*0], _a0 );
+				for(kk=1; kk<kmax; kk++)
+					{
+					_a0 = _mm512_load_pd( &pC10[0+ps*kk] );
+					_b0 = _mm512_set1_pd( pC00[0+ps*kk] );
+					_t0 = _mm512_mul_pd( _w0, _b0 );
+					_a0 = _mm512_add_pd( _a0, _t0 );
+					_mm512_store_pd( &pC10[0+ps*kk], _a0 );
+					}
+				pC10 += ps*sdd;
+				}
+			for(ll=0; ll<jmax-jj; ll++)
+				{
+				w00 = pC10[0+ps*0];
+				for(kk=1; kk<kmax; kk++)
+					{
+					w00 += pC10[0+ps*kk] * pC00[0+ps*kk];
+					}
+				w00 = w00*pT[0+ldt*0];
+				pC10[0+ps*0] += w00;
+				for(kk=1; kk<kmax; kk++)
+					{
+					pC10[0+ps*kk] += w00 * pC00[0+ps*kk];
+					}
+				pC10 += 1;
+				}
+			}
+		}
+	return;
+	}
+
+
+
+

--- a/kernel/avx512/kernel_dgeqrf_8_lib8.c
+++ b/kernel/avx512/kernel_dgeqrf_8_lib8.c
@@ -1818,4 +1818,79 @@ void kernel_dlarft_la_8_lib8(int kmax, double *dD, double *pA, double *pT)
 
 
 
+void kernel_dlarfb8_rn_la_1_lib8(int n1, double *pVA, double *pT, double *pD, double *pA)
+	{
+	const int ps = 8;
+	double pW[8];
+	int kk;
+	// 0
+	pW[0+ps*0] = pD[0+ps*0];
+	// 1
+	pW[0+ps*1] = pD[0+ps*1];
+	// 2
+	pW[0+ps*2] = pD[0+ps*2];
+	// 3
+	pW[0+ps*3] = pD[0+ps*3];
+	// 4
+	pW[0+ps*4] = pD[0+ps*4];
+	// 5
+	pW[0+ps*5] = pD[0+ps*5];
+	// 6
+	pW[0+ps*6] = pD[0+ps*6];
+	// 7
+	pW[0+ps*7] = pD[0+ps*7];
+	//
+	for(kk=0; kk<n1; kk++)
+		{
+		pW[0+ps*0] += pA[0+ps*kk]*pVA[0+ps*kk];
+		pW[0+ps*1] += pA[0+ps*kk]*pVA[1+ps*kk];
+		pW[0+ps*2] += pA[0+ps*kk]*pVA[2+ps*kk];
+		pW[0+ps*3] += pA[0+ps*kk]*pVA[3+ps*kk];
+		pW[0+ps*4] += pA[0+ps*kk]*pVA[4+ps*kk];
+		pW[0+ps*5] += pA[0+ps*kk]*pVA[5+ps*kk];
+		pW[0+ps*6] += pA[0+ps*kk]*pVA[6+ps*kk];
+		pW[0+ps*7] += pA[0+ps*kk]*pVA[7+ps*kk];
+		}
+	//
+	pW[0+ps*7] = pW[0+ps*0]*pT[0+ps*7] + pW[0+ps*1]*pT[1+ps*7] + pW[0+ps*2]*pT[2+ps*7] + pW[0+ps*3]*pT[3+ps*7] + pW[0+ps*4]*pT[4+ps*7] + pW[0+ps*5]*pT[5+ps*7] + pW[0+ps*6]*pT[6+ps*7] + pW[0+ps*7]*pT[7+ps*7];
+	//
+	pW[0+ps*6] = pW[0+ps*0]*pT[0+ps*6] + pW[0+ps*1]*pT[1+ps*6] + pW[0+ps*2]*pT[2+ps*6] + pW[0+ps*3]*pT[3+ps*6] + pW[0+ps*4]*pT[4+ps*6] + pW[0+ps*5]*pT[5+ps*6] + pW[0+ps*6]*pT[6+ps*6];
+	//
+	pW[0+ps*5] = pW[0+ps*0]*pT[0+ps*5] + pW[0+ps*1]*pT[1+ps*5] + pW[0+ps*2]*pT[2+ps*5] + pW[0+ps*3]*pT[3+ps*5] + pW[0+ps*4]*pT[4+ps*5] + pW[0+ps*5]*pT[5+ps*5];
+	//
+	pW[0+ps*4] = pW[0+ps*0]*pT[0+ps*4] + pW[0+ps*1]*pT[1+ps*4] + pW[0+ps*2]*pT[2+ps*4] + pW[0+ps*3]*pT[3+ps*4] + pW[0+ps*4]*pT[4+ps*4];
+	//
+	pW[0+ps*3] = pW[0+ps*0]*pT[0+ps*3] + pW[0+ps*1]*pT[1+ps*3] + pW[0+ps*2]*pT[2+ps*3] + pW[0+ps*3]*pT[3+ps*3];
+	//
+	pW[0+ps*2] = pW[0+ps*0]*pT[0+ps*2] + pW[0+ps*1]*pT[1+ps*2] + pW[0+ps*2]*pT[2+ps*2];
+	//
+	pW[0+ps*1] = pW[0+ps*0]*pT[0+ps*1] + pW[0+ps*1]*pT[1+ps*1];
+	//
+	pW[0+ps*0] = pW[0+ps*0]*pT[0+ps*0];
+	//
+	pD[0+ps*0] += pW[0+ps*0];
+	//
+	pD[0+ps*1] += pW[0+ps*1];
+	//
+	pD[0+ps*2] += pW[0+ps*2];
+	//
+	pD[0+ps*3] += pW[0+ps*3];
+	//
+	pD[0+ps*4] += pW[0+ps*4];
+	//
+	pD[0+ps*5] += pW[0+ps*5];
+	//
+	pD[0+ps*6] += pW[0+ps*6];
+	//
+	pD[0+ps*7] += pW[0+ps*7];
+	//
+	for(kk=0; kk<n1; kk++)
+		{
+		pA[0+ps*kk] += pW[0+ps*0]*pVA[0+ps*kk] + pW[0+ps*1]*pVA[1+ps*kk] + pW[0+ps*2]*pVA[2+ps*kk] + pW[0+ps*3]*pVA[3+ps*kk] + pW[0+ps*4]*pVA[4+ps*kk] + pW[0+ps*5]*pVA[5+ps*kk] + pW[0+ps*6]*pVA[6+ps*kk] + pW[0+ps*7]*pVA[7+ps*kk];
+		}
+	return;
+	}
+
+
+
 

--- a/kernel/avx512/kernel_dgeqrf_8_lib8.c
+++ b/kernel/avx512/kernel_dgeqrf_8_lib8.c
@@ -1893,4 +1893,263 @@ void kernel_dlarfb8_rn_la_1_lib8(int n1, double *pVA, double *pT, double *pD, do
 
 
 
+// assume kmax>=8
+// 1 d d d d
+// 0 1 d d d
+// 0 0 1 d d
+// 0 0 0 1 d
+void kernel_dlarft_lla_8_lib8(int n0, int n1, double *dD, double *pL, double *pA, double *pT)
+	{
+	const int ps = 8;
+	int kk;
+	double v10,
+	       v20, v21,
+		   v30, v31, v32,
+		   v40, v41, v42, v43,
+		   v50, v51, v52, v53, v54,
+		   v60, v61, v62, v63, v64, v65,
+		   v70, v71, v72, v73, v74, v75, v76;
+	// orthogonal pD
+	v10 = 0.0;
+	v20 = 0.0;
+	v21 = 0.0;
+	v30 = 0.0;
+	v31 = 0.0;
+	v32 = 0.0;
+	v40 = 0.0;
+	v41 = 0.0;
+	v42 = 0.0;
+	v43 = 0.0;
+	v50 = 0.0;
+	v51 = 0.0;
+	v52 = 0.0;
+	v53 = 0.0;
+	v54 = 0.0;
+	v60 = 0.0;
+	v61 = 0.0;
+	v62 = 0.0;
+	v63 = 0.0;
+	v64 = 0.0;
+	v65 = 0.0;
+	v70 = 0.0;
+	v71 = 0.0;
+	v72 = 0.0;
+	v73 = 0.0;
+	v74 = 0.0;
+	v75 = 0.0;
+	v76 = 0.0;
+	// L
+	for(kk=0; kk<=n0; kk++)
+		{
+		v10 += pL[1+ps*kk]*pL[0+ps*kk];
+		v20 += pL[2+ps*kk]*pL[0+ps*kk];
+		v30 += pL[3+ps*kk]*pL[0+ps*kk];
+		v40 += pL[4+ps*kk]*pL[0+ps*kk];
+		v50 += pL[5+ps*kk]*pL[0+ps*kk];
+		v60 += pL[6+ps*kk]*pL[0+ps*kk];
+		v70 += pL[7+ps*kk]*pL[0+ps*kk];
+		//
+		v21 += pL[2+ps*kk]*pL[1+ps*kk];
+		v31 += pL[3+ps*kk]*pL[1+ps*kk];
+		v41 += pL[4+ps*kk]*pL[1+ps*kk];
+		v51 += pL[5+ps*kk]*pL[1+ps*kk];
+		v61 += pL[6+ps*kk]*pL[1+ps*kk];
+		v71 += pL[7+ps*kk]*pL[1+ps*kk];
+		//
+		v32 += pL[3+ps*kk]*pL[2+ps*kk];
+		v42 += pL[4+ps*kk]*pL[2+ps*kk];
+		v52 += pL[5+ps*kk]*pL[2+ps*kk];
+		v62 += pL[6+ps*kk]*pL[2+ps*kk];
+		v72 += pL[7+ps*kk]*pL[2+ps*kk];
+		//
+		v43 += pL[4+ps*kk]*pL[3+ps*kk];
+		v53 += pL[5+ps*kk]*pL[3+ps*kk];
+		v63 += pL[6+ps*kk]*pL[3+ps*kk];
+		v73 += pL[7+ps*kk]*pL[3+ps*kk];
+		//
+		v54 += pL[5+ps*kk]*pL[4+ps*kk];
+		v64 += pL[6+ps*kk]*pL[4+ps*kk];
+		v74 += pL[7+ps*kk]*pL[4+ps*kk];
+		//
+		v65 += pL[6+ps*kk]*pL[5+ps*kk];
+		v75 += pL[7+ps*kk]*pL[5+ps*kk];
+		//
+		v76 += pL[7+ps*kk]*pL[6+ps*kk];
+		}
+	// L 7
+	v21 += pL[2+ps*kk]*pL[1+ps*kk];
+	v31 += pL[3+ps*kk]*pL[1+ps*kk];
+	v41 += pL[4+ps*kk]*pL[1+ps*kk];
+	v51 += pL[5+ps*kk]*pL[1+ps*kk];
+	v61 += pL[6+ps*kk]*pL[1+ps*kk];
+	v71 += pL[7+ps*kk]*pL[1+ps*kk];
+	//
+	v32 += pL[3+ps*kk]*pL[2+ps*kk];
+	v42 += pL[4+ps*kk]*pL[2+ps*kk];
+	v52 += pL[5+ps*kk]*pL[2+ps*kk];
+	v62 += pL[6+ps*kk]*pL[2+ps*kk];
+	v72 += pL[7+ps*kk]*pL[2+ps*kk];
+	//
+	v43 += pL[4+ps*kk]*pL[3+ps*kk];
+	v53 += pL[5+ps*kk]*pL[3+ps*kk];
+	v63 += pL[6+ps*kk]*pL[3+ps*kk];
+	v73 += pL[7+ps*kk]*pL[3+ps*kk];
+	//
+	v54 += pL[5+ps*kk]*pL[4+ps*kk];
+	v64 += pL[6+ps*kk]*pL[4+ps*kk];
+	v74 += pL[7+ps*kk]*pL[4+ps*kk];
+	//
+	v65 += pL[6+ps*kk]*pL[5+ps*kk];
+	v75 += pL[7+ps*kk]*pL[5+ps*kk];
+	//
+	v76 += pL[7+ps*kk]*pL[6+ps*kk];
+	kk++;
+	// L 6
+	v32 += pL[3+ps*kk]*pL[2+ps*kk];
+	v42 += pL[4+ps*kk]*pL[2+ps*kk];
+	v52 += pL[5+ps*kk]*pL[2+ps*kk];
+	v62 += pL[6+ps*kk]*pL[2+ps*kk];
+	v72 += pL[7+ps*kk]*pL[2+ps*kk];
+	//
+	v43 += pL[4+ps*kk]*pL[3+ps*kk];
+	v53 += pL[5+ps*kk]*pL[3+ps*kk];
+	v63 += pL[6+ps*kk]*pL[3+ps*kk];
+	v73 += pL[7+ps*kk]*pL[3+ps*kk];
+	//
+	v54 += pL[5+ps*kk]*pL[4+ps*kk];
+	v64 += pL[6+ps*kk]*pL[4+ps*kk];
+	v74 += pL[7+ps*kk]*pL[4+ps*kk];
+	//
+	v65 += pL[6+ps*kk]*pL[5+ps*kk];
+	v75 += pL[7+ps*kk]*pL[5+ps*kk];
+	//
+	v76 += pL[7+ps*kk]*pL[6+ps*kk];
+	kk++;
+	// L 5
+	v43 += pL[4+ps*kk]*pL[3+ps*kk];
+	v53 += pL[5+ps*kk]*pL[3+ps*kk];
+	v63 += pL[6+ps*kk]*pL[3+ps*kk];
+	v73 += pL[7+ps*kk]*pL[3+ps*kk];
+	//
+	v54 += pL[5+ps*kk]*pL[4+ps*kk];
+	v64 += pL[6+ps*kk]*pL[4+ps*kk];
+	v74 += pL[7+ps*kk]*pL[4+ps*kk];
+	//
+	v65 += pL[6+ps*kk]*pL[5+ps*kk];
+	v75 += pL[7+ps*kk]*pL[5+ps*kk];
+	//
+	v76 += pL[7+ps*kk]*pL[6+ps*kk];
+	kk++;
+	// L 4
+	v54 += pL[5+ps*kk]*pL[4+ps*kk];
+	v64 += pL[6+ps*kk]*pL[4+ps*kk];
+	v74 += pL[7+ps*kk]*pL[4+ps*kk];
+	//
+	v65 += pL[6+ps*kk]*pL[5+ps*kk];
+	v75 += pL[7+ps*kk]*pL[5+ps*kk];
+	//
+	v76 += pL[7+ps*kk]*pL[6+ps*kk];
+	kk++;
+	// L 3
+	v65 += pL[6+ps*kk]*pL[5+ps*kk];
+	v75 += pL[7+ps*kk]*pL[5+ps*kk];
+	//
+	v76 += pL[7+ps*kk]*pL[6+ps*kk];
+	kk++;
+	// L 2
+	v76 += pL[7+ps*kk]*pL[6+ps*kk];
+	kk++;
+	// L 1
+	kk++;
+	// A
+	for(kk=0; kk<n1; kk++)
+		{
+		v10 += pA[1+ps*kk]*pA[0+ps*kk];
+		v20 += pA[2+ps*kk]*pA[0+ps*kk];
+		v30 += pA[3+ps*kk]*pA[0+ps*kk];
+		v40 += pA[4+ps*kk]*pA[0+ps*kk];
+		v50 += pA[5+ps*kk]*pA[0+ps*kk];
+		v60 += pA[6+ps*kk]*pA[0+ps*kk];
+		v70 += pA[7+ps*kk]*pA[0+ps*kk];
+		//
+		v21 += pA[2+ps*kk]*pA[1+ps*kk];
+		v31 += pA[3+ps*kk]*pA[1+ps*kk];
+		v41 += pA[4+ps*kk]*pA[1+ps*kk];
+		v51 += pA[5+ps*kk]*pA[1+ps*kk];
+		v61 += pA[6+ps*kk]*pA[1+ps*kk];
+		v71 += pA[7+ps*kk]*pA[1+ps*kk];
+		//
+		v32 += pA[3+ps*kk]*pA[2+ps*kk];
+		v42 += pA[4+ps*kk]*pA[2+ps*kk];
+		v52 += pA[5+ps*kk]*pA[2+ps*kk];
+		v62 += pA[6+ps*kk]*pA[2+ps*kk];
+		v72 += pA[7+ps*kk]*pA[2+ps*kk];
+		//
+		v43 += pA[4+ps*kk]*pA[3+ps*kk];
+		v53 += pA[5+ps*kk]*pA[3+ps*kk];
+		v63 += pA[6+ps*kk]*pA[3+ps*kk];
+		v73 += pA[7+ps*kk]*pA[3+ps*kk];
+		//
+		v54 += pA[5+ps*kk]*pA[4+ps*kk];
+		v64 += pA[6+ps*kk]*pA[4+ps*kk];
+		v74 += pA[7+ps*kk]*pA[4+ps*kk];
+		//
+		v65 += pA[6+ps*kk]*pA[5+ps*kk];
+		v75 += pA[7+ps*kk]*pA[5+ps*kk];
+		//
+		v76 += pA[7+ps*kk]*pA[6+ps*kk];
+		}
+	//
+	pT[0+ps*0] = - dD[0];
+	pT[1+ps*1] = - dD[1];
+	pT[2+ps*2] = - dD[2];
+	pT[3+ps*3] = - dD[3];
+	pT[4+ps*4] = - dD[4];
+	pT[5+ps*5] = - dD[5];
+	pT[6+ps*6] = - dD[6];
+	pT[7+ps*7] = - dD[7];
+	//
+	pT[0+ps*1] = - dD[1] * (v10*pT[0+ps*0]);
+	pT[1+ps*2] = - dD[2] * (v21*pT[1+ps*1]);
+	pT[2+ps*3] = - dD[3] * (v32*pT[2+ps*2]);
+	pT[3+ps*4] = - dD[4] * (v43*pT[3+ps*3]);
+	pT[4+ps*5] = - dD[5] * (v54*pT[4+ps*4]);
+	pT[5+ps*6] = - dD[6] * (v65*pT[5+ps*5]);
+	pT[6+ps*7] = - dD[7] * (v76*pT[6+ps*6]);
+	//
+	pT[0+ps*2] = - dD[2] * (v20*pT[0+ps*0] + v21*pT[0+ps*1]);
+	pT[1+ps*3] = - dD[3] * (v31*pT[1+ps*1] + v32*pT[1+ps*2]);
+	pT[2+ps*4] = - dD[4] * (v42*pT[2+ps*2] + v43*pT[2+ps*3]);
+	pT[3+ps*5] = - dD[5] * (v53*pT[3+ps*3] + v54*pT[3+ps*4]);
+	pT[4+ps*6] = - dD[6] * (v64*pT[4+ps*4] + v65*pT[4+ps*5]);
+	pT[5+ps*7] = - dD[7] * (v75*pT[5+ps*5] + v76*pT[5+ps*6]);
+	//
+	pT[0+ps*3] = - dD[3] * (v30*pT[0+ps*0] + v31*pT[0+ps*1] + v32*pT[0+ps*2]);
+	pT[1+ps*4] = - dD[4] * (v41*pT[1+ps*1] + v42*pT[1+ps*2] + v43*pT[1+ps*3]);
+	pT[2+ps*5] = - dD[5] * (v52*pT[2+ps*2] + v53*pT[2+ps*3] + v54*pT[2+ps*4]);
+	pT[3+ps*6] = - dD[6] * (v63*pT[3+ps*3] + v64*pT[3+ps*4] + v65*pT[3+ps*5]);
+	pT[4+ps*7] = - dD[7] * (v74*pT[4+ps*4] + v75*pT[4+ps*5] + v76*pT[4+ps*6]);
+	//
+	pT[0+ps*4] = - dD[4] * (v40*pT[0+ps*0] + v41*pT[0+ps*1] + v42*pT[0+ps*2] + v43*pT[0+ps*3]);
+	pT[1+ps*5] = - dD[5] * (v51*pT[1+ps*1] + v52*pT[1+ps*2] + v53*pT[1+ps*3] + v54*pT[1+ps*4]);
+	pT[2+ps*6] = - dD[6] * (v62*pT[2+ps*2] + v63*pT[2+ps*3] + v64*pT[2+ps*4] + v65*pT[2+ps*5]);
+	pT[3+ps*7] = - dD[7] * (v73*pT[3+ps*3] + v74*pT[3+ps*4] + v75*pT[3+ps*5] + v76*pT[3+ps*6]);
+	//
+	pT[0+ps*5] = - dD[5] * (v50*pT[0+ps*0] + v51*pT[0+ps*1] + v52*pT[0+ps*2] + v53*pT[0+ps*3] + v54*pT[0+ps*4]);
+	pT[1+ps*6] = - dD[6] * (v61*pT[1+ps*1] + v62*pT[1+ps*2] + v63*pT[1+ps*3] + v64*pT[1+ps*4] + v65*pT[1+ps*5]);
+	pT[2+ps*7] = - dD[7] * (v72*pT[2+ps*2] + v73*pT[2+ps*3] + v74*pT[2+ps*4] + v75*pT[2+ps*5] + v76*pT[2+ps*6]);
+	//
+	pT[0+ps*6] = - dD[6] * (v60*pT[0+ps*0] + v61*pT[0+ps*1] + v62*pT[0+ps*2] + v63*pT[0+ps*3] + v64*pT[0+ps*4] + v65*pT[0+ps*5]);
+	pT[1+ps*7] = - dD[7] * (v71*pT[1+ps*1] + v72*pT[1+ps*2] + v73*pT[1+ps*3] + v74*pT[1+ps*4] + v75*pT[1+ps*5] + v76*pT[1+ps*6]);
+	//
+	pT[0+ps*7] = - dD[7] * (v70*pT[0+ps*0] + v71*pT[0+ps*1] + v72*pT[0+ps*2] + v73*pT[0+ps*3] + v74*pT[0+ps*4] + v75*pT[0+ps*5] + v76*pT[0+ps*6]);
+
+//printf("\n%f\n", v10);
+//printf("\n%f %f\n", v20, v21);
+//printf("\n%f %f %f\n", v30, v31, v32);
+	return;
+	}
+
+
+
 

--- a/kernel/avx512/kernel_dgeqrf_8_lib8.c
+++ b/kernel/avx512/kernel_dgeqrf_8_lib8.c
@@ -67,13 +67,12 @@ void kernel_dgelqf_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd, d
 	double *pC00, *pC10, *pC10a, *pC20, *pC20a, *pC01, *pC11;
 	double pT[4];
 	int ldt = 2;
-	double *pD0 = pD-offD;
 	ii = 0;
 #if 1 // rank 2
 	for(; ii<imax-1; ii+=2)
 		{
 		// first row
-		pC00 = &pD0[((offD+ii)&(ps-1))+((offD+ii)-((offD+ii)&(ps-1)))*sdd+ii*ps];
+		pC00 = &pD[((offD+ii)&(ps-1))+((offD+ii)-((offD+ii)&(ps-1)))*sdd+ii*ps];
 		beta = 0.0;
 		for(jj=1; jj<n-ii; jj++)
 			{
@@ -97,7 +96,7 @@ void kernel_dgelqf_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd, d
 			for(jj=1; jj<n-ii; jj++)
 				pC00[0+ps*jj] *= tmp;
 			}
-		pC10 = &pD0[((offD+ii+1)&(ps-1))+((offD+ii+1)-((offD+ii+1)&(ps-1)))*sdd+ii*ps];
+		pC10 = &pD[((offD+ii+1)&(ps-1))+((offD+ii+1)-((offD+ii+1)&(ps-1)))*sdd+ii*ps];
 		kmax = n-ii;
 		w00 = pC10[0+ps*0]; // pC00[0+ps*0] = 1.0
 		for(kk=1; kk<kmax; kk++)
@@ -149,7 +148,7 @@ void kernel_dgelqf_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd, d
 		jmax0 = (ps-((ii+2+offD)&(ps-1)))&(ps-1);
 		jmax0 = jmax<jmax0 ? jmax : jmax0;
 		jj = 0;
-		pC20a = &pD0[((offD+ii+2)&(ps-1))+((offD+ii+2)-((offD+ii+2)&(ps-1)))*sdd+ii*ps];
+		pC20a = &pD[((offD+ii+2)&(ps-1))+((offD+ii+2)-((offD+ii+2)&(ps-1)))*sdd+ii*ps];
 		pC20 = pC20a;
 		if(jmax0>0)
 			{
@@ -247,7 +246,7 @@ void kernel_dgelqf_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd, d
 #endif
 	for(; ii<imax; ii++)
 		{
-		pC00 = &pD0[((offD+ii)&(ps-1))+((offD+ii)-((offD+ii)&(ps-1)))*sdd+ii*ps];
+		pC00 = &pD[((offD+ii)&(ps-1))+((offD+ii)-((offD+ii)&(ps-1)))*sdd+ii*ps];
 		beta = 0.0;
 		for(jj=1; jj<n-ii; jj++)
 			{
@@ -281,7 +280,7 @@ void kernel_dgelqf_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd, d
 			jmax0 = (ps-((ii+1+offD)&(ps-1)))&(ps-1);
 			jmax0 = jmax<jmax0 ? jmax : jmax0;
 			jj = 0;
-			pC10a = &pD0[((offD+ii+1)&(ps-1))+((offD+ii+1)-((offD+ii+1)&(ps-1)))*sdd+ii*ps];
+			pC10a = &pD[((offD+ii+1)&(ps-1))+((offD+ii+1)-((offD+ii+1)&(ps-1)))*sdd+ii*ps];
 			pC10 = pC10a;
 			if(jmax0>0)
 				{
@@ -371,13 +370,12 @@ void kernel_dgelqf_pd_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd
 	double *pC00, *pC10, *pC10a, *pC20, *pC20a, *pC01, *pC11;
 	double pT[4];
 	int ldt = 2;
-	double *pD0 = pD-offD;
 	ii = 0;
 #if 1 // rank 2
 	for(; ii<imax-1; ii+=2)
 		{
 		// first row
-		pC00 = &pD0[((offD+ii)&(ps-1))+((offD+ii)-((offD+ii)&(ps-1)))*sdd+ii*ps];
+		pC00 = &pD[((offD+ii)&(ps-1))+((offD+ii)-((offD+ii)&(ps-1)))*sdd+ii*ps];
 		sigma = 0.0;
 		for(jj=1; jj<n-ii; jj++)
 			{
@@ -403,7 +401,7 @@ void kernel_dgelqf_pd_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd
 			for(jj=1; jj<n-ii; jj++)
 				pC00[0+ps*jj] *= tmp;
 			}
-		pC10 = &pD0[((offD+ii+1)&(ps-1))+((offD+ii+1)-((offD+ii+1)&(ps-1)))*sdd+ii*ps];
+		pC10 = &pD[((offD+ii+1)&(ps-1))+((offD+ii+1)-((offD+ii+1)&(ps-1)))*sdd+ii*ps];
 		kmax = n-ii;
 		w00 = pC10[0+ps*0]; // pC00[0+ps*0] = 1.0
 		for(kk=1; kk<kmax; kk++)
@@ -457,7 +455,7 @@ void kernel_dgelqf_pd_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd
 		jmax0 = (ps-((ii+2+offD)&(ps-1)))&(ps-1);
 		jmax0 = jmax<jmax0 ? jmax : jmax0;
 		jj = 0;
-		pC20a = &pD0[((offD+ii+2)&(ps-1))+((offD+ii+2)-((offD+ii+2)&(ps-1)))*sdd+ii*ps];
+		pC20a = &pD[((offD+ii+2)&(ps-1))+((offD+ii+2)-((offD+ii+2)&(ps-1)))*sdd+ii*ps];
 		pC20 = pC20a;
 		if(jmax0>0)
 			{
@@ -555,7 +553,7 @@ void kernel_dgelqf_pd_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd
 #endif
 	for(; ii<imax; ii++)
 		{
-		pC00 = &pD0[((offD+ii)&(ps-1))+((offD+ii)-((offD+ii)&(ps-1)))*sdd+ii*ps];
+		pC00 = &pD[((offD+ii)&(ps-1))+((offD+ii)-((offD+ii)&(ps-1)))*sdd+ii*ps];
 		sigma = 0.0;
 		for(jj=1; jj<n-ii; jj++)
 			{
@@ -591,7 +589,7 @@ void kernel_dgelqf_pd_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd
 			jmax0 = (ps-((ii+1+offD)&(ps-1)))&(ps-1);
 			jmax0 = jmax<jmax0 ? jmax : jmax0;
 			jj = 0;
-			pC10a = &pD0[((offD+ii+1)&(ps-1))+((offD+ii+1)-((offD+ii+1)&(ps-1)))*sdd+ii*ps];
+			pC10a = &pD[((offD+ii+1)&(ps-1))+((offD+ii+1)-((offD+ii+1)&(ps-1)))*sdd+ii*ps];
 			pC10 = pC10a;
 			if(jmax0>0)
 				{
@@ -984,15 +982,13 @@ void kernel_dgelqf_pd_la_vs_lib8(int m, int n1, int k, int offD, double *pD, int
 	double *pA00, *pA10, *pA20, *pA01, *pA11;
 	double pT[4];
 	int ldt = 2;
-	double *pD0 = pD-offD; // TODO ?????
-	double *pA0 = pA-offA; // TODO ?????
 	ii = 0;
 #if 1 // rank 2
 	for(; ii<imax-1; ii+=2)
 		{
 		// first row
-		pD00 = &pD0[((offD+ii)&(ps-1))+((offD+ii)-((offD+ii)&(ps-1)))*sdd+ii*ps];
-		pA00 = &pA0[((offA+ii)&(ps-1))+((offA+ii)-((offA+ii)&(ps-1)))*sda+0*ps];
+		pD00 = &pD[((offD+ii)&(ps-1))+((offD+ii)-((offD+ii)&(ps-1)))*sdd+ii*ps];
+		pA00 = &pA[((offA+ii)&(ps-1))+((offA+ii)-((offA+ii)&(ps-1)))*sda+0*ps];
 		sigma = 0.0;
 		for(jj=0; jj<n1; jj++)
 			{
@@ -1018,8 +1014,8 @@ void kernel_dgelqf_pd_la_vs_lib8(int m, int n1, int k, int offD, double *pD, int
 			for(jj=0; jj<n1; jj++)
 				pA00[0+ps*jj] *= tmp;
 			}
-		pD10 = &pD0[((offD+ii+1)&(ps-1))+((offD+ii+1)-((offD+ii+1)&(ps-1)))*sdd+ii*ps];
-		pA10 = &pA0[((offA+ii+1)&(ps-1))+((offA+ii+1)-((offA+ii+1)&(ps-1)))*sda+0*ps];
+		pD10 = &pD[((offD+ii+1)&(ps-1))+((offD+ii+1)-((offD+ii+1)&(ps-1)))*sdd+ii*ps];
+		pA10 = &pA[((offA+ii+1)&(ps-1))+((offA+ii+1)-((offA+ii+1)&(ps-1)))*sda+0*ps];
 		w00 = pD10[0+ps*0]; // pD00[0+ps*0] = 1.0
 		for(kk=0; kk<n1; kk++)
 			{
@@ -1070,12 +1066,12 @@ void kernel_dgelqf_pd_la_vs_lib8(int m, int n1, int k, int offD, double *pD, int
 		jmax0 = (ps-((ii+2+offA)&(ps-1)))&(ps-1);
 		jmax0 = jmax<jmax0 ? jmax : jmax0;
 		jj = 0;
-		pA20 = &pA0[((offA+ii+2)&(ps-1))+((offA+ii+2)-((offA+ii+2)&(ps-1)))*sda+0*ps];
+		pA20 = &pA[((offA+ii+2)&(ps-1))+((offA+ii+2)-((offA+ii+2)&(ps-1)))*sda+0*ps];
 		if(jmax0>0)
 			{
 			for( ; jj<jmax0; jj++)
 				{
-				pD20 = &pD0[((offD+ii+jj+2)&(ps-1))+((offD+ii+jj+2)-((offD+ii+jj+2)&(ps-1)))*sdd+ii*ps];
+				pD20 = &pD[((offD+ii+jj+2)&(ps-1))+((offD+ii+jj+2)-((offD+ii+jj+2)&(ps-1)))*sdd+ii*ps];
 				w00 = pD20[0+ps*0]*1.0 + pD20[0+ps*1]*pD00[0+ps*1];
 				w01 = pD20[0+ps*0]*0.0 + pD20[0+ps*1]*1.0;
 				for(kk=0; kk<n1; kk++)
@@ -1098,7 +1094,7 @@ void kernel_dgelqf_pd_la_vs_lib8(int m, int n1, int k, int offD, double *pD, int
 		for( ; jj<jmax-7; jj+=8)
 			{
 			//
-			pD20 = &pD0[((offD+ii+jj+2)&(ps-1))+((offD+ii+jj+2)-((offD+ii+jj+2)&(ps-1)))*sdd+ii*ps];
+			pD20 = &pD[((offD+ii+jj+2)&(ps-1))+((offD+ii+jj+2)-((offD+ii+jj+2)&(ps-1)))*sdd+ii*ps];
 			_w0 = _mm512_load_pd( &pD20[0+ps*0] );
 			_a0 = _mm512_load_pd( &pD20[0+ps*1] );
 			_b0 = _mm512_set1_pd( pD00[0+ps*1] );
@@ -1148,7 +1144,7 @@ void kernel_dgelqf_pd_la_vs_lib8(int m, int n1, int k, int offD, double *pD, int
 			}
 		for(ll=0; ll<jmax-jj; ll++)
 			{
-			pD20 = &pD0[((offD+ii+jj+ll+2)&(ps-1))+((offD+ii+jj+ll+2)-((offD+ii+jj+ll+2)&(ps-1)))*sdd+ii*ps];
+			pD20 = &pD[((offD+ii+jj+ll+2)&(ps-1))+((offD+ii+jj+ll+2)-((offD+ii+jj+ll+2)&(ps-1)))*sdd+ii*ps];
 			w00 = pD20[0+ps*0]*1.0 + pD20[0+ps*1]*pD00[0+ps*1];
 			w01 = pD20[0+ps*0]*0.0 + pD20[0+ps*1]*1.0;
 			for(kk=0; kk<n1; kk++)
@@ -1170,8 +1166,8 @@ void kernel_dgelqf_pd_la_vs_lib8(int m, int n1, int k, int offD, double *pD, int
 #endif
 	for(; ii<imax; ii++)
 		{
-		pD00 = &pD0[((offD+ii)&(ps-1))+((offD+ii)-((offD+ii)&(ps-1)))*sdd+ii*ps];
-		pA00 = &pA0[((offA+ii)&(ps-1))+((offA+ii)-((offA+ii)&(ps-1)))*sda+0*ps];
+		pD00 = &pD[((offD+ii)&(ps-1))+((offD+ii)-((offD+ii)&(ps-1)))*sdd+ii*ps];
+		pA00 = &pA[((offA+ii)&(ps-1))+((offA+ii)-((offA+ii)&(ps-1)))*sda+0*ps];
 		sigma = 0.0;
 		for(jj=0; jj<n1; jj++)
 			{
@@ -1204,12 +1200,12 @@ void kernel_dgelqf_pd_la_vs_lib8(int m, int n1, int k, int offD, double *pD, int
 		jmax0 = (ps-((ii+1+offA)&(ps-1)))&(ps-1);
 		jmax0 = jmax<jmax0 ? jmax : jmax0;
 		jj = 0;
-		pA10 = &pA0[((offA+ii+1)&(ps-1))+((offA+ii+1)-((offA+ii+1)&(ps-1)))*sda+0*ps];
+		pA10 = &pA[((offA+ii+1)&(ps-1))+((offA+ii+1)-((offA+ii+1)&(ps-1)))*sda+0*ps];
 		if(jmax0>0)
 			{
 			for( ; jj<jmax0; jj++)
 				{
-				pD10 = &pD0[((offD+ii+jj+1)&(ps-1))+((offD+ii+jj+1)-((offD+ii+jj+1)&(ps-1)))*sdd+ii*ps];
+				pD10 = &pD[((offD+ii+jj+1)&(ps-1))+((offD+ii+jj+1)-((offD+ii+jj+1)&(ps-1)))*sdd+ii*ps];
 				w00 = pD10[0+ps*0];
 				for(kk=0; kk<n1; kk++)
 					{
@@ -1228,7 +1224,7 @@ void kernel_dgelqf_pd_la_vs_lib8(int m, int n1, int k, int offD, double *pD, int
 		for( ; jj<jmax-7; jj+=8)
 			{
 			//
-			pD10 = &pD0[((offD+ii+jj+1)&(ps-1))+((offD+ii+jj+1)-((offD+ii+jj+1)&(ps-1)))*sdd+ii*ps];
+			pD10 = &pD[((offD+ii+jj+1)&(ps-1))+((offD+ii+jj+1)-((offD+ii+jj+1)&(ps-1)))*sdd+ii*ps];
 			_w0 = _mm512_load_pd( &pD10[0+ps*0] );
 			for(kk=0; kk<n1; kk++)
 				{
@@ -1256,7 +1252,7 @@ void kernel_dgelqf_pd_la_vs_lib8(int m, int n1, int k, int offD, double *pD, int
 			}
 		for(ll=0; ll<jmax-jj; ll++)
 			{
-			pD10 = &pD0[((offD+ii+jj+ll+1)&(ps-1))+((offD+ii+jj+ll+1)-((offD+ii+jj+ll+1)&(ps-1)))*sdd+ii*ps];
+			pD10 = &pD[((offD+ii+jj+ll+1)&(ps-1))+((offD+ii+jj+ll+1)-((offD+ii+jj+ll+1)&(ps-1)))*sdd+ii*ps];
 			w00 = pD10[0+ps*0];
 			for(kk=0; kk<n1; kk++)
 				{

--- a/kernel/avx512/kernel_dgeqrf_8_lib8.c
+++ b/kernel/avx512/kernel_dgeqrf_8_lib8.c
@@ -803,7 +803,7 @@ void kernel_dlarft_8_lib8(int kmax, double *pD, double *dD, double *pT)
 		v64 += pD[6+ps*kk]*pD[4+ps*kk];
 		v74 += pD[7+ps*kk]*pD[4+ps*kk];
 		//
-		v65 += pD[6+ps*kk]*pD[4+ps*kk];
+		v65 += pD[6+ps*kk]*pD[5+ps*kk];
 		v75 += pD[7+ps*kk]*pD[5+ps*kk];
 		//
 		v76 += pD[7+ps*kk]*pD[6+ps*kk];

--- a/kernel/avx512/kernel_dgeqrf_8_lib8.c
+++ b/kernel/avx512/kernel_dgeqrf_8_lib8.c
@@ -352,4 +352,314 @@ void kernel_dgelqf_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd, d
 
 
 
+// unblocked algorithm
+// positive diagonal
+void kernel_dgelqf_pd_vs_lib8(int m, int n, int k, int offD, double *pD, int sdd, double *dD)
+	{
+	if(m<=0 | n<=0)
+		return;
+	int ii, jj, kk, ll, imax, jmax, jmax0, kmax, kmax0;
+	const int ps = 8;
+	imax = k;//m<n ? m : n;
+	double alpha, beta, sigma, tmp;
+	double w00, w01,
+		   w10, w11,
+		   w20, w21,
+		   w30, w31;
+	__m512d
+		_a0, _b0, _t0, _w0, _w1;
+	double *pC00, *pC10, *pC10a, *pC20, *pC20a, *pC01, *pC11;
+	double pT[4];
+	int ldt = 2;
+	double *pD0 = pD-offD;
+	ii = 0;
+#if 1 // rank 2
+	for(; ii<imax-1; ii+=2)
+		{
+		// first row
+		pC00 = &pD0[((offD+ii)&(ps-1))+((offD+ii)-((offD+ii)&(ps-1)))*sdd+ii*ps];
+		sigma = 0.0;
+		for(jj=1; jj<n-ii; jj++)
+			{
+			tmp = pC00[0+ps*jj];
+			sigma += tmp*tmp;
+			}
+		if(sigma==0.0)
+			{
+			dD[ii] = 0.0;
+			}
+		else
+			{
+			alpha = pC00[0];
+			beta = sigma + alpha*alpha;
+			beta = sqrt(beta);
+			if(alpha<=0)
+				tmp = alpha-beta;
+			else
+				tmp = -sigma / (alpha+beta);
+			dD[ii] = 2*tmp*tmp / (sigma+tmp*tmp);
+			tmp = 1.0 / tmp;
+			pC00[0] = beta;
+			for(jj=1; jj<n-ii; jj++)
+				pC00[0+ps*jj] *= tmp;
+			}
+		pC10 = &pD0[((offD+ii+1)&(ps-1))+((offD+ii+1)-((offD+ii+1)&(ps-1)))*sdd+ii*ps];
+		kmax = n-ii;
+		w00 = pC10[0+ps*0]; // pC00[0+ps*0] = 1.0
+		for(kk=1; kk<kmax; kk++)
+			{
+			w00 += pC10[0+ps*kk] * pC00[0+ps*kk];
+			}
+		w00 = - w00*dD[ii];
+		pC10[0+ps*0] += w00; // pC00[0+ps*0] = 1.0
+		for(kk=1; kk<kmax; kk++)
+			{
+			pC10[0+ps*kk] += w00 * pC00[0+ps*kk];
+			}
+		// second row
+		pC11 = pC10+ps*1;
+		sigma = 0.0;
+		for(jj=1; jj<n-(ii+1); jj++)
+			{
+			tmp = pC11[0+ps*jj];
+			sigma += tmp*tmp;
+			}
+		if(sigma==0.0)
+			{
+			dD[(ii+1)] = 0.0;
+			}
+		else
+			{
+			alpha = pC11[0+ps*0];
+			beta = sigma + alpha*alpha;
+			beta = sqrt(beta);
+			if(alpha<=0)
+				tmp = alpha-beta;
+			else
+				tmp = -sigma / (alpha+beta);
+			dD[ii+1] = 2*tmp*tmp / (sigma+tmp*tmp);
+			tmp = 1.0 / tmp;
+			pC11[0+ps*0] = beta;
+			for(jj=1; jj<n-(ii+1); jj++)
+				pC11[0+ps*jj] *= tmp;
+			}
+		// compute T
+		kmax = n-ii;
+		tmp = 1.0*0.0 + pC00[0+ps*1]*1.0;
+		for(kk=2; kk<kmax; kk++)
+			tmp += pC00[0+ps*kk]*pC10[0+ps*kk];
+		pT[0+ldt*0] = - dD[ii+0];
+		pT[0+ldt*1] = + dD[ii+1] * tmp * dD[ii+0];
+		pT[1+ldt*1] = - dD[ii+1];
+		// downgrade
+		kmax = n-ii;
+		jmax = m-ii-2;
+		jmax0 = (ps-((ii+2+offD)&(ps-1)))&(ps-1);
+		jmax0 = jmax<jmax0 ? jmax : jmax0;
+		jj = 0;
+		pC20a = &pD0[((offD+ii+2)&(ps-1))+((offD+ii+2)-((offD+ii+2)&(ps-1)))*sdd+ii*ps];
+		pC20 = pC20a;
+		if(jmax0>0)
+			{
+			for( ; jj<jmax0; jj++)
+				{
+				w00 = pC20[0+ps*0]*1.0 + pC20[0+ps*1]*pC00[0+ps*1];
+				w01 = pC20[0+ps*0]*0.0 + pC20[0+ps*1]*1.0;
+				for(kk=2; kk<kmax; kk++)
+					{
+					w00 += pC20[0+ps*kk]*pC00[0+ps*kk];
+					w01 += pC20[0+ps*kk]*pC10[0+ps*kk];
+					}
+				w01 = w00*pT[0+ldt*1] + w01*pT[1+ldt*1];
+				w00 = w00*pT[0+ldt*0];
+				pC20[0+ps*0] += w00*1.0          + w01*0.0;
+				pC20[0+ps*1] += w00*pC00[0+ps*1] + w01*1.0;
+				for(kk=2; kk<kmax; kk++)
+					{
+					pC20[0+ps*kk] += w00*pC00[0+ps*kk] + w01*pC10[0+ps*kk];
+					}
+				pC20 += 1;
+				}
+			pC20 += -ps+ps*sdd;
+			}
+		for( ; jj<jmax-7; jj+=8)
+			{
+			//
+			_w0 = _mm512_load_pd( &pC20[0+ps*0] );
+			_a0 = _mm512_load_pd( &pC20[0+ps*1] );
+			_b0 = _mm512_set1_pd( pC00[0+ps*1] );
+			_t0 = _mm512_mul_pd( _a0, _b0 );
+			_w0 = _mm512_add_pd( _w0, _t0 );
+			_w1 = _mm512_load_pd( &pC20[0+ps*1] );
+			for(kk=2; kk<kmax; kk++)
+				{
+				_a0 = _mm512_load_pd( &pC20[0+ps*kk] );
+				_b0 = _mm512_set1_pd( pC00[0+ps*kk] );
+				_t0 = _mm512_mul_pd( _a0, _b0 );
+				_w0 = _mm512_add_pd( _w0, _t0 );
+				_b0 = _mm512_set1_pd( pC10[0+ps*kk] );
+				_t0 = _mm512_mul_pd( _a0, _b0 );
+				_w1 = _mm512_add_pd( _w1, _t0 );
+				}
+			//
+			_b0 = _mm512_set1_pd( pT[1+ldt*1] );
+			_w1 = _mm512_mul_pd( _w1, _b0 );
+			_b0 = _mm512_set1_pd( pT[0+ldt*1] );
+			_t0 = _mm512_mul_pd( _w0, _b0 );
+			_w1 = _mm512_add_pd( _w1, _t0 );
+			_b0 = _mm512_set1_pd( pT[0+ldt*0] );
+			_w0 = _mm512_mul_pd( _w0, _b0 );
+			//
+			_a0 = _mm512_load_pd( &pC20[0+ps*0] );
+			_a0 = _mm512_add_pd( _a0, _w0 );
+			_mm512_store_pd( &pC20[0+ps*0], _a0 );
+			_a0 = _mm512_load_pd( &pC20[0+ps*1] );
+			_b0 = _mm512_set1_pd( pC00[0+ps*1] );
+			_t0 = _mm512_mul_pd( _w0, _b0 );
+			_a0 = _mm512_add_pd( _a0, _t0 );
+			_a0 = _mm512_add_pd( _a0, _w1 );
+			_mm512_store_pd( &pC20[0+ps*1], _a0 );
+			for(kk=2; kk<kmax; kk++)
+				{
+				_a0 = _mm512_load_pd( &pC20[0+ps*kk] );
+				_b0 = _mm512_set1_pd( pC00[0+ps*kk] );
+				_t0 = _mm512_mul_pd( _w0, _b0 );
+				_a0 = _mm512_add_pd( _a0, _t0 );
+				_b0 = _mm512_set1_pd( pC10[0+ps*kk] );
+				_t0 = _mm512_mul_pd( _w1, _b0 );
+				_a0 = _mm512_add_pd( _a0, _t0 );
+				_mm512_store_pd( &pC20[0+ps*kk], _a0 );
+				}
+			pC20 += ps*sdd;
+			}
+		for(ll=0; ll<jmax-jj; ll++)
+			{
+			w00 = pC20[0+ps*0]*1.0 + pC20[0+ps*1]*pC00[0+ps*1];
+			w01 = pC20[0+ps*0]*0.0 + pC20[0+ps*1]*1.0;
+			for(kk=2; kk<kmax; kk++)
+				{
+				w00 += pC20[0+ps*kk]*pC00[0+ps*kk];
+				w01 += pC20[0+ps*kk]*pC10[0+ps*kk];
+				}
+			w01 = w00*pT[0+ldt*1] + w01*pT[1+ldt*1];
+			w00 = w00*pT[0+ldt*0];
+			pC20[0+ps*0] += w00*1.0          + w01*0.0;
+			pC20[0+ps*1] += w00*pC00[0+ps*1] + w01*1.0;
+			for(kk=2; kk<kmax; kk++)
+				{
+				pC20[0+ps*kk] += w00*pC00[0+ps*kk] + w01*pC10[0+ps*kk];
+				}
+			pC20 += 1;
+			}
+		}
+#endif
+	for(; ii<imax; ii++)
+		{
+		pC00 = &pD0[((offD+ii)&(ps-1))+((offD+ii)-((offD+ii)&(ps-1)))*sdd+ii*ps];
+		sigma = 0.0;
+		for(jj=1; jj<n-ii; jj++)
+			{
+			tmp = pC00[0+ps*jj];
+			sigma += tmp*tmp;
+			}
+		if(sigma==0.0)
+			{
+			dD[ii] = 0.0;
+			}
+		else
+			{
+			alpha = pC00[0];
+			beta = sigma + alpha*alpha;
+			beta = sqrt(beta);
+			if(alpha<=0)
+				tmp = alpha-beta;
+			else
+				tmp = -sigma / (alpha+beta);
+			dD[ii] = 2*tmp*tmp / (sigma+tmp*tmp);
+			tmp = 1.0 / tmp;
+			pC00[0] = beta;
+			for(jj=1; jj<n-ii; jj++)
+				pC00[0+ps*jj] *= tmp;
+			}
+		if(ii<n)
+			{
+			// compute T
+			pT[0+ldt*0] = - dD[ii+0];
+			// downgrade
+			kmax = n-ii;
+			jmax = m-ii-1;
+			jmax0 = (ps-((ii+1+offD)&(ps-1)))&(ps-1);
+			jmax0 = jmax<jmax0 ? jmax : jmax0;
+			jj = 0;
+			pC10a = &pD0[((offD+ii+1)&(ps-1))+((offD+ii+1)-((offD+ii+1)&(ps-1)))*sdd+ii*ps];
+			pC10 = pC10a;
+			if(jmax0>0)
+				{
+				for( ; jj<jmax0; jj++)
+					{
+					w00 = pC10[0+ps*0];
+					for(kk=1; kk<kmax; kk++)
+						{
+						w00 += pC10[0+ps*kk] * pC00[0+ps*kk];
+						}
+					w00 = w00*pT[0+ldt*0];
+					pC10[0+ps*0] += w00;
+					for(kk=1; kk<kmax; kk++)
+						{
+						pC10[0+ps*kk] += w00 * pC00[0+ps*kk];
+						}
+					pC10 += 1;
+					}
+				pC10 += -ps+ps*sdd;
+				}
+			for( ; jj<jmax-7; jj+=8)
+				{
+				//
+				_w0 = _mm512_load_pd( &pC10[0+ps*0] );
+				for(kk=1; kk<kmax; kk++)
+					{
+					_a0 = _mm512_load_pd( &pC10[0+ps*kk] );
+					_b0 = _mm512_set1_pd( pC00[0+ps*kk] );
+					_t0 = _mm512_mul_pd( _a0, _b0 );
+					_w0 = _mm512_add_pd( _w0, _t0 );
+					}
+				//
+				_b0 = _mm512_set1_pd( pT[0+ldt*0] );
+				_w0 = _mm512_mul_pd( _w0, _b0 );
+				//
+				_a0 = _mm512_load_pd( &pC10[0+ps*0] );
+				_a0 = _mm512_add_pd( _a0, _w0 );
+				_mm512_store_pd( &pC10[0+ps*0], _a0 );
+				for(kk=1; kk<kmax; kk++)
+					{
+					_a0 = _mm512_load_pd( &pC10[0+ps*kk] );
+					_b0 = _mm512_set1_pd( pC00[0+ps*kk] );
+					_t0 = _mm512_mul_pd( _w0, _b0 );
+					_a0 = _mm512_add_pd( _a0, _t0 );
+					_mm512_store_pd( &pC10[0+ps*kk], _a0 );
+					}
+				pC10 += ps*sdd;
+				}
+			for(ll=0; ll<jmax-jj; ll++)
+				{
+				w00 = pC10[0+ps*0];
+				for(kk=1; kk<kmax; kk++)
+					{
+					w00 += pC10[0+ps*kk] * pC00[0+ps*kk];
+					}
+				w00 = w00*pT[0+ldt*0];
+				pC10[0+ps*0] += w00;
+				for(kk=1; kk<kmax; kk++)
+					{
+					pC10[0+ps*kk] += w00 * pC00[0+ps*kk];
+					}
+				pC10 += 1;
+				}
+			}
+		}
+	return;
+	}
+
+
+
 

--- a/kernel/avx512/kernel_dpack_lib8.S
+++ b/kernel/avx512/kernel_dpack_lib8.S
@@ -4617,6 +4617,247 @@ NAME:
 
 
 //                              1         2          3        4          5
+// void kernel_dpack_nn_24_lib8(int kmax, double *A, int lda, double *C, int sdc)
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dpack_nn_24_lib8)
+
+	PROLOGUE
+
+
+	movq	ARG1, %r10 // kmax
+	movq	ARG2, %r11 // A
+	movq	ARG3, %r12 // lda
+	sall	$ 3, %r12d
+	movq	ARG4, %r13 // C
+	movq	ARG5, %r14 // sdc
+	sall	$ 6, %r14d //8*sizeof(double)*sdc
+
+
+	cmpl	$ 0, %r10d
+	jle		0f // return
+
+
+	cmpl	$ 3, %r10d
+	jle		2f // clean-up loop
+
+
+	// main loop
+	.p2align 3
+1: // main loop
+	
+	vmovupd		0(%r11), %zmm0
+//	prefetcht0	0(%r11, %r12, 4)
+	vmovapd		%zmm0, 0*64(%r13)
+	vmovupd		64(%r11), %zmm0
+//	prefetcht0	0(%r11, %r12, 4)
+	vmovapd		%zmm0, 0*64(%r13, %r14)
+	vmovupd		128(%r11), %zmm0
+//	prefetcht0	0(%r11, %r12, 4)
+	vmovapd		%zmm0, 0*64(%r13, %r14, 2)
+	addq	%r12, %r11
+
+	vmovupd		0(%r11), %zmm0
+//	prefetcht0	0(%r11, %r12, 4)
+	vmovapd		%zmm0, 1*64(%r13)
+	vmovupd		64(%r11), %zmm0
+//	prefetcht0	0(%r11, %r12, 4)
+	vmovapd		%zmm0, 1*64(%r13, %r14)
+	vmovupd		128(%r11), %zmm0
+//	prefetcht0	0(%r11, %r12, 4)
+	vmovapd		%zmm0, 1*64(%r13, %r14, 2)
+	addq	%r12, %r11
+
+	vmovupd		0(%r11), %zmm0
+//	prefetcht0	0(%r11, %r12, 4)
+	vmovapd		%zmm0, 2*64(%r13)
+	vmovupd		64(%r11), %zmm0
+//	prefetcht0	0(%r11, %r12, 4)
+	vmovapd		%zmm0, 2*64(%r13, %r14)
+	vmovupd		128(%r11), %zmm0
+//	prefetcht0	0(%r11, %r12, 4)
+	vmovapd		%zmm0, 2*64(%r13, %r14, 2)
+	addq	%r12, %r11
+
+	vmovupd		0(%r11), %zmm0
+//	prefetcht0	0(%r11, %r12, 4)
+	vmovapd		%zmm0, 3*64(%r13)
+	vmovupd		64(%r11), %zmm0
+//	prefetcht0	0(%r11, %r12, 4)
+	vmovapd		%zmm0, 3*64(%r13, %r14)
+	vmovupd		128(%r11), %zmm0
+//	prefetcht0	0(%r11, %r12, 4)
+	vmovapd		%zmm0, 3*64(%r13, %r14, 2)
+	addq	%r12, %r11
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r13
+
+	cmpl	$ 3, %r10d
+	jg		1b
+
+
+	cmpl	$ 0, %r10d
+	jle		0f // return
+
+
+2: // clean-up loop
+	
+	vmovupd		0(%r11), %zmm0
+	vmovapd		%zmm0, 0(%r13)
+	vmovupd		64(%r11), %zmm0
+	vmovapd		%zmm0, 0(%r13, %r14)
+	vmovupd		128(%r11), %zmm0
+	vmovapd		%zmm0, 0*64(%r13, %r14, 2)
+	addq	%r12, %r11
+
+	subl	$ 1, %r10d
+	addq	$ 1*64, %r13
+
+	cmpl	$ 0, %r10d
+	jg		2b
+
+
+0: // return
+
+	EPILOGUE
+
+	ret
+
+	FUN_END(kernel_dpack_nn_24_lib8)
+
+
+
+
+
+//                                 1         2          3        4          5        6
+// void kernel_dpack_nn_24_vs_lib8(int kmax, double *A, int lda, double *C, int sdc, int m1)
+
+	.p2align 4,,15
+	GLOB_FUN_START(kernel_dpack_nn_24_vs_lib8)
+
+	PROLOGUE
+
+
+	movq	ARG1, %r10 // kmax
+	movq	ARG2, %r11 // A
+	movq	ARG3, %r12 // lda
+	sall	$ 3, %r12d
+	movq	ARG4, %r13 // C
+	movq	ARG5, %r14 // sdc
+	sall	$ 6, %r14d //8*sizeof(double)*sdc
+	movq	ARG6, %r15 // m1
+
+
+	cmpl	$ 0, %r10d
+	jle		0f // return
+
+
+	// compute mask
+	vcvtsi2sd	%r15d, %xmm25, %xmm25
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	vmovupd		.LC02(%rip), %zmm24
+#elif defined(OS_MAC)
+	vmovupd		LC02(%rip), %zmm24
+#endif
+	vbroadcastsd	%xmm25, %zmm25
+	vsubpd		%zmm25, %zmm24, %zmm25
+	vpmovq2m	%zmm25, %k1
+
+
+	cmpl	$ 3, %r10d
+	jle		2f // clean-up loop
+
+
+	// main loop
+	.p2align 3
+1: // main loop
+	
+	vmovupd		0(%r11), %zmm0
+//	prefetcht0	0(%r11, %r12, 4)
+	vmovapd		%zmm0, 0*64(%r13)
+	vmovupd		64(%r11), %zmm0
+//	prefetcht0	0(%r11, %r12, 4)
+	vmovapd		%zmm0, 0*64(%r13, %r14)
+	vmovupd		128(%r11), %zmm0 {%k1}
+//	prefetcht0	0(%r11, %r12, 4)
+	vmovapd		%zmm0, 0*64(%r13, %r14, 2) {%k1}
+	addq	%r12, %r11
+
+	vmovupd		0(%r11), %zmm0
+//	prefetcht0	0(%r11, %r12, 4)
+	vmovapd		%zmm0, 1*64(%r13)
+	vmovupd		64(%r11), %zmm0
+//	prefetcht0	0(%r11, %r12, 4)
+	vmovapd		%zmm0, 1*64(%r13, %r14)
+	vmovupd		128(%r11), %zmm0 {%k1}
+//	prefetcht0	0(%r11, %r12, 4)
+	vmovapd		%zmm0, 1*64(%r13, %r14, 2) {%k1}
+	addq	%r12, %r11
+
+	vmovupd		0(%r11), %zmm0
+//	prefetcht0	0(%r11, %r12, 4)
+	vmovapd		%zmm0, 2*64(%r13)
+	vmovupd		64(%r11), %zmm0
+//	prefetcht0	0(%r11, %r12, 4)
+	vmovapd		%zmm0, 2*64(%r13, %r14)
+	vmovupd		128(%r11), %zmm0 {%k1}
+//	prefetcht0	0(%r11, %r12, 4)
+	vmovapd		%zmm0, 2*64(%r13, %r14, 2) {%k1}
+	addq	%r12, %r11
+
+	vmovupd		0(%r11), %zmm0
+//	prefetcht0	0(%r11, %r12, 4)
+	vmovapd		%zmm0, 3*64(%r13)
+	vmovupd		64(%r11), %zmm0
+//	prefetcht0	0(%r11, %r12, 4)
+	vmovapd		%zmm0, 3*64(%r13, %r14)
+	vmovupd		128(%r11), %zmm0 {%k1}
+//	prefetcht0	0(%r11, %r12, 4)
+	vmovapd		%zmm0, 3*64(%r13, %r14, 2) {%k1}
+	addq	%r12, %r11
+
+	subl	$ 4, %r10d
+	addq	$ 4*64, %r13
+
+	cmpl	$ 3, %r10d
+	jg		1b
+
+
+	cmpl	$ 0, %r10d
+	jle		0f // return
+
+
+2: // clean-up loop
+	
+	vmovupd		0(%r11), %zmm0
+	vmovapd		%zmm0, 0(%r13)
+	vmovupd		64(%r11), %zmm0
+	vmovapd		%zmm0, 0*64(%r13, %r14)
+	vmovupd		128(%r11), %zmm0 {%k1}
+	vmovapd		%zmm0, 0*64(%r13, %r14, 2) {%k1}
+	addq	%r12, %r11
+
+	subl	$ 1, %r10d
+	addq	$ 1*64, %r13
+
+	cmpl	$ 0, %r10d
+	jg		2b
+
+
+0: // return
+
+	EPILOGUE
+
+	ret
+
+	FUN_END(kernel_dpack_nn_24_vs_lib8)
+
+
+
+
+
+//                              1         2          3        4          5
 // void kernel_dpack_nn_16_lib8(int kmax, double *A, int lda, double *C, int sdc)
 
 	.p2align 4,,15
@@ -5235,6 +5476,23 @@ LC01:
 	.double 13.5
 	.double 14.5
 	.double 15.5
+
+
+#if defined(OS_LINUX) | defined(OS_WINDOWS)
+	.align 64
+.LC02:
+#elif defined(OS_MAC)
+	.align 6
+LC02:
+#endif
+	.double 16.5
+	.double 17.5
+	.double 18.5
+	.double 19.5
+	.double 20.5
+	.double 21.5
+	.double 22.5
+	.double 23.5
 
 
 #if defined(OS_LINUX)

--- a/tests/classes/gemm.c
+++ b/tests/classes/gemm.c
@@ -97,8 +97,8 @@ void set_test_args(struct TestArgs *targs)
 #endif
 
 #if defined(TARGET_X64_INTEL_SKYLAKE_X)
-	targs->nis = 17;
-	targs->njs = 9;
+	targs->nis = 25;
+	targs->njs = 25;
 #else
 	targs->nis = 13;
 	targs->njs = 5;

--- a/tests/test_d_blasfeo_api.c
+++ b/tests/test_d_blasfeo_api.c
@@ -54,7 +54,7 @@ int main()
 
 	int ii;
 
-	int n = 16;
+	int n = 24;
 
 	//
 	// matrices in column-major format
@@ -233,10 +233,10 @@ int main()
 	
 #endif
 
-#if 0
+#if 1
 	// gemm_nt
 	alpha = 1.0;
-	beta = 0.0;
+	beta = 1.0;
 
 	blasfeo_print_dmat(n, n, &sD, 0, 0);
 //	d_print_mat(n, n, D, n);
@@ -331,15 +331,15 @@ int main()
 //	kernel_dgemm_tt_8x16_libc8cc(16, &alpha, A, n, sB.pA, sB.cn, &beta, D, n, D, n);
 //	kernel_dgemm_tt_8x16_vs_libc8cc(16, &alpha, A, n, sB.pA, sB.cn, &beta, D, n, D, n, 8, 16);
 
-	blasfeo_dgemm_nn(n, n, n, alpha, &sA, 0, 0, &sB, 0, 0, beta, &sA, 0, 0, &sD, 0, 0);
+//	blasfeo_dgemm_nn(n, n, n, alpha, &sA, 0, 0, &sB, 0, 0, beta, &sA, 0, 0, &sD, 0, 0);
 //	blasfeo_dgemm_nt(n, n, n, alpha, &sA, 0, 0, &sB, 0, 0, beta, &sD, 0, 0, &sD, 0, 0);
 //	blasfeo_dgemm_tn(n, n, n, alpha, &sA, 0, 0, &sB, 0, 0, beta, &sD, 0, 0, &sD, 0, 0);
 //	blasfeo_dgemm_tt(n, n, n, alpha, &sA, 0, 0, &sB, 0, 0, beta, &sD, 0, 0, &sD, 0, 0);
-//	blasfeo_dsyrk_ln(n, n, alpha, &sA, 0, 0, &sA, 0, 0, beta, &sB, 0, 0, &sD, 0, 0);
+	blasfeo_dsyrk_ln(n, n, alpha, &sA, 0, 0, &sA, 0, 0, beta, &sB, 0, 0, &sD, 0, 0);
 //	blasfeo_dsyrk_ln_mn(n, n, n, alpha, &sA, 0, 0, &sB, 0, 0, beta, &sD, 0, 0, &sD, 0, 0);
-//	blasfeo_dpotrf_l(n, &sD, 0, 0, &sD, 0, 0);
+	blasfeo_dpotrf_l(n, &sD, 0, 0, &sD, 0, 0);
 //	blasfeo_dpotrf_l_mn(n, n, &sD, 0, 0, &sD, 0, 0);
-//	blasfeo_dtrsm_rltn(n, n, alpha, &sD, 0, 0, &sB, 0, 0, &sE, 0, 0);
+	blasfeo_dtrsm_rltn(n, n, alpha, &sD, 0, 0, &sB, 0, 0, &sE, 0, 0);
 //	blasfeo_dsyrk_dpotrf_ln(n, n, &sA, 0, 0, &sA, 0, 0, &sB, 0, 0, &sD, 0, 0);
 //	blasfeo_dsyrk_dpotrf_ln_mn(n, n, n, &sA, 0, 0, &sA, 0, 0, &sB, 0, 0, &sD, 0, 0);
 //	blasfeo_dtrmm_rlnn(n, n, alpha, &sA, 0, 0, &sB, 0, 0, &sD, 0, 0);
@@ -358,7 +358,7 @@ int main()
 //	kernel_dsyrk_dpotrf_nt_l_8x8_vs_lib8(n, sA.pA, sA.pA, 0, sA.pA, sA.pA, sB.pA, sD.pA, sD.dA, 8, 8);
 
 	blasfeo_print_dmat(n, n, &sD, 0, 0);
-//	blasfeo_print_dmat(n, n, &sE, 0, 0);
+	blasfeo_print_dmat(n, n, &sE, 0, 0);
 //	d_print_mat(n, n, D, n);
 	return 0;
 #endif

--- a/tests/test_d_blasfeo_api.c
+++ b/tests/test_d_blasfeo_api.c
@@ -54,7 +54,7 @@ int main()
 
 	int ii;
 
-	int n = 24;
+	int n = 16;
 
 	//
 	// matrices in column-major format
@@ -613,9 +613,9 @@ int main()
 //	blasfeo_dgelqf_pd(n, 2*n, &lq0, 0, 0, &lq0, 0, 0, lq0_work);
 	blasfeo_dgelqf_pd_la(n, n, &lq0, 0, 0, &lq0, 0, n, lq0_work);
 
-//	blasfeo_print_dmat(n, 2*n, &lq0, 0, 0);
-	blasfeo_print_dmat(n, n, &lq0, 0, 0);
-	return 0;
+	blasfeo_print_dmat(n, 2*n, &lq0, 0, 0);
+//	blasfeo_print_dmat(n, n, &lq0, 0, 0);
+//	return 0;
 
 	blasfeo_dtrcp_l(n, &lq0, 0, 0, &lq1, 0, 0);
 	blasfeo_pack_dmat(n, n, B, n, &lq1, 0, n);

--- a/tests/test_d_blasfeo_api.c
+++ b/tests/test_d_blasfeo_api.c
@@ -54,7 +54,7 @@ int main()
 
 	int ii;
 
-	int n = 16;
+	int n = 24;
 
 	//
 	// matrices in column-major format
@@ -613,8 +613,8 @@ int main()
 //	blasfeo_dgelqf_pd(n, 2*n, &lq0, 0, 0, &lq0, 0, 0, lq0_work);
 	blasfeo_dgelqf_pd_la(n, n, &lq0, 0, 0, &lq0, 0, n, lq0_work);
 
-	blasfeo_print_dmat(n, 2*n, &lq0, 0, 0);
-//	blasfeo_print_dmat(n, n, &lq0, 0, 0);
+//	blasfeo_print_dmat(n, 2*n, &lq0, 0, 0);
+	blasfeo_print_dmat(n, n, &lq0, 0, 0);
 	return 0;
 
 	blasfeo_dtrcp_l(n, &lq0, 0, 0, &lq1, 0, 0);

--- a/tests/test_d_blasfeo_api.c
+++ b/tests/test_d_blasfeo_api.c
@@ -609,8 +609,8 @@ int main()
 
 	blasfeo_print_dmat(n, 2*n, &lq0, 0, 0);
 
-	blasfeo_dgelqf(n, 2*n, &lq0, 0, 0, &lq0, 0, 0, lq0_work);
-//	blasfeo_dgelqf_pd(n, 2*n, &lq0, 0, 0, &lq0, 0, 0, lq0_work);
+//	blasfeo_dgelqf(n, 2*n, &lq0, 0, 0, &lq0, 0, 0, lq0_work);
+	blasfeo_dgelqf_pd(n, 2*n, &lq0, 0, 0, &lq0, 0, 0, lq0_work);
 //	blasfeo_dgelqf_pd_la(n, n, &lq0, 0, 0, &lq0, 0, n, lq0_work);
 
 	blasfeo_print_dmat(n, 2*n, &lq0, 0, 0);

--- a/tests/test_d_blasfeo_api.c
+++ b/tests/test_d_blasfeo_api.c
@@ -614,6 +614,7 @@ int main()
 //	blasfeo_dgelqf_pd_la(n, n, &lq0, 0, 0, &lq0, 0, n, lq0_work);
 
 	blasfeo_print_dmat(n, 2*n, &lq0, 0, 0);
+//	blasfeo_print_dmat(n, n, &lq0, 0, 0);
 	return 0;
 
 	blasfeo_dtrcp_l(n, &lq0, 0, 0, &lq1, 0, 0);

--- a/tests/test_d_blasfeo_api.c
+++ b/tests/test_d_blasfeo_api.c
@@ -335,14 +335,14 @@ int main()
 //	blasfeo_dgemm_nt(n, n, n, alpha, &sA, 0, 0, &sB, 0, 0, beta, &sD, 0, 0, &sD, 0, 0);
 //	blasfeo_dgemm_tn(n, n, n, alpha, &sA, 0, 0, &sB, 0, 0, beta, &sD, 0, 0, &sD, 0, 0);
 //	blasfeo_dgemm_tt(n, n, n, alpha, &sA, 0, 0, &sB, 0, 0, beta, &sD, 0, 0, &sD, 0, 0);
-	blasfeo_dsyrk_ln(n, n, alpha, &sA, 0, 0, &sA, 0, 0, beta, &sB, 0, 0, &sD, 0, 0);
+//	blasfeo_dsyrk_ln(n, n, alpha, &sA, 0, 0, &sA, 0, 0, beta, &sB, 0, 0, &sD, 0, 0);
 //	blasfeo_dsyrk_ln_mn(n, n, n, alpha, &sA, 0, 0, &sB, 0, 0, beta, &sD, 0, 0, &sD, 0, 0);
-	blasfeo_dpotrf_l(n, &sD, 0, 0, &sD, 0, 0);
+//	blasfeo_dpotrf_l(n, &sD, 0, 0, &sD, 0, 0);
 //	blasfeo_dpotrf_l_mn(n, n, &sD, 0, 0, &sD, 0, 0);
-	blasfeo_dtrsm_rltn(n, n, alpha, &sD, 0, 0, &sB, 0, 0, &sE, 0, 0);
-//	blasfeo_dsyrk_dpotrf_ln(n, n, &sA, 0, 0, &sA, 0, 0, &sB, 0, 0, &sD, 0, 0);
+	blasfeo_dsyrk_dpotrf_ln(n, n, &sA, 0, 0, &sA, 0, 0, &sB, 0, 0, &sD, 0, 0);
 //	blasfeo_dsyrk_dpotrf_ln_mn(n, n, n, &sA, 0, 0, &sA, 0, 0, &sB, 0, 0, &sD, 0, 0);
 //	blasfeo_dtrmm_rlnn(n, n, alpha, &sA, 0, 0, &sB, 0, 0, &sD, 0, 0);
+	blasfeo_dtrsm_rltn(n, n, alpha, &sD, 0, 0, &sB, 0, 0, &sE, 0, 0);
 
 //	blasfeo_dgecp(n, n, &sA, 0, 0, &sD, 0, 0);
 //	blasfeo_dtrcp_l(n, &sA, 0, 0, &sD, 0, 0);
@@ -597,7 +597,7 @@ int main()
 	return 0;
 #endif
 
-#if 1
+#if 0
 	// array lq
 	struct blasfeo_dmat lq0; blasfeo_allocate_dmat(n, 2*n, &lq0);
 	struct blasfeo_dmat lq1; blasfeo_allocate_dmat(n, 2*n, &lq1);
@@ -1220,8 +1220,8 @@ int main()
 //	blasfeo_free_dmat(&sB);
 //	blasfeo_free_dmat(&sD);
 	v_free_align(memory_strmat);
-	blasfeo_free_dmat(&lq0);
-	free(lq0_work);
+//	blasfeo_free_dmat(&lq0);
+//	free(lq0_work);
 
 	return 0;
 

--- a/tests/test_d_blasfeo_api.c
+++ b/tests/test_d_blasfeo_api.c
@@ -54,7 +54,7 @@ int main()
 
 	int ii;
 
-	int n = 24;
+	int n = 16;
 
 	//
 	// matrices in column-major format
@@ -233,7 +233,7 @@ int main()
 	
 #endif
 
-#if 1
+#if 0
 	// gemm_nt
 	alpha = 1.0;
 	beta = 0.0;
@@ -597,6 +597,7 @@ int main()
 	return 0;
 #endif
 
+#if 1
 	// array lq
 	struct blasfeo_dmat lq0; blasfeo_allocate_dmat(n, 2*n, &lq0);
 	struct blasfeo_dmat lq1; blasfeo_allocate_dmat(n, 2*n, &lq1);
@@ -608,10 +609,12 @@ int main()
 
 	blasfeo_print_dmat(n, 2*n, &lq0, 0, 0);
 
-	blasfeo_dgelqf_pd(n, 2*n, &lq0, 0, 0, &lq0, 0, 0, lq0_work);
+	blasfeo_dgelqf(n, 2*n, &lq0, 0, 0, &lq0, 0, 0, lq0_work);
+//	blasfeo_dgelqf_pd(n, 2*n, &lq0, 0, 0, &lq0, 0, 0, lq0_work);
 //	blasfeo_dgelqf_pd_la(n, n, &lq0, 0, 0, &lq0, 0, n, lq0_work);
 
 	blasfeo_print_dmat(n, 2*n, &lq0, 0, 0);
+	return 0;
 
 	blasfeo_dtrcp_l(n, &lq0, 0, 0, &lq1, 0, 0);
 	blasfeo_pack_dmat(n, n, B, n, &lq1, 0, n);
@@ -625,6 +628,7 @@ int main()
 	blasfeo_print_dmat(n, 2*n, &lq1, 0, 0);
 
 	return 0;
+#endif
 
 
 //	blasfeo_print_tran_dvec(n, &sv, 0);

--- a/tests/test_d_blasfeo_api.c
+++ b/tests/test_d_blasfeo_api.c
@@ -610,8 +610,8 @@ int main()
 	blasfeo_print_dmat(n, 2*n, &lq0, 0, 0);
 
 //	blasfeo_dgelqf(n, 2*n, &lq0, 0, 0, &lq0, 0, 0, lq0_work);
-	blasfeo_dgelqf_pd(n, 2*n, &lq0, 0, 0, &lq0, 0, 0, lq0_work);
-//	blasfeo_dgelqf_pd_la(n, n, &lq0, 0, 0, &lq0, 0, n, lq0_work);
+//	blasfeo_dgelqf_pd(n, 2*n, &lq0, 0, 0, &lq0, 0, 0, lq0_work);
+	blasfeo_dgelqf_pd_la(n, n, &lq0, 0, 0, &lq0, 0, n, lq0_work);
 
 	blasfeo_print_dmat(n, 2*n, &lq0, 0, 0);
 //	blasfeo_print_dmat(n, n, &lq0, 0, 0);

--- a/tests/test_d_blasfeo_api.c
+++ b/tests/test_d_blasfeo_api.c
@@ -615,7 +615,7 @@ int main()
 
 	blasfeo_print_dmat(n, 2*n, &lq0, 0, 0);
 //	blasfeo_print_dmat(n, n, &lq0, 0, 0);
-//	return 0;
+	return 0;
 
 	blasfeo_dtrcp_l(n, &lq0, 0, 0, &lq1, 0, 0);
 	blasfeo_pack_dmat(n, n, B, n, &lq1, 0, n);

--- a/tests/test_d_blasfeo_api.c
+++ b/tests/test_d_blasfeo_api.c
@@ -615,7 +615,7 @@ int main()
 
 	blasfeo_print_dmat(n, 2*n, &lq0, 0, 0);
 //	blasfeo_print_dmat(n, n, &lq0, 0, 0);
-	return 0;
+//	return 0;
 
 	blasfeo_dtrcp_l(n, &lq0, 0, 0, &lq1, 0, 0);
 	blasfeo_pack_dmat(n, n, B, n, &lq1, 0, n);


### PR DESCRIPTION
Some more work on Skylake target with AVX512 ISA:
- add panel-major routines needed in HPIPM robust mode (e.g. various kinds of tailored LQ factorizations)
- experiment with 24x8 kernels on selected routines
- general bug fixes and performance improvements