### PR TITLE
Completed AVX512 SP sgemm_nn _vs kernels

### DIFF
--- a/blasfeo_hp_pm/s_blas3_lib16.c
+++ b/blasfeo_hp_pm/s_blas3_lib16.c
@@ -116,7 +116,7 @@ void blasfeo_hp_sgemm_nt(int m, int n, int k, float alpha, struct blasfeo_smat *
 #endif
 		}
 
-	const int bs = 8;
+	const int bs = 16;
 
 	int sda = sA->cn;
 	int sdb = sB->cn;

--- a/kernel/avx512/kernel_sgemm_16x16_lib16.S
+++ b/kernel/avx512/kernel_sgemm_16x16_lib16.S
@@ -6977,21 +6977,21 @@ NAME:
 	vmovaps		192+256(%r12), %zmm25
 	vfmadd231ps	%zmm24, %zmm25, %zmm7
 	vmovaps		0+512(%r12), %zmm25
-	vfmadd231ps	%zmm24, %zmm25, %zmm4
+	vfmadd231ps	%zmm24, %zmm25, %zmm8
 	vmovaps		64+512(%r12), %zmm25
-	vfmadd231ps	%zmm24, %zmm25, %zmm5
+	vfmadd231ps	%zmm24, %zmm25, %zmm9
 	vmovaps		128+512(%r12), %zmm25
-	vfmadd231ps	%zmm24, %zmm25, %zmm6
+	vfmadd231ps	%zmm24, %zmm25, %zmm10
 	vmovaps		192+512(%r12), %zmm25
-	vfmadd231ps	%zmm24, %zmm25, %zmm7
+	vfmadd231ps	%zmm24, %zmm25, %zmm11
 	vmovaps		0+768(%r12), %zmm25
-	vfmadd231ps	%zmm24, %zmm25, %zmm4
+	vfmadd231ps	%zmm24, %zmm25, %zmm12
 	vmovaps		64+768(%r12), %zmm25
-	vfmadd231ps	%zmm24, %zmm25, %zmm5
+	vfmadd231ps	%zmm24, %zmm25, %zmm13
 	vmovaps		128+768(%r12), %zmm25
-	vfmadd231ps	%zmm24, %zmm25, %zmm6
+	vfmadd231ps	%zmm24, %zmm25, %zmm14
 	vmovaps		192+768(%r12), %zmm25
-	vfmadd231ps	%zmm24, %zmm25, %zmm7
+	vfmadd231ps	%zmm24, %zmm25, %zmm15
 
 0:
 

