### PR TITLE
changed CMake variable BUILD_SHARED_LIBS from STRING to BOOL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ set(BLASFEO_EXAMPLES ON CACHE BOOL "Examples enabled")
 # set(BLASFEO_EXAMPLES OFF CACHE BOOL "Examples disabled")
 
 # build shared library
-set(BUILD_SHARED_LIBS OFF CACHE STRING "Build shared libraries")
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries")
 
 # headers installation directory
 set(BLASFEO_HEADERS_INSTALLATION_DIRECTORY "include" CACHE STRING "Headers local installation directory")


### PR DESCRIPTION
Hi Gianluca,

When using CMake, I noticed that variable BUILD_SHARED_LIBS is defined as a STRING. I think it can be changed to a BOOL; this makes it easier to toggle.

Kind regards,
Wilm

