### PR TITLE
Typo in HP GEMM functions?

### DIFF
--- a/blasfeo_hp_pm/d_blas3_lib4.c
+++ b/blasfeo_hp_pm/d_blas3_lib4.c
@@ -343,7 +343,7 @@ void blasfeo_hp_dgemm_nn(int m, int n, int k, double alpha, struct blasfeo_dmat 
 	int offsetD;
 	if(ci0>=0)
 		{
-		pC += ci0/ps*ps*sdd;
+		pC += ci0/ps*ps*sdc;
 		offsetC = ci0%ps;
 		}
 	else
@@ -750,7 +750,7 @@ void blasfeo_hp_dgemm_nt(int m, int n, int k, double alpha, struct blasfeo_dmat 
 	int offsetD;
 	if(ci0>=0)
 		{
-		pC += ci0/ps*ps*sdd;
+		pC += ci0/ps*ps*sdc;
 		offsetC = ci0%ps;
 		}
 	else
@@ -1887,7 +1887,7 @@ void blasfeo_hp_dgemm_tt(int m, int n, int k, double alpha, struct blasfeo_dmat 
 	int offsetD;
 	if(ci0>=0)
 		{
-		pC += ci0/ps*ps*sdd;
+		pC += ci0/ps*ps*sdc;
 		offsetC = ci0%ps;
 		}
 	else
@@ -5092,7 +5092,7 @@ void blasfeo_hp_dsyrk_ln(int m, int k, double alpha, struct blasfeo_dmat *sA, in
 	int offsetD;
 	if(ci0>=0)
 		{
-		pC += ci0/ps*ps*sdd;
+		pC += ci0/ps*ps*sdc;
 		offsetC = ci0%ps;
 		}
 	else

--- a/blasfeo_hp_pm/d_blas3_lib8.c
+++ b/blasfeo_hp_pm/d_blas3_lib8.c
@@ -79,7 +79,7 @@ void blasfeo_hp_dgemm_nn(int m, int n, int k, double alpha, struct blasfeo_dmat 
 	int offsetD;
 	if(ci0>=0)
 		{
-		pC += ci0/ps*ps*sdd;
+		pC += ci0/ps*ps*sdc;
 		offsetC = ci0%ps;
 		}
 	else
@@ -302,7 +302,7 @@ void blasfeo_hp_dgemm_nt(int m, int n, int k, double alpha, struct blasfeo_dmat 
 	int offsetD;
 	if(ci0>=0)
 		{
-		pC += ci0/ps*ps*sdd;
+		pC += ci0/ps*ps*sdc;
 		offsetC = ci0%ps;
 		}
 	else
@@ -983,7 +983,7 @@ void blasfeo_hp_dgemm_tt(int m, int n, int k, double alpha, struct blasfeo_dmat 
 	int offsetD;
 	if(ci0>=0)
 		{
-		pC += ci0/ps*ps*sdd;
+		pC += ci0/ps*ps*sdc;
 		offsetC = ci0%ps;
 		}
 	else
@@ -1793,7 +1793,7 @@ void blasfeo_hp_dsyrk_ln(int m, int k, double alpha, struct blasfeo_dmat *sA, in
 	int offsetD;
 	if(ci0>=0)
 		{
-		pC += ci0/ps*ps*sdd;
+		pC += ci0/ps*ps*sdc;
 		offsetC = ci0%ps;
 		}
 	else

--- a/blasfeo_hp_pm/s_blas3_lib4.c
+++ b/blasfeo_hp_pm/s_blas3_lib4.c
@@ -74,7 +74,7 @@ void blasfeo_hp_sgemm_nt(int m, int n, int k, float alpha, struct blasfeo_smat *
 	int offsetD;
 	if(ci0>=0)
 		{
-		pC += ci0/ps*ps*sdd;
+		pC += ci0/ps*ps*sdc;
 		offsetC = ci0%ps;
 		}
 	else
@@ -485,7 +485,7 @@ void blasfeo_hp_sgemm_nn(int m, int n, int k, float alpha, struct blasfeo_smat *
 	int offsetD;
 	if(ci0>=0)
 		{
-		pC += ci0/ps*ps*sdd;
+		pC += ci0/ps*ps*sdc;
 		offsetC = ci0%ps;
 		}
 	else
@@ -1592,7 +1592,7 @@ void blasfeo_hp_ssyrk_ln(int m, int k, float alpha, struct blasfeo_smat *sA, int
 	int offsetD;
 	if(ci0>=0)
 		{
-		pC += ci0/ps*ps*sdd;
+		pC += ci0/ps*ps*sdc;
 		offsetC = ci0%ps;
 		}
 	else


### PR DESCRIPTION
Hello,

I experienced some problems using the GEMM functions. Compile target: High Performance, panel major order, for x64 Intel Haswell. After a little review of the code a little bit I think I found a small typo.

The issue occurs when using for example

void blasfeo_dgemm_nt(int m, int n, int k, double alpha, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dmat *sB, int bi, int bj, double beta, struct blasfeo_dmat *sC, int ci, int cj, struct blasfeo_dmat *sD, int di, int dj);

sC is a matrix of different dimensions than sD, and ci is not zero.

I think for example blasfeo_hp_pm/d_blas3_lib4.c line 753 should be
pC += ci0/ps\*ps\*sdc;
instead of
pC += ci0/ps\*ps\*sdd;

Fixing this solved my issue.

Kind regards,
Lander Vanroye