--- a/kernel/avx512/kernel_sgemm_16x16_lib16.S
+++ b/kernel/avx512/kernel_sgemm_16x16_lib16.S
@@ -5890,6 +5890,3898 @@ NAME:
 
 
 #if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_GEMM_NN_VX2_LIB16
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_gemm_nn_vx2_lib16)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+
+	// preload
+	vmovaps 		0(%r11), %zmm25 {%k1}{z} // A
+
+	cmpl	$ 16, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	-1*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	15*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	addq	%r13, %r12
+
+	cmpl	$ 16, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean16-up
+
+	cmpl	$ 15, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	-1*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	//vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	15*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	addq	%r13, %r12
+
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovaps			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+
+	addq	$ 64, %r11
+	addq	$ 4, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_gemm_nn_vx2_lib16)
+#endif
+
+
+
+
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_GEMM_NN_VX3_LIB16
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_gemm_nn_vx3_lib16)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+
+	// preload
+	vmovaps 		0(%r11), %zmm25 {%k1}{z} // A
+
+	cmpl	$ 16, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	-1*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	-1*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	15*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	15*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	addq	%r13, %r12
+
+	cmpl	$ 16, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean16-up
+
+	cmpl	$ 15, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	-1*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	-1*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	//vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	15*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	15*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	addq	%r13, %r12
+
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovaps			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+
+	addq	$ 64, %r11
+	addq	$ 4, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_gemm_nn_vx3_lib16)
+#endif
+
+
+
+
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_GEMM_NN_VX4_LIB16
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_gemm_nn_vx4_lib16)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+
+	// preload
+	vmovaps 		0(%r11), %zmm25 {%k1}{z} // A
+
+	cmpl	$ 16, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	-1*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	-1*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	-1*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	15*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	15*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	15*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	addq	%r13, %r12
+
+	cmpl	$ 16, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean16-up
+
+	cmpl	$ 15, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	-1*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	-1*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	-1*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	//vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	15*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	15*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	15*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	addq	%r13, %r12
+
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovaps			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+
+	addq	$ 64, %r11
+	addq	$ 4, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_gemm_nn_vx4_lib16)
+#endif
+
+
+
+
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_GEMM_NN_VX5_LIB16
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_gemm_nn_vx5_lib16)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+
+	// preload
+	vmovaps 		0(%r11), %zmm25 {%k1}{z} // A
+
+	cmpl	$ 16, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	-1*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	-1*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	-1*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	-1*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	15*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	15*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	15*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	15*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	addq	%r13, %r12
+
+	cmpl	$ 16, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean16-up
+
+	cmpl	$ 15, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	-1*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	-1*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	-1*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	-1*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	//vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	15*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	15*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	15*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	15*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	addq	%r13, %r12
+
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovaps			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+
+	addq	$ 64, %r11
+	addq	$ 4, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_gemm_nn_vx5_lib16)
+#endif
+
+
+
+
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_GEMM_NN_VX6_LIB16
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_gemm_nn_vx6_lib16)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+
+	// preload
+	vmovaps 		0(%r11), %zmm25 {%k1}{z} // A
+
+	cmpl	$ 16, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	-1*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	-1*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	-1*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	-1*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	-1*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	15*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	15*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	15*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	15*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	15*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	addq	%r13, %r12
+
+	cmpl	$ 16, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean16-up
+
+	cmpl	$ 15, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	-1*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	-1*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	-1*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	-1*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	-1*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	//vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	15*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	15*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	15*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	15*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	15*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	addq	%r13, %r12
+
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovaps			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+
+	addq	$ 64, %r11
+	addq	$ 4, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_gemm_nn_vx6_lib16)
+#endif
+
+
+
+
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_GEMM_NN_VX7_LIB16
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_gemm_nn_vx7_lib16)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+
+	// preload
+	vmovaps 		0(%r11), %zmm25 {%k1}{z} // A
+
+	cmpl	$ 16, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	-1*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	-1*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	-1*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	-1*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	-1*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	-1*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	15*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	15*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	15*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	15*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	15*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	15*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	addq	%r13, %r12
+
+	cmpl	$ 16, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean16-up
+
+	cmpl	$ 15, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	-1*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	-1*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	-1*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	-1*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	-1*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	-1*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	//vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	15*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	15*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	15*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	15*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	15*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	15*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	addq	%r13, %r12
+
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovaps			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+
+	addq	$ 64, %r11
+	addq	$ 4, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_gemm_nn_vx7_lib16)
+#endif
+
+
+
+
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_GEMM_NN_VX8_LIB16
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_gemm_nn_vx8_lib16)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+
+	// preload
+	vmovaps 		0(%r11), %zmm25 {%k1}{z} // A
+
+	cmpl	$ 16, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	-1*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	-1*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	-1*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	-1*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	-1*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	-1*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	-1*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	15*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	15*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	15*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	15*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	15*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	15*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	15*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	addq	%r13, %r12
+
+	cmpl	$ 16, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean16-up
+
+	cmpl	$ 15, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	-1*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	-1*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	-1*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	-1*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	-1*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	-1*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	-1*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	//vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	15*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	15*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	15*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	15*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	15*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	15*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	15*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	addq	%r13, %r12
+
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovaps			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+
+	addq	$ 64, %r11
+	addq	$ 4, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_gemm_nn_vx8_lib16)
+#endif
+
+
+
+
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_GEMM_NN_VX9_LIB16
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_gemm_nn_vx9_lib16)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+
+	// preload
+	vmovaps 		0(%r11), %zmm25 {%k1}{z} // A
+
+	cmpl	$ 16, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	-1*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	-1*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	-1*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	-1*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	-1*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	-1*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	-1*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	vbroadcastss	-1*4+8*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm8
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	15*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	15*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	15*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	15*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	15*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	15*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	15*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	vbroadcastss	15*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm8
+	addq	%r13, %r12
+
+	cmpl	$ 16, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean16-up
+
+	cmpl	$ 15, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	-1*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	-1*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	-1*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	-1*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	-1*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	-1*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	-1*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	vbroadcastss	-1*4+8*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm8
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	//vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	15*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	15*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	15*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	15*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	15*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	15*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	15*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	vbroadcastss	15*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm8
+	addq	%r13, %r12
+
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovaps			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+
+	addq	$ 64, %r11
+	addq	$ 4, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_gemm_nn_vx9_lib16)
+#endif
+
+
+
+
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_GEMM_NN_VX10_LIB16
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_gemm_nn_vx10_lib16)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+
+	// preload
+	vmovaps 		0(%r11), %zmm25 {%k1}{z} // A
+
+	cmpl	$ 16, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	-1*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	-1*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	-1*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	-1*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	-1*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	-1*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	-1*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	vbroadcastss	-1*4+8*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm8
+	vbroadcastss	-1*4+9*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm9
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	15*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	15*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	15*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	15*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	15*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	15*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	15*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	vbroadcastss	15*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm8
+	vbroadcastss	15*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm9
+	addq	%r13, %r12
+
+	cmpl	$ 16, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean16-up
+
+	cmpl	$ 15, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	-1*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	-1*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	-1*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	-1*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	-1*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	-1*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	-1*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	vbroadcastss	-1*4+8*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm8
+	vbroadcastss	-1*4+9*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm9
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	//vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	15*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	15*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	15*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	15*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	15*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	15*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	15*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	vbroadcastss	15*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm8
+	vbroadcastss	15*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm9
+	addq	%r13, %r12
+
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovaps			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+
+	addq	$ 64, %r11
+	addq	$ 4, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_gemm_nn_vx10_lib16)
+#endif
+
+
+
+
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_GEMM_NN_VX11_LIB16
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_gemm_nn_vx11_lib16)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+
+	// preload
+	vmovaps 		0(%r11), %zmm25 {%k1}{z} // A
+
+	cmpl	$ 16, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+	vbroadcastss	0*4+10*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm10
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	-1*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	-1*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	-1*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	-1*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	-1*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	-1*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	-1*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	vbroadcastss	-1*4+8*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm8
+	vbroadcastss	-1*4+9*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm9
+	vbroadcastss	-1*4+10*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm10
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+	vbroadcastss	0*4+10*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm10
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	15*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	15*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	15*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	15*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	15*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	15*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	15*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	vbroadcastss	15*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm8
+	vbroadcastss	15*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm9
+	vbroadcastss	15*4+10*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm10
+	addq	%r13, %r12
+
+	cmpl	$ 16, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean16-up
+
+	cmpl	$ 15, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+	vbroadcastss	0*4+10*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm10
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	-1*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	-1*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	-1*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	-1*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	-1*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	-1*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	-1*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	vbroadcastss	-1*4+8*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm8
+	vbroadcastss	-1*4+9*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm9
+	vbroadcastss	-1*4+10*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm10
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+	vbroadcastss	0*4+10*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm10
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	//vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	15*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	15*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	15*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	15*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	15*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	15*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	15*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	vbroadcastss	15*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm8
+	vbroadcastss	15*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm9
+	vbroadcastss	15*4+10*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm10
+	addq	%r13, %r12
+
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovaps			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+	vbroadcastss	0*4+10*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm10
+
+	addq	$ 64, %r11
+	addq	$ 4, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_gemm_nn_vx11_lib16)
+#endif
+
+
+
+
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_GEMM_NN_VX12_LIB16
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_gemm_nn_vx12_lib16)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+
+	// preload
+	vmovaps 		0(%r11), %zmm25 {%k1}{z} // A
+
+	cmpl	$ 16, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+	vbroadcastss	0*4+10*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm10
+	vbroadcastss	0*4+11*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm11
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	-1*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	-1*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	-1*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	-1*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	-1*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	-1*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	-1*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	vbroadcastss	-1*4+8*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm8
+	vbroadcastss	-1*4+9*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm9
+	vbroadcastss	-1*4+10*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm10
+	vbroadcastss	-1*4+11*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm11
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+	vbroadcastss	0*4+10*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm10
+	vbroadcastss	0*4+11*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm11
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	15*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	15*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	15*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	15*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	15*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	15*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	15*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	vbroadcastss	15*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm8
+	vbroadcastss	15*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm9
+	vbroadcastss	15*4+10*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm10
+	vbroadcastss	15*4+11*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm11
+	addq	%r13, %r12
+
+	cmpl	$ 16, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean16-up
+
+	cmpl	$ 15, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+	vbroadcastss	0*4+10*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm10
+	vbroadcastss	0*4+11*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm11
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	-1*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	-1*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	-1*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	-1*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	-1*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	-1*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	-1*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	vbroadcastss	-1*4+8*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm8
+	vbroadcastss	-1*4+9*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm9
+	vbroadcastss	-1*4+10*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm10
+	vbroadcastss	-1*4+11*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm11
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+	vbroadcastss	0*4+10*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm10
+	vbroadcastss	0*4+11*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm11
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	//vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	15*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	15*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	15*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	15*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	15*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	15*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	15*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	vbroadcastss	15*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm8
+	vbroadcastss	15*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm9
+	vbroadcastss	15*4+10*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm10
+	vbroadcastss	15*4+11*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm11
+	addq	%r13, %r12
+
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovaps			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+	vbroadcastss	0*4+10*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm10
+	vbroadcastss	0*4+11*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm11
+
+	addq	$ 64, %r11
+	addq	$ 4, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_gemm_nn_vx12_lib16)
+#endif
+
+
+
+
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_GEMM_NN_VX13_LIB16
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_gemm_nn_vx13_lib16)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+
+	// preload
+	vmovaps 		0(%r11), %zmm25 {%k1}{z} // A
+
+	cmpl	$ 16, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+	vbroadcastss	0*4+10*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm10
+	vbroadcastss	0*4+11*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm11
+	vbroadcastss	0*4+12*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm12
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	-1*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	-1*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	-1*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	-1*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	-1*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	-1*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	-1*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	vbroadcastss	-1*4+8*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm8
+	vbroadcastss	-1*4+9*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm9
+	vbroadcastss	-1*4+10*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm10
+	vbroadcastss	-1*4+11*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm11
+	vbroadcastss	-1*4+12*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm12
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+	vbroadcastss	0*4+10*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm10
+	vbroadcastss	0*4+11*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm11
+	vbroadcastss	0*4+12*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm12
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	15*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	15*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	15*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	15*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	15*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	15*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	15*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	vbroadcastss	15*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm8
+	vbroadcastss	15*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm9
+	vbroadcastss	15*4+10*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm10
+	vbroadcastss	15*4+11*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm11
+	vbroadcastss	15*4+12*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm12
+	addq	%r13, %r12
+
+	cmpl	$ 16, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean16-up
+
+	cmpl	$ 15, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+	vbroadcastss	0*4+10*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm10
+	vbroadcastss	0*4+11*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm11
+	vbroadcastss	0*4+12*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm12
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	-1*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	-1*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	-1*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	-1*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	-1*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	-1*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	-1*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	vbroadcastss	-1*4+8*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm8
+	vbroadcastss	-1*4+9*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm9
+	vbroadcastss	-1*4+10*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm10
+	vbroadcastss	-1*4+11*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm11
+	vbroadcastss	-1*4+12*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm12
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+	vbroadcastss	0*4+10*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm10
+	vbroadcastss	0*4+11*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm11
+	vbroadcastss	0*4+12*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm12
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	//vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	15*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	15*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	15*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	15*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	15*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	15*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	15*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	vbroadcastss	15*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm8
+	vbroadcastss	15*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm9
+	vbroadcastss	15*4+10*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm10
+	vbroadcastss	15*4+11*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm11
+	vbroadcastss	15*4+12*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm12
+	addq	%r13, %r12
+
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovaps			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+	vbroadcastss	0*4+10*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm10
+	vbroadcastss	0*4+11*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm11
+	vbroadcastss	0*4+12*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm12
+
+	addq	$ 64, %r11
+	addq	$ 4, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_gemm_nn_vx13_lib16)
+#endif
+
+
+
+
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_GEMM_NN_VX14_LIB16
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_gemm_nn_vx14_lib16)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+
+	// preload
+	vmovaps 		0(%r11), %zmm25 {%k1}{z} // A
+
+	cmpl	$ 16, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+	vbroadcastss	0*4+10*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm10
+	vbroadcastss	0*4+11*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm11
+	vbroadcastss	0*4+12*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm12
+	vbroadcastss	0*4+13*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm13
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	-1*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	-1*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	-1*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	-1*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	-1*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	-1*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	-1*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	vbroadcastss	-1*4+8*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm8
+	vbroadcastss	-1*4+9*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm9
+	vbroadcastss	-1*4+10*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm10
+	vbroadcastss	-1*4+11*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm11
+	vbroadcastss	-1*4+12*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm12
+	vbroadcastss	-1*4+13*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm13
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+	vbroadcastss	0*4+10*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm10
+	vbroadcastss	0*4+11*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm11
+	vbroadcastss	0*4+12*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm12
+	vbroadcastss	0*4+13*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm13
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	15*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	15*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	15*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	15*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	15*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	15*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	15*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	vbroadcastss	15*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm8
+	vbroadcastss	15*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm9
+	vbroadcastss	15*4+10*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm10
+	vbroadcastss	15*4+11*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm11
+	vbroadcastss	15*4+12*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm12
+	vbroadcastss	15*4+13*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm13
+	addq	%r13, %r12
+
+	cmpl	$ 16, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean16-up
+
+	cmpl	$ 15, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+	vbroadcastss	0*4+10*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm10
+	vbroadcastss	0*4+11*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm11
+	vbroadcastss	0*4+12*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm12
+	vbroadcastss	0*4+13*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm13
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	-1*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	-1*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	-1*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	-1*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	-1*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	-1*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	-1*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	vbroadcastss	-1*4+8*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm8
+	vbroadcastss	-1*4+9*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm9
+	vbroadcastss	-1*4+10*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm10
+	vbroadcastss	-1*4+11*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm11
+	vbroadcastss	-1*4+12*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm12
+	vbroadcastss	-1*4+13*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm13
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+	vbroadcastss	0*4+10*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm10
+	vbroadcastss	0*4+11*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm11
+	vbroadcastss	0*4+12*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm12
+	vbroadcastss	0*4+13*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm13
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	//vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	15*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	15*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	15*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	15*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	15*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	15*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	15*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	vbroadcastss	15*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm8
+	vbroadcastss	15*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm9
+	vbroadcastss	15*4+10*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm10
+	vbroadcastss	15*4+11*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm11
+	vbroadcastss	15*4+12*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm12
+	vbroadcastss	15*4+13*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm13
+	addq	%r13, %r12
+
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovaps			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+	vbroadcastss	0*4+10*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm10
+	vbroadcastss	0*4+11*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm11
+	vbroadcastss	0*4+12*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm12
+	vbroadcastss	0*4+13*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm13
+
+	addq	$ 64, %r11
+	addq	$ 4, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_gemm_nn_vx14_lib16)
+#endif
+
+
+
+
+
+#if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_GEMM_NN_VX15_LIB16
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_gemm_nn_vx15_lib16)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+
+	// preload
+	vmovaps 		0(%r11), %zmm25 {%k1}{z} // A
+
+	cmpl	$ 16, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+	vbroadcastss	0*4+10*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm10
+	vbroadcastss	0*4+11*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm11
+	vbroadcastss	0*4+12*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm12
+	vbroadcastss	0*4+13*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm13
+	vbroadcastss	0*4+14*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm14
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	-1*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	-1*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	-1*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	-1*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	-1*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	-1*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	-1*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	vbroadcastss	-1*4+8*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm8
+	vbroadcastss	-1*4+9*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm9
+	vbroadcastss	-1*4+10*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm10
+	vbroadcastss	-1*4+11*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm11
+	vbroadcastss	-1*4+12*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm12
+	vbroadcastss	-1*4+13*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm13
+	vbroadcastss	-1*4+14*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm14
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+	vbroadcastss	0*4+10*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm10
+	vbroadcastss	0*4+11*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm11
+	vbroadcastss	0*4+12*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm12
+	vbroadcastss	0*4+13*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm13
+	vbroadcastss	0*4+14*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm14
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	15*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	15*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	15*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	15*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	15*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	15*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	15*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	vbroadcastss	15*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm8
+	vbroadcastss	15*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm9
+	vbroadcastss	15*4+10*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm10
+	vbroadcastss	15*4+11*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm11
+	vbroadcastss	15*4+12*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm12
+	vbroadcastss	15*4+13*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm13
+	vbroadcastss	15*4+14*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm14
+	addq	%r13, %r12
+
+	cmpl	$ 16, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean16-up
+
+	cmpl	$ 15, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+	vbroadcastss	0*4+10*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm10
+	vbroadcastss	0*4+11*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm11
+	vbroadcastss	0*4+12*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm12
+	vbroadcastss	0*4+13*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm13
+	vbroadcastss	0*4+14*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm14
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	-1*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	-1*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	-1*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	-1*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	-1*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	-1*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	-1*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	vbroadcastss	-1*4+8*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm8
+	vbroadcastss	-1*4+9*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm9
+	vbroadcastss	-1*4+10*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm10
+	vbroadcastss	-1*4+11*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm11
+	vbroadcastss	-1*4+12*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm12
+	vbroadcastss	-1*4+13*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm13
+	vbroadcastss	-1*4+14*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm14
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+	vbroadcastss	0*4+1*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+	vbroadcastss	0*4+10*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm10
+	vbroadcastss	0*4+11*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm11
+	vbroadcastss	0*4+12*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm12
+	vbroadcastss	0*4+13*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm13
+	vbroadcastss	0*4+14*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm14
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	//vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	15*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm1
+	vbroadcastss	15*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm2
+	vbroadcastss	15*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm3
+	vbroadcastss	15*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm4
+	vbroadcastss	15*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm5
+	vbroadcastss	15*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm6
+	vbroadcastss	15*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm7
+	vbroadcastss	15*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm8
+	vbroadcastss	15*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm9
+	vbroadcastss	15*4+10*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm10
+	vbroadcastss	15*4+11*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm11
+	vbroadcastss	15*4+12*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm12
+	vbroadcastss	15*4+13*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm13
+	vbroadcastss	15*4+14*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm14
+	addq	%r13, %r12
+
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovaps			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vbroadcastss	0*4+1*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm1
+	vbroadcastss	0*4+2*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm2
+	vbroadcastss	0*4+3*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm3
+	vbroadcastss	0*4+4*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm4
+	vbroadcastss	0*4+5*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm5
+	vbroadcastss	0*4+6*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm6
+	vbroadcastss	0*4+7*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm7
+	vbroadcastss	0*4+8*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm8
+	vbroadcastss	0*4+9*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm9
+	vbroadcastss	0*4+10*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm10
+	vbroadcastss	0*4+11*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm11
+	vbroadcastss	0*4+12*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm12
+	vbroadcastss	0*4+13*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm13
+	vbroadcastss	0*4+14*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm14
+
+	addq	$ 64, %r11
+	addq	$ 4, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_gemm_nn_vx15_lib16)
+#endif
+
+
+
+
+
+#if MACRO_LEVEL>=2
 	.macro INNER_KERNEL_GEMM_NN_VX16_LIB16
 #else
 	.p2align 4,,15
