### PR TITLE
Add basic handling of shared library extensions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1476,7 +1476,7 @@ clean:
 deep_clean: clean
 	rm -f ./include/blasfeo_target.h
 	rm -f ./lib/libblasfeo.a
-	rm -f ./lib/libblasfeo.so
+	rm -f ./lib/libblasfeo.$(SO_EXT)
 	make -C netlib deep_clean
 	make -C examples deep_clean
 	make -C tests deep_clean

--- a/Makefile
+++ b/Makefile
@@ -1166,7 +1166,6 @@ endif
 ifeq ($(SANDBOX_MODE), 1)
 	( cd sandbox; $(MAKE) obj)
 endif
-	# TODO fix shared library extension depending on architecture
 	$(CC) -shared -o libblasfeo.$(SO_EXT) $(OBJS) $(LIBS_EXTERNAL_BLAS) -lm #-Wl,-Bsymbolic
 	mv libblasfeo.$(SO_EXT) ./lib/
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -1168,9 +1168,9 @@ ifeq ($(SANDBOX_MODE), 1)
 endif
 	# TODO fix shared library extension depending on architecture
 	$(CC) -shared -o libblasfeo.$(SO_EXT) $(OBJS) $(LIBS_EXTERNAL_BLAS) -lm #-Wl,-Bsymbolic
-	mv libblasfeo.so ./lib/
+	mv libblasfeo.$(SO_EXT) ./lib/
 	@echo
-	@echo " libblasfeo.so shared library build complete."
+	@echo " libblasfeo.$(SO_EXT) shared library build complete."
 	@echo
 
 
@@ -1448,7 +1448,7 @@ endif
 install_shared:
 	mkdir -p $(PREFIX)/blasfeo
 	mkdir -p $(PREFIX)/blasfeo/lib
-	cp -f ./lib/libblasfeo.so $(PREFIX)/blasfeo/lib/
+	cp -f ./lib/libblasfeo.$(SO_EXT) $(PREFIX)/blasfeo/lib/
 	mkdir -p $(PREFIX)/blasfeo/include
 	cp -f ./include/*.h $(PREFIX)/blasfeo/include/
 ifeq ($(CBLAS_API), 1)

--- a/Makefile
+++ b/Makefile
@@ -1167,7 +1167,7 @@ ifeq ($(SANDBOX_MODE), 1)
 	( cd sandbox; $(MAKE) obj)
 endif
 	# TODO fix shared library extension depending on architecture
-	$(CC) -shared -o libblasfeo.so $(OBJS) $(LIBS_EXTERNAL_BLAS) -lm #-Wl,-Bsymbolic
+	$(CC) -shared -o libblasfeo.$(SO_EXT) $(OBJS) $(LIBS_EXTERNAL_BLAS) -lm #-Wl,-Bsymbolic
 	mv libblasfeo.so ./lib/
 	@echo
 	@echo " libblasfeo.so shared library build complete."

--- a/Makefile.rule
+++ b/Makefile.rule
@@ -609,3 +609,14 @@ CFLAGS  += -DTARGET_GENERIC
 endif
 # TODO remove and fix tests
 # CFLAGS  += -DBLASFEO_TARGET=$(TARGET)
+
+# Set shared library extension
+ifeq ($(OS), LINUX)
+SO_EXT = "so"
+endif
+ifeq ($(OS), MAC)
+SO_EXT = "dylib"
+endif
+ifeq ($(OS), WINDOWS)
+SO_EXT = "dll"
+endif

--- a/Makefile.rule
+++ b/Makefile.rule
@@ -612,11 +612,11 @@ endif
 
 # Set shared library extension
 ifeq ($(OS), LINUX)
-SO_EXT = "so"
+SO_EXT = so
 endif
 ifeq ($(OS), MAC)
-SO_EXT = "dylib"
+SO_EXT = dylib
 endif
 ifeq ($(OS), WINDOWS)
-SO_EXT = "dll"
+SO_EXT = dll
 endif


### PR DESCRIPTION
In order to support the `blasfeo_jll` build for both linux and mac hosts the `shared_library` target needs to correctly set the extension of the output binary.

This also sets the windows binary shared library extension (even though windows builds seem to be broken :) )