### PR TITLE
Add ref implementations for all `trmv_*` methods and add fallbacks to these in the HP implementation

### DIFF
--- a/blasfeo_hp_pm/d_blas2_lib4.c
+++ b/blasfeo_hp_pm/d_blas2_lib4.c
@@ -1956,14 +1956,34 @@ void blasfeo_dtrmv_unn(int m, struct blasfeo_dmat *sA, int ai, int aj, struct bl
 	blasfeo_hp_dtrmv_unn(m, sA, ai, aj, sx, xi, sz, zi);
 	}
 
-
+void blasfeo_dtrmv_unu(int m, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dvec *sx, int xi, struct blasfeo_dvec *sz, int zi)
+	{
+#if defined(BLASFEO_REF_API)
+	blasfeo_ref_dtrmv_unu(m, sA, ai, aj, sx, xi, sz, zi);
+#else
+#ifdef EXT_DEP
+	printf("\nblasfeo_dtrsv_unu: feature not implemented yet: ai=%d\n", ai);
+#endif
+	exit(1);
+#endif
+	}
 
 void blasfeo_dtrmv_utn(int m, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dvec *sx, int xi, struct blasfeo_dvec *sz, int zi)
 	{
 	blasfeo_hp_dtrmv_utn(m, sA, ai, aj, sx, xi, sz, zi);
 	}
 