@@ -6362,9 +10254,9 @@ NAME:
 	jg		101f
 
 #if MACRO_LEVEL>=2
-	//INNER_KERNEL_GEMM_NN_VX2_LIB16
+	INNER_KERNEL_GEMM_NN_VX2_LIB16
 #else
-	//CALL(inner_kernel_gemm_nn_vx2_lib16)
+	CALL(inner_kernel_gemm_nn_vx2_lib16)
 #endif
 	
 	jmp		115f
@@ -6375,9 +10267,9 @@ NAME:
 	jg		102f
 
 #if MACRO_LEVEL>=2
-	//INNER_KERNEL_GEMM_NN_VX3_LIB16
+	INNER_KERNEL_GEMM_NN_VX3_LIB16
 #else
-	//CALL(inner_kernel_gemm_nn_vx3_lib16)
+	CALL(inner_kernel_gemm_nn_vx3_lib16)
 #endif
 	
 	jmp		115f
@@ -6388,9 +10280,9 @@ NAME:
 	jg		103f
 
 #if MACRO_LEVEL>=2
-	//INNER_KERNEL_GEMM_NN_VX4_LIB16
+	INNER_KERNEL_GEMM_NN_VX4_LIB16
 #else
-	//CALL(inner_kernel_gemm_nn_vx4_lib16)
+	CALL(inner_kernel_gemm_nn_vx4_lib16)
 #endif
 	
 	jmp		115f
