### PR TITLE
Replace AVX instructions in SSE3 kernel by <=SSE3 equivalents.

### DIFF
--- a/kernel/sse3/kernel_align_x64.S
+++ b/kernel/sse3/kernel_align_x64.S
@@ -62,10 +62,8 @@
 	movq	%r12, 16(%rsp); \
 	movq	%r13, 24(%rsp); \
 	movq	%r14, 32(%rsp); \
-	movq	%r15, 40(%rsp); \
-	vzeroupper;
+	movq	%r15, 40(%rsp);
 #define EPILOGUE \
-	vzeroupper; \
 	movq	  (%rsp), %rbx; \
 	movq	 8(%rsp), %rbp; \
 	movq	16(%rsp), %r12; \
@@ -105,19 +103,17 @@
 	movq	%r15, 40(%rsp); \
 	movq	%rdi, 48(%rsp); \
 	movq	%rsi, 56(%rsp); \
-	vmovups	%xmm6, 64(%rsp); \
-	vmovups	%xmm7, 80(%rsp); \
-	vmovups	%xmm8, 96(%rsp); \
-	vmovups	%xmm9, 112(%rsp); \
-	vmovups	%xmm10, 128(%rsp); \
-	vmovups	%xmm11, 144(%rsp); \
-	vmovups	%xmm12, 160(%rsp); \
-	vmovups	%xmm13, 176(%rsp); \
-	vmovups	%xmm14, 192(%rsp); \
-	vmovups	%xmm15, 208(%rsp); \
-	vzeroupper;
+	movups	%xmm6, 64(%rsp); \
+	movups	%xmm7, 80(%rsp); \
+	movups	%xmm8, 96(%rsp); \
+	movups	%xmm9, 112(%rsp); \
+	movups	%xmm10, 128(%rsp); \
+	movups	%xmm11, 144(%rsp); \
+	movups	%xmm12, 160(%rsp); \
+	movups	%xmm13, 176(%rsp); \
+	movups	%xmm14, 192(%rsp); \
+	movups	%xmm15, 208(%rsp);
 #define EPILOGUE \
-	vzeroupper; \
 	movq	  (%rsp), %rbx; \
 	movq	 8(%rsp), %rbp; \
 	movq	16(%rsp), %r12; \
@@ -126,16 +122,16 @@
 	movq	40(%rsp), %r15; \
 	movq	48(%rsp), %rdi; \
 	movq	56(%rsp), %rsi; \
-	vmovups	64(%rsp), %xmm6; \
-	vmovups	80(%rsp), %xmm7; \
-	vmovups	96(%rsp), %xmm8; \
-	vmovups	112(%rsp), %xmm9; \
-	vmovups	128(%rsp), %xmm10; \
-	vmovups	144(%rsp), %xmm11; \
-	vmovups	160(%rsp), %xmm12; \
-	vmovups	176(%rsp), %xmm13; \
-	vmovups	192(%rsp), %xmm14; \
-	vmovups	208(%rsp), %xmm15; \
+	movups	64(%rsp), %xmm6; \
+	movups	80(%rsp), %xmm7; \
+	movups	96(%rsp), %xmm8; \
+	movups	112(%rsp), %xmm9; \
+	movups	128(%rsp), %xmm10; \
+	movups	144(%rsp), %xmm11; \
+	movups	160(%rsp), %xmm12; \
+	movups	176(%rsp), %xmm13; \
+	movups	192(%rsp), %xmm14; \
+	movups	208(%rsp), %xmm15; \
 	addq	$STACKSIZE, %rsp;
 
 #else
@@ -185,7 +181,7 @@ blasfeo_align_2MB:
 	movq	%r10, (%r11)
 
 	EPILOGUE
-	
+
 	ret
 
 #if defined(OS_LINUX)

--- a/kernel/sse3/kernel_dgemv_4_lib4.S
+++ b/kernel/sse3/kernel_dgemv_4_lib4.S
@@ -940,6 +940,7 @@ NAME:
 	mulpd			%xmm0, %xmm12
 	movhpd			%xmm12, %xmm0
 
+	// AVX instructions below are not compiled due to `#if 0` above
 	movapd			32(%r10), %ymm13
 	vblendpd		$ 0x3, %ymm14, %ymm13, %ymm13
 	vpermilpd		$ 0x3, %ymm0, %ymm12
@@ -1012,8 +1013,8 @@ NAME:
 	// beta
 	movddup	0(%r11), %xmm15
 
-	vxorpd		%xmm14, %xmm14, %xmm14 // 0.0
-	vucomisd	%xmm14, %xmm15 // beta==0.0 ?
+	xorpd		%xmm14, %xmm14 // 0.0
+	ucomisd		%xmm14, %xmm15 // beta==0.0 ?
 	je			0f // end
 
 	movupd	0(%r12), %xmm14
@@ -1077,9 +1078,9 @@ NAME:
 	// beta
 	movddup	0(%r11), %xmm15
 
-	vxorpd		%xmm14, %xmm14, %xmm14 // 0.0
-	vucomisd	%xmm14, %xmm15 // beta==0.0 ?
-	je			0f // end
+	xorpd	%xmm14, %xmm14 // 0.0
+	ucomisd	%xmm14, %xmm15 // beta==0.0 ?
+	je		0f // end
 
 	movupd	0(%r12), %xmm14
 	mulpd	%xmm15, %xmm14


### PR DESCRIPTION
Hi Gianluca, we have found some AVX instructions being used in the SS3 kernel that obviously don't work on SSE3-only hardware. These changes should fix the issue.
 