### PR TITLE
Adding support for BLAS sgemv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -569,6 +569,7 @@ file(GLOB BLASFEO_HP_CM_SP_SRC
 	${PROJECT_SOURCE_DIR}/blasfeo_hp_cm/sgemm.c
 	${PROJECT_SOURCE_DIR}/blasfeo_hp_cm/strsm.c
 	${PROJECT_SOURCE_DIR}/blasfeo_hp_cm/spotrf.c
+	${PROJECT_SOURCE_DIR}/blasfeo_hp_cm/sgemv.c
 	)
 
 file(GLOB BLASFEO_HP_CM_REF_DP_SRC
@@ -637,6 +638,7 @@ file(GLOB BLAS_SP_SRC
 	${PROJECT_SOURCE_DIR}/blas_api/sgemm_ref.c # XXX
 	${PROJECT_SOURCE_DIR}/blas_api/strsm_ref.c # XXX
 	${PROJECT_SOURCE_DIR}/blas_api/spotrf_ref.c # XXX
+	${PROJECT_SOURCE_DIR}/blas_api/sgemv_ref.c # XXX
 	)
 
 file(GLOB REF_BLAS_DP_SRC

--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,7 @@ BLAS_SP_OBJS += \
 		blas_api/sgemm_ref.o \
 		blas_api/strsm_ref.o \
 		blas_api/spotrf_ref.o \
+		blas_api/sgemv_ref.o \
 
 REF_BLAS_DP_OBJS += \
 		blasfeo_ref/d_blas3_ref_blas.o \

--- a/blas_api/Makefile
+++ b/blas_api/Makefile
@@ -71,6 +71,7 @@ ifeq ($(SP_ROUTINES), 1)
 	OBJS += sgemm_ref.o # XXX
 	OBJS += strsm_ref.o # XXX
 	OBJS += spotrf_ref.o # XXX
+	OBJS += sgemv_ref.o # XXX
 endif # SP
 
 endif # BLAS_API
@@ -108,6 +109,7 @@ dger_ref.o: dger_ref.c xger_ref.c
 sgemm_ref.o: sgemm_ref.c xgemm_ref.c ../blasfeo_hp_cm/sgemm.c
 strsm_ref.o: strsm_ref.c xtrsm_ref.c
 spotrf_ref.o: spotrf_ref.c xpotrf_ref.c
+sgemv_ref.o: sgemv_ref.c xgemv_ref.c
 
 zen5_dgemm_ref.o: zen5_dgemm_ref.c xgemm_ref.c ../blasfeo_hp_cm/zen5_dgemm.c
 zen5_dsyrk_ref.o: zen5_dsyrk_ref.c xsyrk_ref.c ../blasfeo_hp_cm/zen5_dsyrk.c

--- a/blas_api/sgemv_ref.c
+++ b/blas_api/sgemv_ref.c
@@ -1,0 +1,71 @@
+/**************************************************************************************************
+*                                                                                                 *
+* This file is part of BLASFEO.                                                                   *
+*                                                                                                 *
+* BLASFEO -- BLAS for embedded optimization.                                                      *
+* Copyright (C) 2019 by Gianluca Frison.                                                          *
+* Developed at IMTEK (University of Freiburg) under the supervision of Moritz Diehl.              *
+* All rights reserved.                                                                            *
+*                                                                                                 *
+* The 2-Clause BSD License                                                                        *
+*                                                                                                 *
+* Redistribution and use in source and binary forms, with or without                              *
+* modification, are permitted provided that the following conditions are met:                     *
+*                                                                                                 *
+* 1. Redistributions of source code must retain the above copyright notice, this                  *
+*    list of conditions and the following disclaimer.                                             *
+* 2. Redistributions in binary form must reproduce the above copyright notice,                    *
+*    this list of conditions and the following disclaimer in the documentation                    *
+*    and/or other materials provided with the distribution.                                       *
+*                                                                                                 *
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND                 *
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED                   *
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE                          *
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR                 *
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES                  *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;                    *
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND                     *
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT                      *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS                   *
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                                    *
+*                                                                                                 *
+* Author: Gianluca Frison, gianluca.frison (at) imtek.uni-freiburg.de                             *
+*                                                                                                 *
+**************************************************************************************************/
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <blasfeo_common.h>
+#include <blasfeo_s_blasfeo_api.h>
+
+
+
+#if ( defined(BLAS_API) & defined(MF_PANELMAJ) )
+#define GEMV_N blasfeo_cm_sgemv_n
+#define GEMV_T blasfeo_cm_sgemv_t
+#define MAT blasfeo_cm_smat
+#define VEC blasfeo_cm_svec
+#else
+#define GEMV_N blasfeo_sgemv_n
+#define GEMV_T blasfeo_sgemv_t
+#define MAT blasfeo_smat
+#define VEC blasfeo_svec
+#endif
+#define REAL float
+
+
+
+#if defined(FORTRAN_BLAS_API)
+#define GEMV sgemv_
+#else
+#define GEMV blasfeo_blas_sgemv
+#endif
+
+
+
+
+#include "xgemv_ref.c"
+
+
+

--- a/blasfeo_hp_cm/sgemv.c
+++ b/blasfeo_hp_cm/sgemv.c
@@ -1,0 +1,196 @@
+/**************************************************************************************************
+*                                                                                                 *
+* This file is part of BLASFEO.                                                                   *
+*                                                                                                 *
+* BLASFEO -- BLAS for embedded optimization.                                                      *
+* Copyright (C) 2019 by Gianluca Frison.                                                          *
+* Developed at IMTEK (University of Freiburg) under the supervision of Moritz Diehl.              *
+* All rights reserved.                                                                            *
+*                                                                                                 *
+* The 2-Clause BSD License                                                                        *
+*                                                                                                 *
+* Redistribution and use in source and binary forms, with or without                              *
+* modification, are permitted provided that the following conditions are met:                     *
+*                                                                                                 *
+* 1. Redistributions of source code must retain the above copyright notice, this                  *
+*    list of conditions and the following disclaimer.                                             *
+* 2. Redistributions in binary form must reproduce the above copyright notice,                    *
+*    this list of conditions and the following disclaimer in the documentation                    *
+*    and/or other materials provided with the distribution.                                       *
+*                                                                                                 *
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND                 *
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED                   *
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE                          *
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR                 *
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES                  *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;                    *
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND                     *
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT                      *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS                   *
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                                    *
+*                                                                                                 *
+* Author: Gianluca Frison, gianluca.frison (at) imtek.uni-freiburg.de                             *
+*                                                                                                 *
+**************************************************************************************************/
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <blasfeo_target.h>
+#include <blasfeo_block_size.h>
+#include <blasfeo_common.h>
+#include <blasfeo_stdlib.h>
+#include <blasfeo_s_aux.h>
+#include <blasfeo_s_kernel.h>
+#include <blasfeo_memory.h>
+
+#include <blasfeo_timing.h>
+
+
+
+#if ( defined(BLAS_API) & defined(MF_PANELMAJ) )
+#define blasfeo_smat blasfeo_cm_smat
+#define blasfeo_svec blasfeo_cm_svec
+#define blasfeo_hp_sgemv_n blasfeo_hp_cm_sgemv_n
+#define blasfeo_hp_sgemv_t blasfeo_hp_cm_sgemv_t
+#define blasfeo_sgemv_n blasfeo_cm_sgemv_n
+#define blasfeo_sgemv_t blasfeo_cm_sgemv_t
+#endif
+
+
+
+void blasfeo_hp_sgemv_n(int m, int n, float alpha, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, float beta, struct blasfeo_svec *sy, int yi, struct blasfeo_svec *sz, int zi)
+	{
+
+#if defined(PRINT_NAME)
+#ifdef EXT_DEP
+	printf("\nblasfeo_hp_sgemv_n (cm) %d %d %f %p %d %d %p %d %f %p %d %p %d\n", m, n, alpha, sA, ai, aj, sx, xi, beta, sy, yi, sz, zi);
+#endif
+#endif
+
+	if(m<=0 | n<=0 | (alpha==0 & beta==0))
+		return;
+
+	// extract pointer to column-major matrices from structures
+	int lda = sA->m;
+
+	size_t lda_s = lda;
+
+	float *A = sA->pA + ai + aj*lda_s;
+	float *x = sx->pa + xi;
+	float *y = sy->pa + yi;
+	float *z = sz->pa + zi;
+
+	int ii;
+
+	// copy and scale y into z
+	if(beta==0.0)
+		{
+		ii = 0;
+		for(; ii<m-3; ii+=4)
+			{
+			z[ii+0] = 0.0;
+			z[ii+1] = 0.0;
+			z[ii+2] = 0.0;
+			z[ii+3] = 0.0;
+			}
+		for(; ii<m; ii++)
+			{
+			z[ii+0] = 0.0;
+			}
+		}
+	else
+		{
+		ii = 0;
+		for(; ii<m-3; ii+=4)
+			{
+			z[ii+0] = beta*y[ii+0];
+			z[ii+1] = beta*y[ii+1];
+			z[ii+2] = beta*y[ii+2];
+			z[ii+3] = beta*y[ii+3];
+			}
+		for(; ii<m; ii++)
+			{
+			z[ii+0] = beta*y[ii+0];
+			}
+		}
+
+	// main loop
+	ii = 0;
+	for(; ii<n-3; ii+=4)
+		{
+		kernel_sgemv_n_4_libc(m, &alpha, A+ii*lda_s, lda, x+ii, z);
+		}
+	// clean up at the end
+	if(ii<n)
+		{
+		kernel_sgemv_n_4_vs_libc(m, &alpha, A+ii*lda_s, lda, x+ii, z, n-ii);
+		}
+	
+	return;
+	}
+
+
+
+void blasfeo_hp_sgemv_t(int m, int n, float alpha, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, float beta, struct blasfeo_svec *sy, int yi, struct blasfeo_svec *sz, int zi)
+	{
+
+#if defined(PRINT_NAME)
+#ifdef EXT_DEP
+	printf("\nblasfeo_hp_sgemv_t (cm) %d %d %f %p %d %d %p %d %f %p %d %p %d\n", m, n, alpha, sA, ai, aj, sx, xi, beta, sy, yi, sz, zi);
+#endif
+#endif
+
+	if(m<=0 | n<=0 | (alpha==0 & beta==0))
+		return;
+
+	// extract pointer to column-major matrices from structures
+	int lda = sA->m;
+
+	size_t lda_s = lda;
+
+	float *A = sA->pA + ai + aj*lda_s;
+	float *x = sx->pa + xi;
+	float *y = sy->pa + yi;
+	float *z = sz->pa + zi;
+
+	int ii;
+
+	// main loop
+	ii = 0;
+	for(; ii<n-3; ii+=4)
+		{
+		kernel_sgemv_t_4_libc(m, &alpha, A+ii*lda_s, lda, x, &beta, y+ii, z+ii);
+		}
+	// clean up at the end
+	if(ii<n)
+		{
+		kernel_sgemv_t_4_vs_libc(m, &alpha, A+ii*lda_s, lda, x, &beta, y+ii, z+ii, n-ii);
+		}
+	
+	return;
+	}
+
+
+
+#if defined(LA_HIGH_PERFORMANCE)
+
+
+
+void blasfeo_sgemv_n(int m, int n, float alpha, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, float beta, struct blasfeo_svec *sy, int yi, struct blasfeo_svec *sz, int zi)
+
+	{
+	blasfeo_hp_sgemv_n(m, n, alpha, sA, ai, aj, sx, xi, beta, sy, yi, sz, zi);
+	}
+
+
+
+void blasfeo_sgemv_t(int m, int n, float alpha, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, float beta, struct blasfeo_svec *sy, int yi, struct blasfeo_svec *sz, int zi)
+
+	{
+	blasfeo_hp_sgemv_t(m, n, alpha, sA, ai, aj, sx, xi, beta, sy, yi, sz, zi);
+	}
+
+
+
+#endif

--- a/include/blasfeo_s_blasfeo_api.h
+++ b/include/blasfeo_s_blasfeo_api.h
@@ -298,6 +298,9 @@ void blasfeo_cm_strsm_runn(int m, int n, float alpha, struct blasfeo_cm_smat *sA
 void blasfeo_cm_strsm_runu(int m, int n, float alpha, struct blasfeo_cm_smat *sA, int ai, int aj, struct blasfeo_cm_smat *sB, int bi, int bj, struct blasfeo_cm_smat *sD, int di, int dj);
 void blasfeo_cm_strsm_rutn(int m, int n, float alpha, struct blasfeo_cm_smat *sA, int ai, int aj, struct blasfeo_cm_smat *sB, int bi, int bj, struct blasfeo_cm_smat *sD, int di, int dj);
 void blasfeo_cm_strsm_rutu(int m, int n, float alpha, struct blasfeo_cm_smat *sA, int ai, int aj, struct blasfeo_cm_smat *sB, int bi, int bj, struct blasfeo_cm_smat *sD, int di, int dj);
+// BLAS 2
+void blasfeo_cm_sgemv_n(int m, int n, float alpha, struct blasfeo_cm_smat *sA, int ai, int aj, struct blasfeo_cm_svec *sx, int xi, float beta, struct blasfeo_cm_svec *sy, int yi, struct blasfeo_cm_svec *sz, int zi);
+void blasfeo_cm_sgemv_t(int m, int n, float alpha, struct blasfeo_cm_smat *sA, int ai, int aj, struct blasfeo_cm_svec *sx, int xi, float beta, struct blasfeo_cm_svec *sy, int yi, struct blasfeo_cm_svec *sz, int zi);
 // LAPACK
 void blasfeo_cm_spotrf_l(int m, struct blasfeo_cm_smat *sC, int ci, int cj, struct blasfeo_cm_smat *sD, int di, int dj);
 void blasfeo_cm_spotrf_u(int m, struct blasfeo_cm_smat *sC, int ci, int cj, struct blasfeo_cm_smat *sD, int di, int dj);

--- a/include/blasfeo_s_kernel.h
+++ b/include/blasfeo_s_kernel.h
@@ -666,6 +666,12 @@ void kernel_sgemm_nt_4x4_vs_libcccc(int kmax, float *alpha, float *A, int lda, f
 void kernel_sgemm_tt_4x4_libcccc(int kmax, float *alpha, float *A, int lda, float *B, int ldb, float *beta, float *C, int ldc, float *D, int ldd);
 void kernel_sgemm_tt_4x4_vs_libcccc(int kmax, float *alpha, float *A, int lda, float *B, int ldb, float *beta, float *C, int ldc, float *D, int ldd, int m1, int n1);
 
+// level 2 BLAS
+void kernel_sgemv_n_4_libc(int kmax, float *alpha, float *A, int lda, float *x, float *z);
+void kernel_sgemv_n_4_vs_libc(int kmax, float *alpha, float *A, int lda, float *x, float *z, int km);
+void kernel_sgemv_t_4_libc(int kmax, float *alpha, float *A, int lda, float *x, float *beta, float *y, float *z);
+void kernel_sgemv_t_4_vs_libc(int kmax, float *alpha, float *A, int lda, float *x, float *beta, float *y, float *z, int km);
+
 // vector
 void kernel_sdot_11_lib(int n, float *x, float *y, float *res);
 void kernel_saxpy_11_lib(int n, float *alpha, float *x, float *y);

--- a/kernel/generic/Makefile
+++ b/kernel/generic/Makefile
@@ -401,3 +401,4 @@ kernel_dgemv_4_lib4.o: kernel_dgemv_4_lib4.c kernel_dgemv_4_lib.c
 kernel_dsymv_4_lib4.o: kernel_dsymv_4_lib4.c kernel_dsymv_4_lib.c
 kernel_dger_lib4.o: kernel_dger_lib4.c kernel_dger_lib.c
 kernel_sgemm_4x4_lib4.o: kernel_sgemm_4x4_lib4.c kernel_sgemm_4x4_lib.c
+kernel_sgemv_4_lib4.o: kernel_sgemv_4_lib4.c kernel_sgemv_4_lib.c

--- a/kernel/generic/kernel_sgemv_4_lib.c
+++ b/kernel/generic/kernel_sgemv_4_lib.c
@@ -1,0 +1,794 @@
+/**************************************************************************************************
+*                                                                                                 *
+* This file is part of BLASFEO.                                                                   *
+*                                                                                                 *
+* BLASFEO -- BLAS For Embedded Optimization.                                                      *
+* Copyright (C) 2019 by Gianluca Frison.                                                          *
+* Developed at IMTEK (University of Freiburg) under the supervision of Moritz Diehl.              *
+* All rights reserved.                                                                            *
+*                                                                                                 *
+* The 2-Clause BSD License                                                                        *
+*                                                                                                 *
+* Redistribution and use in source and binary forms, with or without                              *
+* modification, are permitted provided that the following conditions are met:                     *
+*                                                                                                 *
+* 1. Redistributions of source code must retain the above copyright notice, this                  *
+*    list of conditions and the following disclaimer.                                             *
+* 2. Redistributions in binary form must reproduce the above copyright notice,                    *
+*    this list of conditions and the following disclaimer in the documentation                    *
+*    and/or other materials provided with the distribution.                                       *
+*                                                                                                 *
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND                 *
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED                   *
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE                          *
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR                 *
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES                  *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;                    *
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND                     *
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT                      *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS                   *
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                                    *
+*                                                                                                 *
+* Author: Gianluca Frison, gianluca.frison (at) imtek.uni-freiburg.de                             *
+*                                                                                                 *
+**************************************************************************************************/
+
+#include <blasfeo_s_kernel.h>
+
+
+
+// XXX copy and scale y_n into z_n outside the kernel !!!!!
+#if 1 //#if defined(TARGET_GENERIC) || defined(TARGET_X86_AMD_BARCELONA) || defined(TARGET_X86_AMD_JAGUAR) || defined(TARGET_X64_INTEL_CORE) || defined(TARGET_X64_AMD_BULLDOZER) || defined(TARGET_ARMV7A_ARM_CORTEX_A15) || defined(TARGET_ARMV7A_ARM_CORTEX_A7) || defined(TARGET_ARMV7A_ARM_CORTEX_A9) //|| defined(TARGET_ARMV8A_ARM_CORTEX_A57) || defined(TARGET_ARMV8A_ARM_CORTEX_A53)
+void kernel_sgemv_n_4_libc(int kmax, float *alpha, float *A, int lda, float *x, float *z)
+	{
+
+	if(kmax<=0) 
+		return;
+	
+	int k;
+
+	float
+		a_00, a_01, a_02, a_03,
+		x_0, x_1, x_2, x_3, y_0;
+	
+	x_0 = alpha[0]*x[0];
+	x_1 = alpha[0]*x[1];
+	x_2 = alpha[0]*x[2];
+	x_3 = alpha[0]*x[3];
+
+	k = 0;
+	for(; k<kmax-3; k+=4)
+		{
+
+		// 0
+		y_0 = z[0]; 
+
+		a_00 = A[0+lda*0];
+		a_01 = A[0+lda*1];
+		a_02 = A[0+lda*2];
+		a_03 = A[0+lda*3];
+		
+		y_0 += a_00 * x_0;
+		y_0 += a_01 * x_1;
+		y_0 += a_02 * x_2;
+		y_0 += a_03 * x_3;
+
+		z[0] = y_0;
+
+
+		// 1
+		y_0 = z[1]; 
+
+		a_00 = A[1+lda*0];
+		a_01 = A[1+lda*1];
+		a_02 = A[1+lda*2];
+		a_03 = A[1+lda*3];
+		
+		y_0 += a_00 * x_0;
+		y_0 += a_01 * x_1;
+		y_0 += a_02 * x_2;
+		y_0 += a_03 * x_3;
+
+		z[1] = y_0;
+
+
+		// 2
+		y_0 = z[2]; 
+
+		a_00 = A[2+lda*0];
+		a_01 = A[2+lda*1];
+		a_02 = A[2+lda*2];
+		a_03 = A[2+lda*3];
+		
+		y_0 += a_00 * x_0;
+		y_0 += a_01 * x_1;
+		y_0 += a_02 * x_2;
+		y_0 += a_03 * x_3;
+
+		z[2] = y_0;
+
+
+		// 3
+		y_0 = z[3]; 
+
+		a_00 = A[3+lda*0];
+		a_01 = A[3+lda*1];
+		a_02 = A[3+lda*2];
+		a_03 = A[3+lda*3];
+		
+		y_0 += a_00 * x_0;
+		y_0 += a_01 * x_1;
+		y_0 += a_02 * x_2;
+		y_0 += a_03 * x_3;
+
+		z[3] = y_0;
+
+
+		A += 4;
+		z += 4;
+
+		}
+	for(; k<kmax; k++)
+		{
+
+		// 0
+		y_0 = z[0]; 
+
+		a_00 = A[0+lda*0];
+		a_01 = A[0+lda*1];
+		a_02 = A[0+lda*2];
+		a_03 = A[0+lda*3];
+		
+		y_0 += a_00 * x_0;
+		y_0 += a_01 * x_1;
+		y_0 += a_02 * x_2;
+		y_0 += a_03 * x_3;
+
+		z[0] = y_0;
+
+		A += 1;
+		z += 1;
+
+		}
+	
+	return;
+
+	}
+#endif
+
+
+
+#if 1 //defined(TARGET_GENERIC) || defined(TARGET_X86_AMD_BARCELONA) || defined(TARGET_X86_AMD_JAGUAR) || defined(TARGET_X64_INTEL_CORE) || defined(TARGET_X64_AMD_BULLDOZER) || defined(TARGET_ARMV7A_ARM_CORTEX_A15) || defined(TARGET_ARMV7A_ARM_CORTEX_A7) || defined(TARGET_ARMV7A_ARM_CORTEX_A9) || defined(TARGET_ARMV8A_ARM_CORTEX_A57) || defined(TARGET_ARMV8A_ARM_CORTEX_A53)
+static void kernel_sgemv_n_3_libc(int kmax, float *alpha, float *A, int lda, float *x, float *z)
+	{
+
+	if(kmax<=0) 
+		return;
+	
+	int k;
+
+	float
+		a_00, a_01, a_02,
+		x_0, x_1, x_2, y_0;
+	
+	x_0 = alpha[0]*x[0];
+	x_1 = alpha[0]*x[1];
+	x_2 = alpha[0]*x[2];
+
+	k = 0;
+	for(; k<kmax-3; k+=4)
+		{
+
+		// 0
+		y_0 = z[0]; 
+
+		a_00 = A[0+lda*0];
+		a_01 = A[0+lda*1];
+		a_02 = A[0+lda*2];
+		
+		y_0 += a_00 * x_0;
+		y_0 += a_01 * x_1;
+		y_0 += a_02 * x_2;
+
+		z[0] = y_0;
+
+
+		// 1
+		y_0 = z[1]; 
+
+		a_00 = A[1+lda*0];
+		a_01 = A[1+lda*1];
+		a_02 = A[1+lda*2];
+		
+		y_0 += a_00 * x_0;
+		y_0 += a_01 * x_1;
+		y_0 += a_02 * x_2;
+
+		z[1] = y_0;
+
+
+		// 2
+		y_0 = z[2]; 
+
+		a_00 = A[2+lda*0];
+		a_01 = A[2+lda*1];
+		a_02 = A[2+lda*2];
+		
+		y_0 += a_00 * x_0;
+		y_0 += a_01 * x_1;
+		y_0 += a_02 * x_2;
+
+		z[2] = y_0;
+
+
+		// 3
+		y_0 = z[3]; 
+
+		a_00 = A[3+lda*0];
+		a_01 = A[3+lda*1];
+		a_02 = A[3+lda*2];
+		
+		y_0 += a_00 * x_0;
+		y_0 += a_01 * x_1;
+		y_0 += a_02 * x_2;
+
+		z[3] = y_0;
+
+
+		A += 4;
+		z += 4;
+
+		}
+	for(; k<kmax; k++)
+		{
+
+		// 0
+		y_0 = z[0]; 
+
+		a_00 = A[0+lda*0];
+		a_01 = A[0+lda*1];
+		a_02 = A[0+lda*2];
+		
+		y_0 += a_00 * x_0;
+		y_0 += a_01 * x_1;
+		y_0 += a_02 * x_2;
+
+		z[0] = y_0;
+
+		A += 1;
+		z += 1;
+
+		}
+	
+	return;
+
+	}
+#endif
+
+
+
+#if 1 //defined(TARGET_GENERIC) || defined(TARGET_X86_AMD_BARCELONA) || defined(TARGET_X86_AMD_JAGUAR) || defined(TARGET_X64_INTEL_CORE) || defined(TARGET_X64_AMD_BULLDOZER) || defined(TARGET_ARMV7A_ARM_CORTEX_A15) || defined(TARGET_ARMV7A_ARM_CORTEX_A7) || defined(TARGET_ARMV7A_ARM_CORTEX_A9) || defined(TARGET_ARMV8A_ARM_CORTEX_A57) || defined(TARGET_ARMV8A_ARM_CORTEX_A53)
+static void kernel_sgemv_n_2_libc(int kmax, float *alpha, float *A, int lda, float *x, float *z)
+	{
+
+	if(kmax<=0) 
+		return;
+	
+	int k;
+
+	float
+		a_00, a_01,
+		x_0, x_1, y_0;
+	
+	x_0 = alpha[0]*x[0];
+	x_1 = alpha[0]*x[1];
+
+	k = 0;
+	for(; k<kmax-3; k+=4)
+		{
+
+		// 0
+		y_0 = z[0]; 
+
+		a_00 = A[0+lda*0];
+		a_01 = A[0+lda*1];
+		
+		y_0 += a_00 * x_0;
+		y_0 += a_01 * x_1;
+
+		z[0] = y_0;
+
+
+		// 1
+		y_0 = z[1]; 
+
+		a_00 = A[1+lda*0];
+		a_01 = A[1+lda*1];
+		
+		y_0 += a_00 * x_0;
+		y_0 += a_01 * x_1;
+
+		z[1] = y_0;
+
+
+		// 2
+		y_0 = z[2]; 
+
+		a_00 = A[2+lda*0];
+		a_01 = A[2+lda*1];
+		
+		y_0 += a_00 * x_0;
+		y_0 += a_01 * x_1;
+
+		z[2] = y_0;
+
+
+		// 3
+		y_0 = z[3]; 
+
+		a_00 = A[3+lda*0];
+		a_01 = A[3+lda*1];
+		
+		y_0 += a_00 * x_0;
+		y_0 += a_01 * x_1;
+
+		z[3] = y_0;
+
+
+		A += 4;
+		z += 4;
+
+		}
+	for(; k<kmax; k++)
+		{
+
+		// 0
+		y_0 = z[0]; 
+
+		a_00 = A[0+lda*0];
+		a_01 = A[0+lda*1];
+		
+		y_0 += a_00 * x_0;
+		y_0 += a_01 * x_1;
+
+		z[0] = y_0;
+
+		A += 1;
+		z += 1;
+
+		}
+	
+	return;
+
+	}
+#endif
+
+
+
+#if 1 //defined(TARGET_GENERIC) || defined(TARGET_X86_AMD_BARCELONA) || defined(TARGET_X86_AMD_JAGUAR) || defined(TARGET_X64_INTEL_CORE) || defined(TARGET_X64_AMD_BULLDOZER) || defined(TARGET_ARMV7A_ARM_CORTEX_A15) || defined(TARGET_ARMV7A_ARM_CORTEX_A7) || defined(TARGET_ARMV7A_ARM_CORTEX_A9) || defined(TARGET_ARMV8A_ARM_CORTEX_A57) || defined(TARGET_ARMV8A_ARM_CORTEX_A53)
+static void kernel_sgemv_n_1_libc(int kmax, float *alpha, float *A, int lda, float *x, float *z)
+	{
+
+	if(kmax<=0) 
+		return;
+	
+	int k;
+
+	float
+		a_00,
+		x_0, y_0;
+	
+	x_0 = alpha[0]*x[0];
+
+	k = 0;
+	for(; k<kmax-3; k+=4)
+		{
+
+		// 0
+		y_0 = z[0]; 
+
+		a_00 = A[0+lda*0];
+		
+		y_0 += a_00 * x_0;
+
+		z[0] = y_0;
+
+
+		// 1
+		y_0 = z[1]; 
+
+		a_00 = A[1+lda*0];
+		
+		y_0 += a_00 * x_0;
+
+		z[1] = y_0;
+
+
+		// 2
+		y_0 = z[2]; 
+
+		a_00 = A[2+lda*0];
+		
+		y_0 += a_00 * x_0;
+
+		z[2] = y_0;
+
+
+		// 3
+		y_0 = z[3]; 
+
+		a_00 = A[3+lda*0];
+		
+		y_0 += a_00 * x_0;
+
+		z[3] = y_0;
+
+
+		A += 4;
+		z += 4;
+
+		}
+	for(; k<kmax; k++)
+		{
+
+		// 0
+		y_0 = z[0]; 
+
+		a_00 = A[0+lda*0];
+		
+		y_0 += a_00 * x_0;
+
+		z[0] = y_0;
+
+		A += 1;
+		z += 1;
+
+		}
+	
+	return;
+
+	}
+#endif
+
+
+
+#if 1 //defined(TARGET_GENERIC) || defined(TARGET_X86_AMD_BARCELONA) || defined(TARGET_X86_AMD_JAGUAR) || defined(TARGET_X64_AMD_BULLDOZER) || defined(TARGET_ARMV7A_ARM_CORTEX_A15) || defined(TARGET_ARMV7A_ARM_CORTEX_A7) || defined(TARGET_ARMV7A_ARM_CORTEX_A9) || defined(TARGET_ARMV8A_ARM_CORTEX_A57) || defined(TARGET_ARMV8A_ARM_CORTEX_A53)
+// XXX copy and scale y_n into z_n outside the kernel !!!!!
+void kernel_sgemv_n_4_vs_libc(int kmax, float *alpha, float *A, int lda, float *x, float *z, int km)
+	{
+
+	if(km<=0)
+		return;
+
+	if(km==1)
+		{
+		kernel_sgemv_n_1_libc(kmax, alpha, A, lda, x, z);
+		}
+	else if(km==2)
+		{
+		kernel_sgemv_n_2_libc(kmax, alpha, A, lda, x, z);
+		}
+	else if(km==3)
+		{
+		kernel_sgemv_n_3_libc(kmax, alpha, A, lda, x, z);
+		}
+	else
+		{
+		kernel_sgemv_n_4_libc(kmax, alpha, A, lda, x, z);
+		}
+
+	return;
+
+	}
+#endif
+
+
+
+#if 1 //#if defined(TARGET_GENERIC) || defined(TARGET_X86_AMD_BARCELONA) || defined(TARGET_X86_AMD_JAGUAR) || defined(TARGET_X64_INTEL_CORE) || defined(TARGET_X64_AMD_BULLDOZER) || defined(TARGET_ARMV7A_ARM_CORTEX_A15) || defined(TARGET_ARMV7A_ARM_CORTEX_A7) || defined(TARGET_ARMV7A_ARM_CORTEX_A9) //|| defined(TARGET_ARMV8A_ARM_CORTEX_A57) || defined(TARGET_ARMV8A_ARM_CORTEX_A53)
+void kernel_sgemv_t_4_libc(int kmax, float *alpha, float *A, int lda, float *x, float *beta, float *y, float *z)
+	{
+
+	int k, kend;
+	
+	float
+		x_0, x_1, x_2, x_3;
+	
+	float yy[4] = {0.0, 0.0, 0.0, 0.0};
+	
+	k=0;
+	for(; k<kmax-3; k+=4)
+		{
+		
+		x_0 = x[0];
+		x_1 = x[1];
+		x_2 = x[2];
+		x_3 = x[3];
+		
+		yy[0] += A[0+lda*0] * x_0;
+		yy[1] += A[0+lda*1] * x_0;
+		yy[2] += A[0+lda*2] * x_0;
+		yy[3] += A[0+lda*3] * x_0;
+
+		yy[0] += A[1+lda*0] * x_1;
+		yy[1] += A[1+lda*1] * x_1;
+		yy[2] += A[1+lda*2] * x_1;
+		yy[3] += A[1+lda*3] * x_1;
+		
+		yy[0] += A[2+lda*0] * x_2;
+		yy[1] += A[2+lda*1] * x_2;
+		yy[2] += A[2+lda*2] * x_2;
+		yy[3] += A[2+lda*3] * x_2;
+
+		yy[0] += A[3+lda*0] * x_3;
+		yy[1] += A[3+lda*1] * x_3;
+		yy[2] += A[3+lda*2] * x_3;
+		yy[3] += A[3+lda*3] * x_3;
+		
+		A += 4;
+		x += 4;
+
+		}
+	for(; k<kmax; k++)
+		{
+		
+		x_0 = x[0];
+	
+		yy[0] += A[0+lda*0] * x_0;
+		yy[1] += A[0+lda*1] * x_0;
+		yy[2] += A[0+lda*2] * x_0;
+		yy[3] += A[0+lda*3] * x_0;
+	
+		A += 1;
+		x += 1;
+		
+		}
+
+	if(beta[0]==0.0)
+		{
+		z[0] = alpha[0]*yy[0];
+		z[1] = alpha[0]*yy[1];
+		z[2] = alpha[0]*yy[2];
+		z[3] = alpha[0]*yy[3];
+		}
+	else
+		{
+		z[0] = alpha[0]*yy[0] + beta[0]*y[0];
+		z[1] = alpha[0]*yy[1] + beta[0]*y[1];
+		z[2] = alpha[0]*yy[2] + beta[0]*y[2];
+		z[3] = alpha[0]*yy[3] + beta[0]*y[3];
+		}
+
+	return;
+
+	}
+#endif
+
+
+
+static void kernel_sgemv_t_3_libc(int kmax, float *alpha, float *A, int lda, float *x, float *beta, float *y, float *z)
+	{
+
+	int k, kend;
+	
+	float
+		x_0, x_1, x_2, x_3;
+	
+	float yy[3] = {0.0, 0.0, 0.0};
+	
+	k=0;
+	for(; k<kmax-3; k+=4)
+		{
+		
+		x_0 = x[0];
+		x_1 = x[1];
+		x_2 = x[2];
+		x_3 = x[3];
+		
+		yy[0] += A[0+lda*0] * x_0;
+		yy[1] += A[0+lda*1] * x_0;
+		yy[2] += A[0+lda*2] * x_0;
+
+		yy[0] += A[1+lda*0] * x_1;
+		yy[1] += A[1+lda*1] * x_1;
+		yy[2] += A[1+lda*2] * x_1;
+		
+		yy[0] += A[2+lda*0] * x_2;
+		yy[1] += A[2+lda*1] * x_2;
+		yy[2] += A[2+lda*2] * x_2;
+
+		yy[0] += A[3+lda*0] * x_3;
+		yy[1] += A[3+lda*1] * x_3;
+		yy[2] += A[3+lda*2] * x_3;
+		
+		A += 4;
+		x += 4;
+
+		}
+	for(; k<kmax; k++)
+		{
+		
+		x_0 = x[0];
+	
+		yy[0] += A[0+lda*0] * x_0;
+		yy[1] += A[0+lda*1] * x_0;
+		yy[2] += A[0+lda*2] * x_0;
+	
+		A += 1;
+		x += 1;
+		
+		}
+
+	if(beta[0]==0.0)
+		{
+		z[0] = alpha[0]*yy[0];
+		z[1] = alpha[0]*yy[1];
+		z[2] = alpha[0]*yy[2];
+		}
+	else
+		{
+		z[0] = alpha[0]*yy[0] + beta[0]*y[0];
+		z[1] = alpha[0]*yy[1] + beta[0]*y[1];
+		z[2] = alpha[0]*yy[2] + beta[0]*y[2];
+		}
+
+	return;
+
+	}
+
+
+
+static void kernel_sgemv_t_2_libc(int kmax, float *alpha, float *A, int lda, float *x, float *beta, float *y, float *z)
+	{
+
+	int k, kend;
+	
+	float
+		x_0, x_1, x_2, x_3;
+	
+	float yy[2] = {0.0, 0.0};
+	
+	k=0;
+	for(; k<kmax-3; k+=4)
+		{
+		
+		x_0 = x[0];
+		x_1 = x[1];
+		x_2 = x[2];
+		x_3 = x[3];
+		
+		yy[0] += A[0+lda*0] * x_0;
+		yy[1] += A[0+lda*1] * x_0;
+
+		yy[0] += A[1+lda*0] * x_1;
+		yy[1] += A[1+lda*1] * x_1;
+		
+		yy[0] += A[2+lda*0] * x_2;
+		yy[1] += A[2+lda*1] * x_2;
+
+		yy[0] += A[3+lda*0] * x_3;
+		yy[1] += A[3+lda*1] * x_3;
+		
+		A += 4;
+		x += 4;
+
+		}
+	for(; k<kmax; k++)
+		{
+		
+		x_0 = x[0];
+	
+		yy[0] += A[0+lda*0] * x_0;
+		yy[1] += A[0+lda*1] * x_0;
+	
+		A += 1;
+		x += 1;
+		
+		}
+
+	if(beta[0]==0.0)
+		{
+		z[0] = alpha[0]*yy[0];
+		z[1] = alpha[0]*yy[1];
+		}
+	else
+		{
+		z[0] = alpha[0]*yy[0] + beta[0]*y[0];
+		z[1] = alpha[0]*yy[1] + beta[0]*y[1];
+		}
+
+	return;
+
+	}
+
+
+
+static void kernel_sgemv_t_1_libc(int kmax, float *alpha, float *A, int lda, float *x, float *beta, float *y, float *z)
+	{
+
+	int k, kend;
+	
+	float
+		x_0, x_1, x_2, x_3;
+	
+	float yy[1] = {0.0};
+	
+	k=0;
+	for(; k<kmax-3; k+=4)
+		{
+		
+		x_0 = x[0];
+		x_1 = x[1];
+		x_2 = x[2];
+		x_3 = x[3];
+		
+		yy[0] += A[0+lda*0] * x_0;
+
+		yy[0] += A[1+lda*0] * x_1;
+		
+		yy[0] += A[2+lda*0] * x_2;
+
+		yy[0] += A[3+lda*0] * x_3;
+		
+		A += 4;
+		x += 4;
+
+		}
+	for(; k<kmax; k++)
+		{
+		
+		x_0 = x[0];
+	
+		yy[0] += A[0+lda*0] * x_0;
+	
+		A += 1;
+		x += 1;
+		
+		}
+
+	if(beta[0]==0.0)
+		{
+		z[0] = alpha[0]*yy[0];
+		}
+	else
+		{
+		z[0] = alpha[0]*yy[0] + beta[0]*y[0];
+		}
+
+	return;
+
+	}
+
+
+
+#if 1 //defined(TARGET_GENERIC) || defined(TARGET_X86_AMD_BARCELONA) || defined(TARGET_X86_AMD_JAGUAR) || defined(TARGET_X64_AMD_BULLDOZER) || defined(TARGET_ARMV7A_ARM_CORTEX_A15) || defined(TARGET_ARMV7A_ARM_CORTEX_A7) || defined(TARGET_ARMV7A_ARM_CORTEX_A9) || defined(TARGET_ARMV8A_ARM_CORTEX_A57) || defined(TARGET_ARMV8A_ARM_CORTEX_A53)
+// XXX copy and scale y_n into z_n outside the kernel !!!!!
+void kernel_sgemv_t_4_vs_libc(int kmax, float *alpha, float *A, int lda, float *x, float *beta, float *y, float *z, int km)
+	{
+
+	if(km<=0)
+		return;
+
+	if(km==1)
+		{
+		kernel_sgemv_t_1_libc(kmax, alpha, A, lda, x, beta, y, z);
+		}
+	else if(km==2)
+		{
+		kernel_sgemv_t_2_libc(kmax, alpha, A, lda, x, beta, y, z);
+		}
+	else if(km==3)
+		{
+		kernel_sgemv_t_3_libc(kmax, alpha, A, lda, x, beta, y, z);
+		}
+	else
+		{
+		kernel_sgemv_t_4_libc(kmax, alpha, A, lda, x, beta, y, z);
+		}
+
+	return;
+
+	}
+#endif
+
+
+

--- a/kernel/generic/kernel_sgemv_4_lib4.c
+++ b/kernel/generic/kernel_sgemv_4_lib4.c
@@ -1610,3 +1610,11 @@ void kernel_strmv_ut_4_lib4(int kmax, float *A, int sda, float *x, float *z)
 #endif
 
 
+
+//#if defined(BLAS_API)
+#if ( defined(BLAS_API) | ( defined(LA_HIGH_PERFORMANCE) & defined(MF_COLMAJ) ) )
+
+#include "kernel_sgemv_4_lib.c"
+
+#endif
+


### PR DESCRIPTION
The code matches the double-precision variant. The only difference is that the target-specific kernels are omitted and only the generic ones remain.