@@ -6401,9 +10293,9 @@ NAME:
 	jg		104f
 
 #if MACRO_LEVEL>=2
-	//INNER_KERNEL_GEMM_NN_VX5_LIB16
+	INNER_KERNEL_GEMM_NN_VX5_LIB16
 #else
-	//CALL(inner_kernel_gemm_nn_vx5_lib16)
+	CALL(inner_kernel_gemm_nn_vx5_lib16)
 #endif
 	
 	jmp		115f
@@ -6414,9 +10306,9 @@ NAME:
 	jg		105f
 
 #if MACRO_LEVEL>=2
-	//INNER_KERNEL_GEMM_NN_VX6_LIB16
+	INNER_KERNEL_GEMM_NN_VX6_LIB16
 #else
-	//CALL(inner_kernel_gemm_nn_vx6_lib16)
+	CALL(inner_kernel_gemm_nn_vx6_lib16)
 #endif
 	
 	jmp		115f
@@ -6427,9 +10319,9 @@ NAME:
 	jg		106f
 
 #if MACRO_LEVEL>=2
-	//INNER_KERNEL_GEMM_NN_VX7_LIB16
+	INNER_KERNEL_GEMM_NN_VX7_LIB16
 #else
-	//CALL(inner_kernel_gemm_nn_vx7_lib16)
+	CALL(inner_kernel_gemm_nn_vx7_lib16)
 #endif
 	
 	jmp		115f
