### PR TITLE
Speedup inf norm computation by not using C99 fmax

### DIFF
--- a/auxiliary/d_aux_lib4.c
+++ b/auxiliary/d_aux_lib4.c
@@ -4899,14 +4899,9 @@ void blasfeo_dvecnrm_inf(int m, struct blasfeo_dvec *sx, int xi, double *ptr_nor
 	double tmp;
 	for(ii=0; ii<m; ii++)
 		{
-#ifdef USE_C99_MATH
-		norm = fmax(norm, fabs(x[ii]));
-		is_nan |= x[ii]!=x[ii];
-#else // no c99
 		tmp = fabs(x[ii]);
 		norm = tmp>norm ? tmp : norm;
 		is_nan |= x[ii]!=x[ii];
-#endif
 		}
 #ifdef NAN
 	*ptr_norm = is_nan==0 ? norm : NAN;

--- a/auxiliary/d_aux_lib8.c
+++ b/auxiliary/d_aux_lib8.c
@@ -1448,13 +1448,9 @@ void blasfeo_dvecnrm_inf(int m, struct blasfeo_dvec *sx, int xi, double *ptr_nor
 	double tmp;
 	for(ii=0; ii<m; ii++)
 		{
-#if 0 //def USE_C99_MATH // does not propagate NaN !!!
-		norm = fmax(norm, fabs(x[ii]));
-#else // no c99
 		tmp = fabs(x[ii]);
 //		norm = tmp>norm ? tmp : norm; // does not propagate NaN !!!
 		norm = norm>=tmp ? norm : tmp;
-#endif
 		}
 	*ptr_norm = norm;
 	return;

--- a/auxiliary/s_aux_lib16.c
+++ b/auxiliary/s_aux_lib16.c
@@ -1275,14 +1275,9 @@ void blasfeo_svecnrm_inf(int m, struct blasfeo_svec *sx, int xi, float *ptr_norm
 	float tmp;
 	for(ii=0; ii<m; ii++)
 		{
-#if 0 //def USE_C99_MATH // does not propagate NaN !!!
-		norm = fmax(norm, fabs(x[ii]));
-#else // no c99
 		tmp = fabs(x[ii]);
 //		norm = tmp>norm ? tmp : norm; // does not propagate NaN !!!
 		norm = norm>=tmp ? norm : tmp;
-#endif
-
 		}
 	*ptr_norm = norm;
 	return;

--- a/auxiliary/s_aux_lib4.c
+++ b/auxiliary/s_aux_lib4.c
@@ -3828,13 +3828,9 @@ void blasfeo_svecnrm_inf(int m, struct blasfeo_svec *sx, int xi, float *ptr_norm
 	float tmp;
 	for(ii=0; ii<m; ii++)
 		{
-#if 0 //def USE_C99_MATH // does not propagate NaN !!!
-		norm = fmax(norm, fabs(x[ii]));
-#else // no c99
 		tmp = fabs(x[ii]);
 //		norm = tmp>norm ? tmp : norm; // does not propagate NaN !!!
 		norm = norm>=tmp ? norm : tmp;
-#endif
 		}
 	*ptr_norm = norm;
 	return;

--- a/auxiliary/s_aux_lib8.c
+++ b/auxiliary/s_aux_lib8.c
@@ -3371,13 +3371,9 @@ void blasfeo_svecnrm_inf(int m, struct blasfeo_svec *sx, int xi, float *ptr_norm
 	float tmp;
 	for(ii=0; ii<m; ii++)
 		{
-#if 0 //def USE_C99_MATH // does not propagate NaN !!!
-		norm = fmax(norm, fabs(x[ii]));
-#else // no c99
 		tmp = fabs(x[ii]);
 //		norm = tmp>norm ? tmp : norm; // does not propagate NaN !!!
 		norm = norm>=tmp ? norm : tmp;
-#endif
 		}
 	*ptr_norm = norm;
 	return;


### PR DESCRIPTION
I compared the computation of inf norm for vectors of length 10 on my Intel CPU.
Calling `blasfeo_dvecnrm_inf` 100.000.000 times took 2.341168 seconds before, and 0.781388 seconds after the change.

The idea of using `fmax` was that the compiler could use an optimized routine, such as [`_mm_max_pd`](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=max&techs=SSE_ALL&ig_expand=4338).
However, it seem that `_mm_max_pd` does behave differently than `fmax` and thus other instructions are emitted by the compiler.

In particular, the functions differ as follows:
- `fmax`:  "If one of the two arguments is NaN, the value of the other argument is returned." - https://en.cppreference.com/w/c/numeric/math/fmax
- `maxpd`: "If only one value is a NaN (SNaN or QNaN) for this instruction, the second operand (source operand), either a NaN or a valid floating-point value, is written to the result." - https://www.felixcloutier.com/x86/maxpd

An even more efficient implementation could be achieved using `_mm_max_pd` directly.