### PR TITLE
fix bug in generic target 'kernel_dtrmv_ut_4_lib4'

### DIFF
--- a/kernel/generic/kernel_dgemv_4_lib4.c
+++ b/kernel/generic/kernel_dgemv_4_lib4.c
@@ -38,7 +38,6 @@
 #include <blasfeo_d_kernel.h>
 
 
-
 #if defined(TARGET_GENERIC) || defined(TARGET_X64_AMD_BULLDOZER) || defined(TARGET_ARMV7A_ARM_CORTEX_A15) || defined(TARGET_ARMV7A_ARM_CORTEX_A7) || defined(TARGET_ARMV7A_ARM_CORTEX_A9) //|| defined(TARGET_ARMV8A_ARM_CORTEX_A57) || defined(TARGET_ARMV8A_ARM_CORTEX_A53)
 void kernel_dgemv_n_4_lib4(int kmax, double *alpha, double *A, double *x, double *beta, double *y, double *z)
 	{
@@ -1562,7 +1561,7 @@ void kernel_dtrmv_ut_4_lib4(int kmax, double *A, int sda, double *x, double *z)
 	
 	double x_0, x_1, x_2, x_3;
 	
-	int k1 = kmax/bs*bs;
+	int k1 = (kmax-bs)/bs*bs; // subtract bs to make sure we don't multiply the triangular part
 	double alpha1 = 1.0;
 	double beta1  = 1.0;
 


### PR DESCRIPTION
The generic `kernel_dtrmv_ut_4_lib4` has a bug in it which was causing `blasfeo_dtrmv_utn` to return incorrect results on some targets, namely first identified by the failures:
```
N = 10: Test Failed at /Users/runner/work/BLASFEO.jl/BLASFEO.jl/test/mat/level2.jl:75
    Expression: transpose(A_unn) * a ≈ transpose(A_unn_blasfeo) * a_blasfeo
     Evaluated: [0.49207249172917555, 0.9152204879686595, 0.9732434369202764, 2.008748370650951, 1.0191427869648968, 1.581692403024052, 2.6568478297541374, 1.487958122587504, 2.578589246560512, 3.1510610966134163] ≈ [2.471633446497567, 1.9198972934000615, 1.9291816401303072, 2.8375923620008305, 1.4663381104171935, 2.5637923294697376, 2.99847162486522, 2.1025786190126774, 2.578589246560512, 3.1510610966134167]
```

in this `BLASFEO.jl` PR: https://github.com/JuliaEmbedded/BLASFEO.jl/pull/11

This is because the kernel was multiplying also the triangular part using the `gemm` kernel.