@@ -6440,9 +10332,9 @@ NAME:
 	jg		107f
 
 #if MACRO_LEVEL>=2
-	//INNER_KERNEL_GEMM_NN_VX8_LIB16
+	INNER_KERNEL_GEMM_NN_VX8_LIB16
 #else
-	//CALL(inner_kernel_gemm_nn_vx8_lib16)
+	CALL(inner_kernel_gemm_nn_vx8_lib16)
 #endif
 	
 	jmp		115f
@@ -6453,9 +10345,9 @@ NAME:
 	jg		108f
 
 #if MACRO_LEVEL>=2
-	//INNER_KERNEL_GEMM_NN_VX9_LIB16
+	INNER_KERNEL_GEMM_NN_VX9_LIB16
 #else
-	//CALL(inner_kernel_gemm_nn_vx9_lib16)
+	CALL(inner_kernel_gemm_nn_vx9_lib16)
 #endif
 	
 	jmp		115f
@@ -6466,9 +10358,9 @@ NAME:
 	jg		109f
 
 #if MACRO_LEVEL>=2
-	//INNER_KERNEL_GEMM_NN_VX10_LIB16
+	INNER_KERNEL_GEMM_NN_VX10_LIB16
 #else
-	//CALL(inner_kernel_gemm_nn_vx10_lib16)
+	CALL(inner_kernel_gemm_nn_vx10_lib16)
 #endif
 	
 	jmp		115f