-
+void blasfeo_dtrmv_utu(int m, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dvec *sx, int xi, struct blasfeo_dvec *sz, int zi)
+	{
+#if defined(BLASFEO_REF_API)
+	blasfeo_ref_dtrmv_utu(m, sA, ai, aj, sx, xi, sz, zi);
+#else
+#ifdef EXT_DEP
+	printf("\nblasfeo_dtrsv_utu: feature not implemented yet: ai=%d\n", ai);
+#endif
+	exit(1);
+#endif
+	}
 
 void blasfeo_dtrsv_lnn_mn(int m, int n, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dvec *sx, int xi, struct blasfeo_dvec *sz, int zi)
 	{

--- a/blasfeo_hp_pm/s_blas2_lib4.c
+++ b/blasfeo_hp_pm/s_blas2_lib4.c
@@ -478,6 +478,110 @@ void blasfeo_hp_strmv_lnn(int m, struct blasfeo_smat *sA, int ai, int aj, struct
 	return;
 	}
 
+// m >= n
+static void blasfeo_hp_sdtrmv_lnu_mn(int m, int n, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
+	{
+
+	if(m<=0)
+		return;
+
+	const int bs = 4;
+
+	int sda = sA->cn;
+	float *pA = sA->pA + aj*bs + ai/bs*bs*sda + ai%bs;
+	float *x = sx->pa + xi;
+	float *z = sz->pa + zi;
+
+	if(m-n>0)
+		blasfeo_hp_sgemv_n(m-n, n, 1.0, sA, ai+n, aj, sx, xi, 0.0, sz, zi+n, sz, zi+n);
+
+	float *pA2 = pA;
+	float *z2 = z;
+	int m2 = n;
+	int n2 = 0;
+	float *pA3, *x3;
+
+	float alpha = 1.0;
+	float beta = 1.0;
+
+	float zt[4];
+
+	int ii, jj, jj_end;
+
+	ii = 0;
+
+	if(ai%4!=0)
+		{
+		pA2 += sda*bs - ai%bs;
+		z2 += bs-ai%bs;
+		m2 -= bs-ai%bs;
+		n2 += bs-ai%bs;
+		}
+
+	pA2 += m2/bs*bs*sda;
+	z2 += m2/bs*bs;
+	n2 += m2/bs*bs;
+
+	if(m2%bs!=0)
+		{
+		//
+		pA3 = pA2 + bs*n2;
+		x3 = x + n2;
+		zt[3] = pA3[3+bs*0]*x3[0] + pA3[3+bs*1]*x3[1] + pA3[3+bs*2]*x3[2] + 1.0*x3[3];
+		zt[2] = pA3[2+bs*0]*x3[0] + pA3[2+bs*1]*x3[1] + 1.0*x3[2];
+		zt[1] = pA3[1+bs*0]*x3[0] + 1.0*x3[1];
+		zt[0] = 1.0*x3[0];
+		kernel_sgemv_n_4_lib4(n2, &alpha, pA2, x, &beta, zt, zt);
+		for(jj=0; jj<m2%bs; jj++)
+			z2[jj] = zt[jj];
+		}
+	for(; ii<m2-3; ii+=4)
+		{
+		pA2 -= bs*sda;
+		z2 -= 4;
+		n2 -= 4;
+		pA3 = pA2 + bs*n2;
+		x3 = x + n2;
+		z2[3] = pA3[3+bs*0]*x3[0] + pA3[3+bs*1]*x3[1] + pA3[3+bs*2]*x3[2] + 1.0*x3[3];
+		z2[2] = pA3[2+bs*0]*x3[0] + pA3[2+bs*1]*x3[1] + 1.0*x3[2];
+		z2[1] = pA3[1+bs*0]*x3[0] + 1.0*x3[1];
+		z2[0] = 1.0*x3[0];
+		kernel_sgemv_n_4_lib4(n2, &alpha, pA2, x, &beta, z2, z2);
+		}
+	if(ai%4!=0)
+		{
+		if(ai%bs==1)
+			{
+			zt[2] = pA[2+bs*0]*x[0] + pA[2+bs*1]*x[1] + 1.0*x[2];
+			zt[1] = pA[1+bs*0]*x[0] + 1.0*x[1];
+			zt[0] = 1.0*x[0];
+			jj_end = 4-ai%bs<n ? 4-ai%bs : n;
+			for(jj=0; jj<jj_end; jj++)
+				z[jj] = zt[jj];
+			}
+		else if(ai%bs==2)
+			{
+			zt[1] = pA[1+bs*0]*x[0] + 1.0*x[1];
+			zt[0] = 1.0*x[0];
+			jj_end = 4-ai%bs<n ? 4-ai%bs : n;
+			for(jj=0; jj<jj_end; jj++)
+				z[jj] = zt[jj];
+			}
+		else // if (ai%bs==3)
+			{
+			z[0] = 1.0*x[0];
+			}
+		}
+
+	return;
+
+	}
+
+void blasfeo_hp_strmv_lnu(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
+	{
+	blasfeo_hp_strmv_lnu_mn(m, m, sA, ai, aj, sx, xi, sz, zi);
+	return;
+	}
 
 
 // m >= n
@@ -1341,10 +1445,10 @@ void blasfeo_strmv_lnn(int m, struct blasfeo_smat *sA, int ai, int aj, struct bl
 
 
 
-//void blasfeo_strmv_lnu(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
-//	{
-//	blasfeo_hp_strmv_lnu(m, sA, ai, aj, sx, xi, sz, zi);
-//	}
+void blasfeo_strmv_lnu(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
+	{
+	blasfeo_hp_strmv_lnu(m, sA, ai, aj, sx, xi, sz, zi);
+	}
 
 
 

--- a/blasfeo_hp_pm/s_blas2_lib4.c
+++ b/blasfeo_hp_pm/s_blas2_lib4.c
@@ -479,7 +479,7 @@ void blasfeo_hp_strmv_lnn(int m, struct blasfeo_smat *sA, int ai, int aj, struct
 	}
 
 // m >= n
-static void blasfeo_hp_sdtrmv_lnu_mn(int m, int n, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
+static void blasfeo_hp_strmv_lnu_mn(int m, int n, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
 	{
 
 	if(m<=0)

--- a/blasfeo_hp_pm/s_blas2_lib8.c
+++ b/blasfeo_hp_pm/s_blas2_lib8.c
@@ -288,6 +288,164 @@ void blasfeo_hp_strmv_lnn(int m, struct blasfeo_smat *sA, int ai, int aj, struct
 	return;
 	}
 
+// m >= n
+static void blasfeo_hp_strmv_lnu_mn(int m, int n, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
+	{
+
+	if(m<=0)
+		return;
+
+	const int bs = 8;
+
+	int sda = sA->cn;
+	float *pA = sA->pA + aj*bs + ai/bs*bs*sda + ai%bs;
+	float *x = sx->pa + xi;
+	float *z = sz->pa + zi;
+
+	if(m-n>0)
+		blasfeo_hp_sgemv_n(m-n, n, 1.0, sA, ai+n, aj, sx, xi, 0.0, sz, zi+n, sz, zi+n);
+
+	float *pA2 = pA;
+	float *z2 = z;
+	int m2 = n;
+	int n2 = 0;
+	float *pA3, *x3;
+
+	float alpha = 1.0;
+	float beta = 1.0;
+
+	float zt[8];
+
+	int ii, jj, jj_end;
+
+	ii = 0;
+
+	if(ai%bs!=0)
+		{
+		pA2 += sda*bs - ai%bs;
+		z2 += bs-ai%bs;
+		m2 -= bs-ai%bs;
+		n2 += bs-ai%bs;
+		}
+	
+	pA2 += m2/bs*bs*sda;
+	z2 += m2/bs*bs;
+	n2 += m2/bs*bs;
+
+	if(m2%bs!=0)
+		{
+		//
+		pA3 = pA2 + bs*n2;
+		x3 = x + n2;
+		zt[7] = pA3[7+bs*0]*x3[0] + pA3[7+bs*1]*x3[1] + pA3[7+bs*2]*x3[2] + pA3[7+bs*3]*x3[3] + pA3[7+bs*4]*x3[4] + pA3[7+bs*5]*x3[5] + pA3[7+bs*6]*x3[6] + 1.0*x3[7];
+		zt[6] = pA3[6+bs*0]*x3[0] + pA3[6+bs*1]*x3[1] + pA3[6+bs*2]*x3[2] + pA3[6+bs*3]*x3[3] + pA3[6+bs*4]*x3[4] + pA3[6+bs*5]*x3[5] + 1.0*x3[6];
+		zt[5] = pA3[5+bs*0]*x3[0] + pA3[5+bs*1]*x3[1] + pA3[5+bs*2]*x3[2] + pA3[5+bs*3]*x3[3] + pA3[5+bs*4]*x3[4] + 1.0*x3[5];
+		zt[4] = pA3[4+bs*0]*x3[0] + pA3[4+bs*1]*x3[1] + pA3[4+bs*2]*x3[2] + pA3[4+bs*3]*x3[3] + 1.0*x3[4];
+		zt[3] = pA3[3+bs*0]*x3[0] + pA3[3+bs*1]*x3[1] + pA3[3+bs*2]*x3[2] + 1.0*x3[3];
+		zt[2] = pA3[2+bs*0]*x3[0] + pA3[2+bs*1]*x3[1] + 1.0*x3[2];
+		zt[1] = pA3[1+bs*0]*x3[0] + 1.0*x3[1];
+		zt[0] = 1.0*x3[0];
+		kernel_sgemv_n_8_lib8(n2, &alpha, pA2, x, &beta, zt, zt);
+		for(jj=0; jj<m2%bs; jj++)
+			z2[jj] = zt[jj];
+		}
+	for(; ii<m2-7; ii+=8)
+		{
+		pA2 -= bs*sda;
+		z2 -= 8;
+		n2 -= 8;
+		pA3 = pA2 + bs*n2;
+		x3 = x + n2;
+		z2[7] = pA3[7+bs*0]*x3[0] + pA3[7+bs*1]*x3[1] + pA3[7+bs*2]*x3[2] + pA3[7+bs*3]*x3[3] + pA3[7+bs*4]*x3[4] + pA3[7+bs*5]*x3[5] + pA3[7+bs*6]*x3[6] + 1.0*x3[7];
+		z2[6] = pA3[6+bs*0]*x3[0] + pA3[6+bs*1]*x3[1] + pA3[6+bs*2]*x3[2] + pA3[6+bs*3]*x3[3] + pA3[6+bs*4]*x3[4] + pA3[6+bs*5]*x3[5] + 1.0*x3[6];
+		z2[5] = pA3[5+bs*0]*x3[0] + pA3[5+bs*1]*x3[1] + pA3[5+bs*2]*x3[2] + pA3[5+bs*3]*x3[3] + pA3[5+bs*4]*x3[4] + 1.0*x3[5];
+		z2[4] = pA3[4+bs*0]*x3[0] + pA3[4+bs*1]*x3[1] + pA3[4+bs*2]*x3[2] + pA3[4+bs*3]*x3[3] + 1.0*x3[4];
+		z2[3] = pA3[3+bs*0]*x3[0] + pA3[3+bs*1]*x3[1] + pA3[3+bs*2]*x3[2] + 1.0*x3[3];
+		z2[2] = pA3[2+bs*0]*x3[0] + pA3[2+bs*1]*x3[1] + 1.0*x3[2];
+		z2[1] = pA3[1+bs*0]*x3[0] + 1.0*x3[1];
+		z2[0] = 1.0*x3[0];
+		kernel_sgemv_n_8_lib8(n2, &alpha, pA2, x, &beta, z2, z2);
+		}
+	if(ai%bs!=0)
+		{
+		if(ai%bs==1)
+			{
+			zt[6] = pA[6+bs*0]*x[0] + pA[6+bs*1]*x[1] + pA[6+bs*2]*x[2] + pA[6+bs*3]*x[3] + pA[6+bs*4]*x[4] + pA[6+bs*5]*x[5] + 1.0*x[6];
+			zt[5] = pA[5+bs*0]*x[0] + pA[5+bs*1]*x[1] + pA[5+bs*2]*x[2] + pA[5+bs*3]*x[3] + pA[5+bs*4]*x[4] + 1.0*x[5];
+			zt[4] = pA[4+bs*0]*x[0] + pA[4+bs*1]*x[1] + pA[4+bs*2]*x[2] + pA[4+bs*3]*x[3] + 1.0*x[4];
+			zt[3] = pA[3+bs*0]*x[0] + pA[3+bs*1]*x[1] + pA[3+bs*2]*x[2] + 1.0*x[3];
+			zt[2] = pA[2+bs*0]*x[0] + pA[2+bs*1]*x[1] + 1.0*x[2];
+			zt[1] = pA[1+bs*0]*x[0] + 1.0*x[1];
+			zt[0] = 1.0*x[0];
+			jj_end = 8-ai%bs<n ? 8-ai%bs : n;
+			for(jj=0; jj<jj_end; jj++)
+				z[jj] = zt[jj];
+			}
+		else if(ai%bs==2)
+			{
+			zt[5] = pA[5+bs*0]*x[0] + pA[5+bs*1]*x[1] + pA[5+bs*2]*x[2] + pA[5+bs*3]*x[3] + pA[5+bs*4]*x[4] + 1.0*x[5];
+			zt[4] = pA[4+bs*0]*x[0] + pA[4+bs*1]*x[1] + pA[4+bs*2]*x[2] + pA[4+bs*3]*x[3] + 1.0*x[4];
+			zt[3] = pA[3+bs*0]*x[0] + pA[3+bs*1]*x[1] + pA[3+bs*2]*x[2] + 1.0*x[3];
+			zt[2] = pA[2+bs*0]*x[0] + pA[2+bs*1]*x[1] + 1.0*x[2];
+			zt[1] = pA[1+bs*0]*x[0] + 1.0*x[1];
+			zt[0] = 1.0*x[0];
+			jj_end = 8-ai%bs<n ? 8-ai%bs : n;
+			for(jj=0; jj<jj_end; jj++)
+				z[jj] = zt[jj];
+			}
+		else if(ai%bs==3)
+			{
+			zt[4] = pA[4+bs*0]*x[0] + pA[4+bs*1]*x[1] + pA[4+bs*2]*x[2] + pA[4+bs*3]*x[3] + 1.0*x[4];
+			zt[3] = pA[3+bs*0]*x[0] + pA[3+bs*1]*x[1] + pA[3+bs*2]*x[2] + 1.0*x[3];
+			zt[2] = pA[2+bs*0]*x[0] + pA[2+bs*1]*x[1] + 1.0*x[2];
+			zt[1] = pA[1+bs*0]*x[0] + 1.0*x[1];
+			zt[0] = 1.0*x[0];
+			jj_end = 8-ai%bs<n ? 8-ai%bs : n;
+			for(jj=0; jj<jj_end; jj++)
+				z[jj] = zt[jj];
+			}
+		else if(ai%bs==4)
+			{
+			zt[3] = pA[3+bs*0]*x[0] + pA[3+bs*1]*x[1] + pA[3+bs*2]*x[2] + 1.0*x[3];
+			zt[2] = pA[2+bs*0]*x[0] + pA[2+bs*1]*x[1] + 1.0*x[2];
+			zt[1] = pA[1+bs*0]*x[0] + 1.0*x[1];
+			zt[0] = 1.0*x[0];
+			jj_end = 8-ai%bs<n ? 8-ai%bs : n;
+			for(jj=0; jj<jj_end; jj++)
+				z[jj] = zt[jj];
+			}
+		else if(ai%bs==5)
+			{
+			zt[2] = pA[2+bs*0]*x[0] + pA[2+bs*1]*x[1] + 1.0*x[2];
+			zt[1] = pA[1+bs*0]*x[0] + 1.0*x[1];
+			zt[0] = 1.0*x[0];
+			jj_end = 8-ai%bs<n ? 8-ai%bs : n;
+			for(jj=0; jj<jj_end; jj++)
+				z[jj] = zt[jj];
+			}
+		else if(ai%bs==6)
+			{
+			zt[1] = pA[1+bs*0]*x[0] + 1.0*x[1];
+			zt[0] = 1.0*x[0];
+			jj_end = 8-ai%bs<n ? 8-ai%bs : n;
+			for(jj=0; jj<jj_end; jj++)
+				z[jj] = zt[jj];
+			}
+		else // if (ai%bs==7)
+			{
+			z[0] = 1.0*x[0];
+			}
+		}
+
+	return;
+
+	}
+
+void blasfeo_hp_strmv_lnu(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
+	{
+	blasfeo_hp_strmv_lnu_mn(m, m, sA, ai, aj, sx, xi, sz, zi);
+	return;
+	}
 
 
 // m >= n
@@ -1250,10 +1408,10 @@ void blasfeo_strmv_lnn(int m, struct blasfeo_smat *sA, int ai, int aj, struct bl
 
 
 
-//void blasfeo_strmv_lnu(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
-//	{
-//	blasfeo_hp_strmv_lnu(m, sA, ai, aj, sx, xi, sz, zi);
-//	}
+void blasfeo_strmv_lnu(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
+	{
+	blasfeo_hp_strmv_lnu(m, sA, ai, aj, sx, xi, sz, zi);
+	}
 
 
 

--- a/blasfeo_hp_pm/s_blas2_lib8.c
+++ b/blasfeo_hp_pm/s_blas2_lib8.c
@@ -1435,7 +1435,6 @@ void blasfeo_strmv_ltu(int m, struct blasfeo_smat *sA, int ai, int aj, struct bl
 	}
 
 
-
 void blasfeo_strmv_unn(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
 	{
 #ifdef BLASFEO_REF_API
@@ -1448,6 +1447,17 @@ void blasfeo_strmv_unn(int m, struct blasfeo_smat *sA, int ai, int aj, struct bl
 #endif
 	}
 
+void blasfeo_strmv_unu(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
+	{
+#ifdef BLASFEO_REF_API
+	blasfeo_ref_strmv_unu(m, sA, ai, aj, sx, xi, sz, zi);
+#else
+#ifdef EXT_DEP
+	printf("\nblasfeo_strmv_unu: feature not implemented yet: ai=%d\n", ai);
+#endif
+	exit(1);
+#endif
+	}
 
 
 void blasfeo_strmv_utn(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
@@ -1462,6 +1472,17 @@ void blasfeo_strmv_utn(int m, struct blasfeo_smat *sA, int ai, int aj, struct bl
 #endif
 	}
 
+void blasfeo_strmv_utu(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
+	{
+#ifdef BLASFEO_REF_API
+	blasfeo_ref_strmv_utu(m, sA, ai, aj, sx, xi, sz, zi);
+#else
+#ifdef EXT_DEP
+	printf("\nblasfeo_strmv_utu: feature not implemented yet: ai=%d\n", ai);
+#endif
+	exit(1);
+#endif
+	}
 
 
 void blasfeo_strsv_lnn_mn(int m, int n, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
@@ -1532,17 +1553,7 @@ void blasfeo_strsv_unn(int m, struct blasfeo_smat *sA, int ai, int aj, struct bl
 #endif
 	}
  
-void blasfeo_strsv_unu(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
-	{
-#ifdef BLASFEO_REF_API
-	blasfeo_ref_strsv_unu(m, sA, ai, aj, sx, xi, sz, zi);
-#else
-#ifdef EXT_DEP
-	printf("\nblasfeo_strsv_unu: feature not implemented yet: ai=%d\n", ai);
-#endif
-	exit(1);
-#endif
-	}
+
 
 void blasfeo_strsv_utn(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
 	{
@@ -1556,17 +1567,6 @@ void blasfeo_strsv_utn(int m, struct blasfeo_smat *sA, int ai, int aj, struct bl
 #endif
 	}
 
-void blasfeo_strsv_utu(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
-	{
-#ifdef BLASFEO_REF_API
-	blasfeo_ref_strsv_utu(m, sA, ai, aj, sx, xi, sz, zi);
-#else
-#ifdef EXT_DEP
-	printf("\nblasfeo_strsv_utu: feature not implemented yet: ai=%d\n", ai);
-#endif
-	exit(1);
-#endif
-	}
 
 
 void blasfeo_sger(int m, int n, float alpha, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sy, int yi, struct blasfeo_smat *sC, int ci, int cj, struct blasfeo_smat *sD, int di, int dj)

--- a/blasfeo_hp_pm/s_blas2_lib8.c
+++ b/blasfeo_hp_pm/s_blas2_lib8.c
@@ -1532,7 +1532,17 @@ void blasfeo_strsv_unn(int m, struct blasfeo_smat *sA, int ai, int aj, struct bl
 #endif
 	}
  
-
+void blasfeo_strsv_unu(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
+	{
+#ifdef BLASFEO_REF_API
+	blasfeo_ref_strsv_unu(m, sA, ai, aj, sx, xi, sz, zi);
+#else
+#ifdef EXT_DEP
+	printf("\nblasfeo_strsv_unu: feature not implemented yet: ai=%d\n", ai);
+#endif
+	exit(1);
+#endif
+	}
 
 void blasfeo_strsv_utn(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
 	{
@@ -1546,6 +1556,17 @@ void blasfeo_strsv_utn(int m, struct blasfeo_smat *sA, int ai, int aj, struct bl
 #endif
 	}
 
+void blasfeo_strsv_utu(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
+	{
+#ifdef BLASFEO_REF_API
+	blasfeo_ref_strsv_utu(m, sA, ai, aj, sx, xi, sz, zi);
+#else
+#ifdef EXT_DEP
+	printf("\nblasfeo_strsv_utu: feature not implemented yet: ai=%d\n", ai);
+#endif
+	exit(1);
+#endif
+	}
 
 
 void blasfeo_sger(int m, int n, float alpha, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sy, int yi, struct blasfeo_smat *sC, int ci, int cj, struct blasfeo_smat *sD, int di, int dj)

--- a/blasfeo_hp_pm/s_blas2_lib8.c
+++ b/blasfeo_hp_pm/s_blas2_lib8.c
@@ -1422,24 +1422,45 @@ void blasfeo_strmv_ltn(int m, struct blasfeo_smat *sA, int ai, int aj, struct bl
 
 
 
-//void blasfeo_strmv_ltu(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
-//	{
-//	blasfeo_hp_strmv_ltu(m, sA, ai, aj, sx, xi, sz, zi);
-//	}
+void blasfeo_strmv_ltu(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
+	{
+#ifdef BLASFEO_REF_API
+	blasfeo_ref_strmv_ltu(m, sA, ai, aj, sx, xi, sz, zi);
+#else
+#ifdef EXT_DEP
+	printf("\nblasfeo_strmv_ltu: feature not implemented yet: ai=%d\n", ai);
+#endif
+	exit(1);
+#endif
+	}
 
 
 
-//void blasfeo_strmv_unn(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
-//	{
-//	blasfeo_hp_strmv_unn(m, sA, ai, aj, sx, xi, sz, zi);
-//	}
+void blasfeo_strmv_unn(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
+	{
+#ifdef BLASFEO_REF_API
+	blasfeo_ref_strmv_unn(m, sA, ai, aj, sx, xi, sz, zi);
+#else
+#ifdef EXT_DEP
+	printf("\nblasfeo_strmv_unn: feature not implemented yet: ai=%d\n", ai);
+#endif
+	exit(1);
+#endif
+	}
 
 
 
-//void blasfeo_strmv_utn(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
-//	{
-//	blasfeo_hp_strmv_utn(m, sA, ai, aj, sx, xi, sz, zi);
-//	}
+void blasfeo_strmv_utn(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
+	{
+#ifdef BLASFEO_REF_API
+	blasfeo_ref_strmv_utn(m, sA, ai, aj, sx, xi, sz, zi);
+#else
+#ifdef EXT_DEP
+	printf("\nblasfeo_strmv_utn: feature not implemented yet: ai=%d\n", ai);
+#endif
+	exit(1);
+#endif
+	}
 
 
 
@@ -1457,10 +1478,17 @@ void blasfeo_strsv_lnn(int m, struct blasfeo_smat *sA, int ai, int aj, struct bl
 
 
 
-//void blasfeo_strsv_lnu(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
-//	{
-//	blasfeo_hp_strsv_lnu(m, sA, ai, aj, sx, xi, sz, zi);
-//	}
+void blasfeo_strsv_lnu(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
+	{
+#ifdef BLASFEO_REF_API
+	blasfeo_ref_strsv_lnu(m, sA, ai, aj, sx, xi, sz, zi);
+#else
+#ifdef EXT_DEP
+	printf("\nblasfeo_strsv_lnu: feature not implemented yet: ai=%d\n", ai);
+#endif
+	exit(1);
+#endif
+	}
 
 
 
@@ -1478,24 +1506,45 @@ void blasfeo_strsv_ltn(int m, struct blasfeo_smat *sA, int ai, int aj, struct bl
 
 
 
-//void blasfeo_strsv_ltu(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
-//	{
-//	blasfeo_hp_strsv_ltu(m, sA, ai, aj, sx, xi, sz, zi);
-//	}
+void blasfeo_strsv_ltu(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
+	{
+#ifdef BLASFEO_REF_API
+	blasfeo_ref_strsv_ltu(m, sA, ai, aj, sx, xi, sz, zi);
+#else
+#ifdef EXT_DEP
+	printf("\nblasfeo_strsv_ltu: feature not implemented yet: ai=%d\n", ai);
+#endif
+	exit(1);
+#endif
+	}
 
 
 
-//void blasfeo_strsv_unn(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
-//	{
-//	blasfeo_hp_strsv_unn(m, sA, ai, aj, sx, xi, sz, zi);
-//	}
+void blasfeo_strsv_unn(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
+	{
+#ifdef BLASFEO_REF_API
+	blasfeo_ref_strsv_unn(m, sA, ai, aj, sx, xi, sz, zi);
+#else
+#ifdef EXT_DEP
+	printf("\nblasfeo_strsv_unn: feature not implemented yet: ai=%d\n", ai);
+#endif
+	exit(1);
+#endif
+	}
+ 
 
 
-
-//void blasfeo_strsv_utn(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
-//	{
-//	blasfeo_hp_strsv_utn(m, sA, ai, aj, sx, xi, sz, zi);
-//	}
+void blasfeo_strsv_utn(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
+	{
+#ifdef BLASFEO_REF_API
+	blasfeo_ref_strsv_utn(m, sA, ai, aj, sx, xi, sz, zi);
+#else
+#ifdef EXT_DEP
+	printf("\nblasfeo_strsv_utn: feature not implemented yet: ai=%d\n", ai);
+#endif
+	exit(1);
+#endif
+	}
 
 
 

--- a/blasfeo_ref/d_blas2_ref.c
+++ b/blasfeo_ref/d_blas2_ref.c
@@ -70,10 +70,16 @@
 #define REF_SYMV_L blasfeo_ref_dsymv_l
 #define REF_SYMV_L_MN blasfeo_ref_dsymv_l_mn
 #define REF_SYMV_U blasfeo_ref_dsymv_u
+
 #define REF_TRMV_LNN blasfeo_ref_dtrmv_lnn
+#define REF_TRMV_LNU blasfeo_ref_dtrmv_lnu
 #define REF_TRMV_LTN blasfeo_ref_dtrmv_ltn
+#define REF_TRMV_LTU blasfeo_ref_dtrmv_ltu
 #define REF_TRMV_UNN blasfeo_ref_dtrmv_unn
+#define REF_TRMV_UNU blasfeo_ref_dtrmv_unu
 #define REF_TRMV_UTN blasfeo_ref_dtrmv_utn
+#define REF_TRMV_UTU blasfeo_ref_dtrmv_utu
+
 #define REF_TRSV_LNN blasfeo_ref_dtrsv_lnn
 #define REF_TRSV_LNN_MN blasfeo_ref_dtrsv_lnn_mn
 #define REF_TRSV_LNU blasfeo_ref_dtrsv_lnu
@@ -84,16 +90,24 @@
 #define REF_TRSV_UTN blasfeo_ref_dtrsv_utn
 #define REF_GER blasfeo_ref_dger
 
+
+
 #define GEMV_N blasfeo_dgemv_n
 #define GEMV_NT blasfeo_dgemv_nt
 #define GEMV_T blasfeo_dgemv_t
 #define SYMV_L blasfeo_dsymv_l
 #define SYMV_L_MN blasfeo_dsymv_l_mn
 #define SYMV_U blasfeo_dsymv_u
+
 #define TRMV_LNN blasfeo_dtrmv_lnn
+#define TRMV_LNU blasfeo_dtrmv_lnu
 #define TRMV_LTN blasfeo_dtrmv_ltn
+#define TRMV_LTU blasfeo_dtrmv_ltu
 #define TRMV_UNN blasfeo_dtrmv_unn
+#define TRMV_UNU blasfeo_dtrmv_unu
 #define TRMV_UTN blasfeo_dtrmv_utn
+#define TRMV_UTU blasfeo_dtrmv_utu
+
 #define TRSV_LNN blasfeo_dtrsv_lnn
 #define TRSV_LNN_MN blasfeo_dtrsv_lnn_mn
 #define TRSV_LNU blasfeo_dtrsv_lnu
@@ -102,6 +116,7 @@
 #define TRSV_LTU blasfeo_dtrsv_ltu
 #define TRSV_UNN blasfeo_dtrsv_unn
 #define TRSV_UTN blasfeo_dtrsv_utn
+
 #define GER blasfeo_dger
 
 

--- a/blasfeo_ref/s_blas2_ref.c
+++ b/blasfeo_ref/s_blas2_ref.c
@@ -70,10 +70,16 @@
 #define REF_SYMV_L blasfeo_ref_ssymv_l
 #define REF_SYMV_L_MN blasfeo_ref_ssymv_l_mn
 #define REF_SYMV_U blasfeo_ref_ssymv_u
+
 #define REF_TRMV_LNN blasfeo_ref_strmv_lnn
+#define REF_TRMV_LNU blasfeo_ref_strmv_lnu
 #define REF_TRMV_LTN blasfeo_ref_strmv_ltn
+#define REF_TRMV_LTU blasfeo_ref_strmv_ltu
 #define REF_TRMV_UNN blasfeo_ref_strmv_unn
+#define REF_TRMV_UNU blasfeo_ref_strmv_unu
 #define REF_TRMV_UTN blasfeo_ref_strmv_utn
+#define REF_TRMV_UTU blasfeo_ref_strmv_utu
+
 #define REF_TRSV_LNN blasfeo_ref_strsv_lnn
 #define REF_TRSV_LNN_MN blasfeo_ref_strsv_lnn_mn
 #define REF_TRSV_LNU blasfeo_ref_strsv_lnu
@@ -82,6 +88,7 @@
 #define REF_TRSV_LTU blasfeo_ref_strsv_ltu
 #define REF_TRSV_UNN blasfeo_ref_strsv_unn
 #define REF_TRSV_UTN blasfeo_ref_strsv_utn
+
 #define REF_GER blasfeo_ref_sger
 
 #define GEMV_N blasfeo_sgemv_n

--- a/blasfeo_ref/s_blas2_ref.c
+++ b/blasfeo_ref/s_blas2_ref.c
@@ -91,16 +91,24 @@
 
 #define REF_GER blasfeo_ref_sger
 
+
+
 #define GEMV_N blasfeo_sgemv_n
 #define GEMV_NT blasfeo_sgemv_nt
 #define GEMV_T blasfeo_sgemv_t
 #define SYMV_L blasfeo_ssymv_l
 #define SYMV_L_MN blasfeo_ssymv_l_mn
 #define SYMV_U blasfeo_ssymv_u
+
 #define TRMV_LNN blasfeo_strmv_lnn
+#define TRMV_LNU blasfeo_strmv_lnu
 #define TRMV_LTN blasfeo_strmv_ltn
+#define TRMV_LTU blasfeo_strmv_ltu
 #define TRMV_UNN blasfeo_strmv_unn
+#define TRMV_UNU blasfeo_strmv_unu
 #define TRMV_UTN blasfeo_strmv_utn
+#define TRMV_UTU blasfeo_strmv_utu
+
 #define TRSV_LNN blasfeo_strsv_lnn
 #define TRSV_LNN_MN blasfeo_strsv_lnn_mn
 #define TRSV_LNU blasfeo_strsv_lnu
@@ -109,6 +117,7 @@
 #define TRSV_LTU blasfeo_strsv_ltu
 #define TRSV_UNN blasfeo_strsv_unn
 #define TRSV_UTN blasfeo_strsv_utn
+
 #define GER blasfeo_sger
 
 

--- a/blasfeo_ref/x_blas2_ref.c
+++ b/blasfeo_ref/x_blas2_ref.c
@@ -1767,28 +1767,40 @@ void TRMV_LNN(int m, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int xi, s
 	REF_TRMV_LNN(m, sA, ai, aj, sx, xi, sz, zi);
 	}
 
-
+void TRMV_LNU(int m, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int xi, struct XVEC *sz, int zi)
+	{
+	REF_TRMV_LNU(m, sA, ai, aj, sx, xi, sz, zi);
+	}
 
 void TRMV_LTN(int m, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int xi, struct XVEC *sz, int zi)
 	{
 	REF_TRMV_LTN(m, sA, ai, aj, sx, xi, sz, zi);
 	}
 
-
+void TRMV_LTU(int m, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int xi, struct XVEC *sz, int zi)
+	{
+	REF_TRMV_LTN(m, sA, ai, aj, sx, xi, sz, zi);
+	}
 
 void TRMV_UNN(int m, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int xi, struct XVEC *sz, int zi)
 	{
 	REF_TRMV_UNN(m, sA, ai, aj, sx, xi, sz, zi);
 	}
 
-
+void TRMV_UNU(int m, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int xi, struct XVEC *sz, int zi)
+	{
+	REF_TRMV_UNN(m, sA, ai, aj, sx, xi, sz, zi);
+	}
 
 void TRMV_UTN(int m, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int xi, struct XVEC *sz, int zi)
 	{
 	REF_TRMV_UTN(m, sA, ai, aj, sx, xi, sz, zi);
 	}
 
-
+void TRMV_UTU(int m, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int xi, struct XVEC *sz, int zi)
+	{
+	REF_TRMV_UTN(m, sA, ai, aj, sx, xi, sz, zi);
+	}
 
 void TRSV_LNN(int m, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int xi, struct XVEC *sz, int zi)
 	{

--- a/blasfeo_ref/x_blas2_ref.c
+++ b/blasfeo_ref/x_blas2_ref.c
@@ -530,6 +530,66 @@ void REF_TRMV_LNN(int m, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int x
 	return;
 	}
 
+static void REF_TRMV_LNU_MN(int m, int n, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int xi, struct XVEC *sz, int zi)
+	{
+	int ii, jj;
+	REAL
+		y_0, y_1;
+#if defined(MF_COLMAJ)
+	int lda = sA->m;
+	REAL *pA = sA->pA + ai + aj*lda;
+	const int aai=0; const int aaj=0;
+#else
+	int aai=ai; int aaj=aj;
+#endif
+	REAL *x = sx->pa + xi;
+	REAL *z = sz->pa + zi;
+	if(m-n>0)
+		{
+		REF_GEMV_N(m-n, n, 1.0, sA, ai+n, aj, sx, xi, 0.0, sz, zi+n, sz, zi+n);
+		}
+	if(n%2!=0)
+		{
+		ii = n-1;
+		y_0 = x[ii];
+		for(jj=0; jj<ii; jj++)
+			{
+			y_0 += XMATEL_A(aai+ii, aaj+jj) * x[jj];
+			}
+		z[ii] = y_0;
+		n -= 1;
+		}
+	for(ii=n-2; ii>=0; ii-=2)
+		{
+		y_0 = x[ii+0];
+		y_1 = x[ii+1];
+		y_1 += XMATEL_A(aai+ii+1, aaj+(ii+0)) * y_0;
+		jj = 0;
+		for(; jj<ii-1; jj+=2)
+			{
+			y_0 += XMATEL_A(aai+ii+0, aaj+(jj+0)) * x[jj+0] + XMATEL_A(aai+ii+0, aaj+(jj+1)) * x[jj+1];
+			y_1 += XMATEL_A(aai+ii+1, aaj+(jj+0)) * x[jj+0] + XMATEL_A(aai+ii+1, aaj+(jj+1)) * x[jj+1];
+			}
+//	XXX there is no clean up loop !!!!!
+//		for(; jj<ii; jj++)
+//			{
+//			y_0 += XMATEL_A(aai+ii+0, aaj+jj) * x[jj];
+//			y_1 += XMATEL_A(aai+ii+1, aaj+jj) * x[jj];
+//			}
+		z[ii+0] = y_0;
+		z[ii+1] = y_1;
+		}
+	return;
+	}
+
+
+	
+void REF_TRMV_LNU(int m, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int xi, struct XVEC *sz, int zi)
+	{
+	REF_TRMV_LNU_MN(m, m, sA, ai, aj, sx, xi, sz, zi);
+	return;
+	}
+
 
 
 static void REF_TRMV_LTN_MN(int m, int n, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int xi, struct XVEC *sz, int zi)
@@ -581,11 +641,63 @@ static void REF_TRMV_LTN_MN(int m, int n, struct XMAT *sA, int ai, int aj, struc
 	return;
 	}
 
-
-
 void REF_TRMV_LTN(int m, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int xi, struct XVEC *sz, int zi)
 	{
 	REF_TRMV_LTN_MN(m, m, sA, ai, aj, sx, xi, sz, zi);
+	return;
+	}
+
+static void REF_TRMV_LTU_MN(int m, int n, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int xi, struct XVEC *sz, int zi)
+	{
+	int ii, jj;
+	REAL y_0, y_1;
+#if defined(MF_COLMAJ)
+	int lda = sA->m;
+	REAL *pA = sA->pA + ai + aj*lda;
+	const int aai=0; const int aaj=0;
+#else
+	int aai=ai; int aaj=aj;
+#endif
+	REAL *x = sx->pa + xi;
+	REAL *z = sz->pa + zi;
+	jj = 0;
+	for(; jj<n-1; jj+=2)
+		{
+		// diagonal block with unit diagonal
+		y_0 = x[jj+0];
+		y_1 = x[jj+1];
+		y_0 += XMATEL_A(aai+jj+1, aaj+(jj+0)) * y_1;
+		ii = jj+2;
+		for(; ii<m-1; ii+=2)
+			{
+			y_0 += XMATEL_A(aai+ii+0, aaj+(jj+0)) * x[ii+0] + XMATEL_A(aai+ii+1, aaj+(jj+0)) * x[ii+1];
+			y_1 += XMATEL_A(aai+ii+0, aaj+(jj+1)) * x[ii+0] + XMATEL_A(aai+ii+1, aaj+(jj+1)) * x[ii+1];
+			}
+		for(; ii<m; ii++)
+			{
+			y_0 += XMATEL_A(aai+ii, aaj+(jj+0)) * x[ii];
+			y_1 += XMATEL_A(aai+ii, aaj+(jj+1)) * x[ii];
+			}
+		z[jj+0] = y_0;
+		z[jj+1] = y_1;
+		}
+	for(; jj<n; jj++)
+		{
+		y_0 = x[jj];
+		for(ii=jj+1; ii<m; ii++)
+			{
+			y_0 += XMATEL_A(aai+ii, aaj+jj) * x[ii];
+			}
+		z[jj] = y_0;
+		}
+	return;
+	}
+
+
+
+void REF_TRMV_LTU(int m, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int xi, struct XVEC *sz, int zi)
+	{
+	REF_TRMV_LTU_MN(m, m, sA, ai, aj, sx, xi, sz, zi);
 	return;
 	}
 
@@ -680,6 +792,53 @@ void REF_TRMV_UNN(int m, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int x
 	return;
 	}
 
+void REF_TRMV_UNU(int m, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int xi, struct XVEC *sz, int zi)
+	{
+	int ii, jj;
+	REAL
+		y_0, y_1,
+		x_0, x_1;
+#if defined(MF_COLMAJ)
+	int lda = sA->m;
+	REAL *pA = sA->pA + ai + aj*lda;
+	const int aai=0; const int aaj=0;
+#else
+	int aai=ai; int aaj=aj;
+#endif
+	REAL *x = sx->pa + xi;
+	REAL *z = sz->pa + zi;
+	jj = 0;
+	for(; jj<m-1; jj+=2)
+		{
+		y_0 = x[jj+0];
+		y_1 = x[jj+1];
+		y_0 += XMATEL_A(aai+jj+0, aaj+(jj+1)) * y_1;
+		ii = jj+2;
+		for(; ii<m-1; ii+=2)
+			{
+			y_0 += XMATEL_A(aai+jj+0, aaj+(ii+0)) * x[ii+0] + XMATEL_A(aai+jj+0, aaj+(ii+1)) * x[ii+1];
+			y_1 += XMATEL_A(aai+jj+1, aaj+(ii+0)) * x[ii+0] + XMATEL_A(aai+jj+1, aaj+(ii+1)) * x[ii+1];
+			}
+		if(ii<m)
+			{
+			y_0 += XMATEL_A(aai+jj+0, aaj+(ii+0)) * x[ii+0];
+			y_1 += XMATEL_A(aai+jj+1, aaj+(ii+0)) * x[ii+0];
+			}
+		z[jj+0] = y_0;
+		z[jj+1] = y_1;
+		}
+	for(; jj<m; jj++)
+		{
+		y_0 = x[jj];
+		for(ii=jj+1; ii<m; ii++)
+			{
+			y_0 += XMATEL_A(aai+jj, aaj+ii) * x[ii];
+			}
+		z[jj] = y_0;
+		}
+	return;
+	}
+
 
 
 void REF_TRMV_UTN(int m, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int xi, struct XVEC *sz, int zi)
@@ -729,6 +888,46 @@ void REF_TRMV_UTN(int m, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int x
 	return;
 	}
 
+void REF_TRMV_UTU(int m, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int xi, struct XVEC *sz, int zi)
+	{
+	int ii, jj;
+	REAL
+		y_0, y_1;
+#if defined(MF_COLMAJ)
+	int lda = sA->m;
+	REAL *pA = sA->pA + ai + aj*lda;
+	const int aai=0; const int aaj=0;
+#else
+	int aai=ai; int aaj=aj;
+#endif
+	REAL *x = sx->pa + xi;
+	REAL *z = sz->pa + zi;
+	if(m%2!=0)
+		{
+		jj = m-1;
+		y_0 = x[jj];
+		for(ii=0; ii<jj; ii++)
+			{
+			y_0 += XMATEL_A(aai+ii, aaj+jj) * x[ii];
+			}
+		z[jj] = y_0;
+		m -= 1; // XXX 
+		}
+	for(jj=m-2; jj>=0; jj-=2)
+		{
+		y_1 = x[jj+1];
+		y_1 += XMATEL_A(aai+jj+0, aaj+(jj+1)) * x[jj+0];
+		y_0 = x[jj+0];
+		for(ii=0; ii<jj-1; ii+=2)
+			{
+			y_0 += XMATEL_A(aai+ii+0, aaj+(jj+0)) * x[ii+0] + XMATEL_A(aai+ii+1, aaj+(jj+0)) * x[ii+1];
+			y_1 += XMATEL_A(aai+ii+0, aaj+(jj+1)) * x[ii+0] + XMATEL_A(aai+ii+1, aaj+(jj+1)) * x[ii+1];
+			}
+		z[jj+0] = y_0;
+		z[jj+1] = y_1;
+		}
+	return;
+	}
 
 
 void REF_TRSV_LNN_MN(int m, int n, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int xi, struct XVEC *sz, int zi)

--- a/blasfeo_ref/x_blas2_ref.c
+++ b/blasfeo_ref/x_blas2_ref.c
@@ -551,7 +551,7 @@ static void REF_TRMV_LNU_MN(int m, int n, struct XMAT *sA, int ai, int aj, struc
 	if(n%2!=0)
 		{
 		ii = n-1;
-		y_0 = x[ii];
+		y_0 = x[ii]; // unit diagonal
 		for(jj=0; jj<ii; jj++)
 			{
 			y_0 += XMATEL_A(aai+ii, aaj+jj) * x[jj];
@@ -561,8 +561,8 @@ static void REF_TRMV_LNU_MN(int m, int n, struct XMAT *sA, int ai, int aj, struc
 		}
 	for(ii=n-2; ii>=0; ii-=2)
 		{
-		y_0 = x[ii+0];
-		y_1 = x[ii+1];
+		y_0 = x[ii+0]; // unit diagonal
+		y_1 = x[ii+1]; // unit diagonal
 		y_1 += XMATEL_A(aai+ii+1, aaj+(ii+0)) * y_0;
 		jj = 0;
 		for(; jj<ii-1; jj+=2)
@@ -570,12 +570,6 @@ static void REF_TRMV_LNU_MN(int m, int n, struct XMAT *sA, int ai, int aj, struc
 			y_0 += XMATEL_A(aai+ii+0, aaj+(jj+0)) * x[jj+0] + XMATEL_A(aai+ii+0, aaj+(jj+1)) * x[jj+1];
 			y_1 += XMATEL_A(aai+ii+1, aaj+(jj+0)) * x[jj+0] + XMATEL_A(aai+ii+1, aaj+(jj+1)) * x[jj+1];
 			}
-//	XXX there is no clean up loop !!!!!
-//		for(; jj<ii; jj++)
-//			{
-//			y_0 += XMATEL_A(aai+ii+0, aaj+jj) * x[jj];
-//			y_1 += XMATEL_A(aai+ii+1, aaj+jj) * x[jj];
-//			}
 		z[ii+0] = y_0;
 		z[ii+1] = y_1;
 		}
@@ -664,8 +658,8 @@ static void REF_TRMV_LTU_MN(int m, int n, struct XMAT *sA, int ai, int aj, struc
 	for(; jj<n-1; jj+=2)
 		{
 		// diagonal block with unit diagonal
-		y_0 = x[jj+0];
-		y_1 = x[jj+1];
+		y_0 = x[jj+0]; // unit diagonal
+		y_1 = x[jj+1]; // unit diagonal
 		y_0 += XMATEL_A(aai+jj+1, aaj+(jj+0)) * y_1;
 		ii = jj+2;
 		for(; ii<m-1; ii+=2)
@@ -683,7 +677,7 @@ static void REF_TRMV_LTU_MN(int m, int n, struct XMAT *sA, int ai, int aj, struc
 		}
 	for(; jj<n; jj++)
 		{
-		y_0 = x[jj];
+		y_0 = x[jj]; // unit diagonal
 		for(ii=jj+1; ii<m; ii++)
 			{
 			y_0 += XMATEL_A(aai+ii, aaj+jj) * x[ii];
@@ -810,8 +804,8 @@ void REF_TRMV_UNU(int m, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int x
 	jj = 0;
 	for(; jj<m-1; jj+=2)
 		{
-		y_0 = x[jj+0];
-		y_1 = x[jj+1];
+		y_0 = x[jj+0]; // unit diagonal
+		y_1 = x[jj+1]; // unit diagonal
 		y_0 += XMATEL_A(aai+jj+0, aaj+(jj+1)) * y_1;
 		ii = jj+2;
 		for(; ii<m-1; ii+=2)
@@ -829,7 +823,7 @@ void REF_TRMV_UNU(int m, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int x
 		}
 	for(; jj<m; jj++)
 		{
-		y_0 = x[jj];
+		y_0 = x[jj]; // unit diagonal
 		for(ii=jj+1; ii<m; ii++)
 			{
 			y_0 += XMATEL_A(aai+jj, aaj+ii) * x[ii];
@@ -905,7 +899,7 @@ void REF_TRMV_UTU(int m, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int x
 	if(m%2!=0)
 		{
 		jj = m-1;
-		y_0 = x[jj];
+		y_0 = x[jj]; // unit diagonal
 		for(ii=0; ii<jj; ii++)
 			{
 			y_0 += XMATEL_A(aai+ii, aaj+jj) * x[ii];
@@ -915,9 +909,9 @@ void REF_TRMV_UTU(int m, struct XMAT *sA, int ai, int aj, struct XVEC *sx, int x
 		}
 	for(jj=m-2; jj>=0; jj-=2)
 		{
-		y_1 = x[jj+1];
+		y_0 = x[jj+0]; // unit diagonal
+		y_1 = x[jj+1]; // unit diagonal
 		y_1 += XMATEL_A(aai+jj+0, aaj+(jj+1)) * x[jj+0];
-		y_0 = x[jj+0];
 		for(ii=0; ii<jj-1; ii+=2)
 			{
 			y_0 += XMATEL_A(aai+ii+0, aaj+(jj+0)) * x[ii+0] + XMATEL_A(aai+ii+1, aaj+(jj+0)) * x[ii+1];

--- a/include/blasfeo_d_blasfeo_api.h
+++ b/include/blasfeo_d_blasfeo_api.h
@@ -109,10 +109,14 @@ void blasfeo_dtrmv_lnu(int m, struct blasfeo_dmat *sA, int ai, int aj, struct bl
 void blasfeo_dtrmv_ltn(int m, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dvec *sx, int xi, struct blasfeo_dvec *sz, int zi);
 // z <= A^T * x ; A lower triangular, assuming unit diagonal
 void blasfeo_dtrmv_ltu(int m, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dvec *sx, int xi, struct blasfeo_dvec *sz, int zi);
-// z <= beta * y + alpha * A * x ; A upper triangular
+// z <= A * x ; A upper triangular
 void blasfeo_dtrmv_unn(int m, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dvec *sx, int xi, struct blasfeo_dvec *sz, int zi);
+  // z <= A * x ; A upper triangular, assuming unit diagonal
+void blasfeo_dtrmv_unu(int m, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dvec *sx, int xi, struct blasfeo_dvec *sz, int zi);
 // z <= A^T * x ; A upper triangular
 void blasfeo_dtrmv_utn(int m, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dvec *sx, int xi, struct blasfeo_dvec *sz, int zi);
+// z <= A^T * x ; A upper triangular, assuming unit diagonal
+void blasfeo_dtrmv_utu(int m, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dvec *sx, int xi, struct blasfeo_dvec *sz, int zi);
 // z_n <= beta_n * y_n + alpha_n * A  * x_n
 // z_t <= beta_t * y_t + alpha_t * A^T * x_t
 void blasfeo_dgemv_nt(int m, int n, double alpha_n, double alpha_t, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dvec *sx_n, int xi_n, struct blasfeo_dvec *sx_t, int xi_t, double beta_n, double beta_t, struct blasfeo_dvec *sy_n, int yi_n, struct blasfeo_dvec *sy_t, int yi_t, struct blasfeo_dvec *sz_n, int zi_n, struct blasfeo_dvec *sz_t, int zi_t);

--- a/include/blasfeo_d_blasfeo_ref_api.h
+++ b/include/blasfeo_d_blasfeo_ref_api.h
@@ -111,8 +111,12 @@ void blasfeo_ref_dtrmv_ltn(int m, struct blasfeo_dmat *sA, int ai, int aj, struc
 void blasfeo_ref_dtrmv_ltu(int m, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dvec *sx, int xi, struct blasfeo_dvec *sz, int zi);
 // z <= beta * y + alpha * A * x ; A upper triangular
 void blasfeo_ref_dtrmv_unn(int m, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dvec *sx, int xi, struct blasfeo_dvec *sz, int zi);
+// z <= A * x ; A upper triangular, unit
+void blasfeo_ref_dtrmv_unu(int m, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dvec *sx, int xi, struct blasfeo_dvec *sz, int zi);
 // z <= A' * x ; A upper triangular
 void blasfeo_ref_dtrmv_utn(int m, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dvec *sx, int xi, struct blasfeo_dvec *sz, int zi);
+// z <= A' * x ; A upper triangular, unit
+void blasfeo_ref_dtrmv_utu(int m, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dvec *sx, int xi, struct blasfeo_dvec *sz, int zi);
 // z_n <= beta_n * y_n + alpha_n * A  * x_n
 // z_t <= beta_t * y_t + alpha_t * A' * x_t
 void blasfeo_ref_dgemv_nt(int m, int n, double alpha_n, double alpha_t, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dvec *sx_n, int xi_n, struct blasfeo_dvec *sx_t, int xi_t, double beta_n, double beta_t, struct blasfeo_dvec *sy_n, int yi_n, struct blasfeo_dvec *sy_t, int yi_t, struct blasfeo_dvec *sz_n, int zi_n, struct blasfeo_dvec *sz_t, int zi_t);

--- a/include/blasfeo_s_blasfeo_api.h
+++ b/include/blasfeo_s_blasfeo_api.h
@@ -105,10 +105,14 @@ void blasfeo_strmv_lnu(int m, struct blasfeo_smat *sA, int ai, int aj, struct bl
 void blasfeo_strmv_ltn(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi);
 // z <= A' * x ; A lower triangular, assuming unit diagonal
 void blasfeo_strmv_ltu(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi);
-// z <= beta * y + alpha * A * x ; A upper triangular
+// z <= A * x ; A upper triangular
 void blasfeo_strmv_unn(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi);
+// z <= A * x ; A upper triangular, assuming unit diagonal
+void blasfeo_strmv_unu(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi);
 // z <= A' * x ; A upper triangular
 void blasfeo_strmv_utn(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi);
+// z <= A' * x ; A upper triangular, assuming unit diagonal
+void blasfeo_strmv_utu(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi);
 // z_n <= beta_n * y_n + alpha_n * A  * x_n
 // z_t <= beta_t * y_t + alpha_t * A' * x_t
 void blasfeo_sgemv_nt(int m, int n, float alpha_n, float alpha_t, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx_n, int xi_n, struct blasfeo_svec *sx_t, int xi_t, float beta_n, float beta_t, struct blasfeo_svec *sy_n, int yi_n, struct blasfeo_svec *sy_t, int yi_t, struct blasfeo_svec *sz_n, int zi_n, struct blasfeo_svec *sz_t, int zi_t);

--- a/include/blasfeo_s_blasfeo_ref_api.h
+++ b/include/blasfeo_s_blasfeo_ref_api.h
@@ -105,10 +105,14 @@ void blasfeo_ref_strmv_lnu(int m, struct blasfeo_smat *sA, int ai, int aj, struc
 void blasfeo_ref_strmv_ltn(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi);
 // z <= A' * x ; A lower triangular, unit diagonal
 void blasfeo_ref_strmv_ltu(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi);
-// z <= beta * y + alpha * A * x ; A upper triangular
+// z <= A * x ; A upper triangular
 void blasfeo_ref_strmv_unn(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi);
+// z <= A * x ; A upper triangular, unit diagonal
+void blasfeo_ref_strmv_unu(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi);
 // z <= A' * x ; A upper triangular
 void blasfeo_ref_strmv_utn(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi);
+// z <= A' * x ; A upper triangular, unit diagonal
+void blasfeo_ref_strmv_utu(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi);
 // z_n <= beta_n * y_n + alpha_n * A  * x_n
 // z_t <= beta_t * y_t + alpha_t * A' * x_t
 void blasfeo_ref_sgemv_nt(int m, int n, float alpha_n, float alpha_t, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_svec *sx_n, int xi_n, struct blasfeo_svec *sx_t, int xi_t, float beta_n, float beta_t, struct blasfeo_svec *sy_n, int yi_n, struct blasfeo_svec *sy_t, int yi_t, struct blasfeo_svec *sz_n, int zi_n, struct blasfeo_svec *sz_t, int zi_t);


### PR DESCRIPTION
Currently (as seen in this `BLASFEO.jl` PR: https://github.com/JuliaEmbedded/BLASFEO.jl/pull/11) some of the `blasfeo_*trmv_*` functions are missing from the binaries as the implementations are commented out. I guess this is because some of the reference implementations are missing. I'm adding them here, as well as  the `lnu` version (for now) in the hp double precision `lib4` and single precision  `lib8`.