@@ -6479,9 +10371,9 @@ NAME:
 	jg		110f
 
 #if MACRO_LEVEL>=2
-	//INNER_KERNEL_GEMM_NN_VX11_LIB16
+	INNER_KERNEL_GEMM_NN_VX11_LIB16
 #else
-	//CALL(inner_kernel_gemm_nn_vx11_lib16)
+	CALL(inner_kernel_gemm_nn_vx11_lib16)
 #endif
 	
 	jmp		115f
@@ -6492,9 +10384,9 @@ NAME:
 	jg		111f
 
 #if MACRO_LEVEL>=2
-	//INNER_KERNEL_GEMM_NN_VX12_LIB16
+	INNER_KERNEL_GEMM_NN_VX12_LIB16
 #else
-	//CALL(inner_kernel_gemm_nn_vx12_lib16)
+	CALL(inner_kernel_gemm_nn_vx12_lib16)
 #endif
 	
 	jmp		115f
@@ -6505,9 +10397,9 @@ NAME:
 	jg		112f
 
 #if MACRO_LEVEL>=2
-	//INNER_KERNEL_GEMM_NN_VX13_LIB16
+	INNER_KERNEL_GEMM_NN_VX13_LIB16
 #else
-	//CALL(inner_kernel_gemm_nn_vx13_lib16)
+	CALL(inner_kernel_gemm_nn_vx13_lib16)
 #endif
 	
 	jmp		115f
@@ -6518,9 +10410,9 @@ NAME:
 	jg		113f
 
 #if MACRO_LEVEL>=2
-	//INNER_KERNEL_GEMM_NN_VX14_LIB16
+	INNER_KERNEL_GEMM_NN_VX14_LIB16
 #else
-	//CALL(inner_kernel_gemm_nn_vx14_lib16)
+	CALL(inner_kernel_gemm_nn_vx14_lib16)
 #endif
 	
 	jmp		115f
@@ -6531,9 +10423,9 @@ NAME:
 	jg		114f
 
 #if MACRO_LEVEL>=2
-	//INNER_KERNEL_GEMM_NN_VX15_LIB16
+	INNER_KERNEL_GEMM_NN_VX15_LIB16
 #else
-	//CALL(inner_kernel_gemm_nn_vx15_lib16)
+	CALL(inner_kernel_gemm_nn_vx15_lib16)
 #endif
 	
 	jmp		115f

--- a/kernel/avx512/kernel_sgemm_16x16_lib16.S
+++ b/kernel/avx512/kernel_sgemm_16x16_lib16.S
@@ -5747,6 +5747,149 @@ NAME:
 // zmm15 <- []
 
 #if MACRO_LEVEL>=2
+	.macro INNER_KERNEL_GEMM_NN_VX1_LIB16
+#else
+	.p2align 4,,15
+	FUN_START(inner_kernel_gemm_nn_vx1_lib16)
+#endif
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// prefetch
+
+
+	// preload
+	vmovaps 		0(%r11), %zmm25 {%k1}{z} // A
+
+	cmpl	$ 16, %r10d
+	jle		0f // consider clean-up loop
+
+	// main loop
+	.p2align 3
+1: // main loop
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	addq	%r13, %r12
+
+	cmpl	$ 16, %r10d
+	jg		1b // main loop
+
+
+0: // consider clean16-up
+
+	cmpl	$ 15, %r10d
+	jle		4f // clean1
+
+	// unroll 0
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			64(%r11), %zmm26 {%k1}{z} // A
+
+	subl	$ 16, %r10d
+
+	// unroll 1 - 14
+	movq			$ 0, %r14
+
+5:
+
+	addq	$ 128, %r11
+	addq	$ 1, %r14
+
+	// unroll 1
+	vbroadcastss	-1*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+
+	// unroll 2
+	vbroadcastss	0*4+0*64(%r12, %r14, 8), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+	vmovaps			1*64(%r11), %zmm26 {%k1}{z} // A
+
+	cmpq	$ 7, %r14
+	jl		5b // main loop
+
+	addq	$ 128, %r11
+
+	// unroll 15
+	vbroadcastss	15*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm26, %zmm24, %zmm0
+	//vmovaps			0*64(%r11), %zmm25 {%k1}{z} // A
+	addq	%r13, %r12
+
+
+	jmp		2f // return
+
+
+4: // consider clean1-up loop
+
+	cmpl	$ 0, %r10d
+	jle		2f // return
+
+	// clean-up loop
+3: // clean up loop
+
+	// unroll 0
+	vmovaps			0(%r11), %zmm25 {%k1}{z} // A
+	vbroadcastss	0*4+0*64(%r12), %zmm24 // B
+	vfmadd231ps		%zmm25, %zmm24, %zmm0
+
+	addq	$ 64, %r11
+	addq	$ 4, %r12
+	subl	$ 1, %r10d
+
+	cmpl	$ 0, %r10d
+	jg		3b // clean up loop
+
+
+2: // return
+
+#if MACRO_LEVEL>=2
+	.endm
+#else
+	ret
+
+	FUN_END(inner_kernel_gemm_nn_vx1_lib16)
+#endif
+
+
+
+
+
+#if MACRO_LEVEL>=2
 	.macro INNER_KERNEL_GEMM_NN_VX16_LIB16
 #else
 	.p2align 4,,15
@@ -6206,9 +6349,9 @@ NAME:
 	jg		100f
 
 #if MACRO_LEVEL>=2
-	//INNER_KERNEL_GEMM_NN_VX1_LIB16
+	INNER_KERNEL_GEMM_NN_VX1_LIB16
 #else
-	//CALL(inner_kernel_gemm_nn_vx1_lib16)
+	CALL(inner_kernel_gemm_nn_vx1_lib16)
 #endif
 	
 	jmp		115f


### PR DESCRIPTION
Finished implementation of the AVX512 routines for `kernel_sgemm_nn_16x16_vs_lib16`, related to #205.

This PR also includes a small correctness fix for the current `sgemm_nt` path, which I found while testing the public `blasfeo_sgemm_nt` routine after the previous `_vs` PR was merged. The fix changes `blasfeo_hp_sgemm_nt` to use the lib16 panel size, and fixes beta accumulation for columns 8-15 in `INNER_SCALE_AB_16X16_LIB16`.

The branch is split into three commits to try to make it easy to review:

- `c2cfd647adb702900a9bc2dfd45e4117aded4923`: fixes the current `sgemm_nt` correctness issues.
- `58f5c25710c269528c2e63acc9de50aade585a4c`: adds only the `kn=1` case for `kernel_sgemm_nn_16x16_vs_lib16`, to make the style/pattern easy to check.
- `ab17d923520eb906eb0e8fafa831b981c9698724`: fleshes out the remaining `kn=2...15` cases in  the same style.

For `sgemm_nt`, I checked the public routine with the BLASFEO `tester.py` infrastructure for `gemm_nt`, with both `K_MAX_STACK=0` and `K_MAX_STACK=500`. I also checked the sequential-`A`, identity-`B` cases for `n={16,17,31,32,33,48,64}` and `beta={0,1}`.  All 14 cases passed.

For `sgemm_nn` `_vs`, I checked the raw kernel for `kn=1...16`, km tails `{1,7,16}`, k cleanup cases `{0,1,4,5,16}`, `offsetB=0`, and `beta={0,1}`. All 480 cases passed.

On my AMD Ryzen AI 9 HX 470, a local raw-kernel benchmark with `TARGET=X64_AMD_ZEN5` and `GHZ_MAX=5.3` gave about `170 Gflop/s` for the wider `kn` cases, matching the local ceiling I also saw for `sgemm_nt`. Smaller widths seem to scale as expected. `kn=1` reaches `62.2 Gflop/s`, `kn=4` reaches `140.3 Gflop/s`, and `kn=7` reaches `170.5 Gflop/s`. On my Zen5 machine (Ryzen AI 9 HX 470) at 32 flop/cycle this is about 98% theoretical peak.